### PR TITLE
Feature/fake data gen

### DIFF
--- a/Core/Inc/0X02C1B.h
+++ b/Core/Inc/0X02C1B.h
@@ -45,5 +45,6 @@ int X02C1B_fsin_off();
 float X02C1B_read_temp(CameraDevice *cam);
 int X02C1B_FSIN_EXT_enable();
 int X02C1B_FSIN_EXT_disable();
+int X02C1B_FSIN_EXT_status(bool *is_enabled);
 int X02C1B_read_security_uid(CameraDevice *cam, uint8_t uid_bytes[6], uint64_t *uid_value);
 #endif /* INC_0X02C1B_H_ */

--- a/Core/Inc/camera_manager.h
+++ b/Core/Inc/camera_manager.h
@@ -99,7 +99,8 @@ void CAM_UART_RxCpltCallback(USART_HandleTypeDef *husart);
 void CAM_SPI_RxCpltCallback(SPI_HandleTypeDef *hspi);
 
 void poll_camera_temperatures(void);
-void scan_camera_sensors(bool scanI2cAtStart);
+void scan_camera_sensor(uint8_t cam_id);  /* Scan single camera slot; sets isPresent */
+void scan_camera_sensors(void);
 uint8_t get_cameras_present(void);  // Get bitmask of present cameras (computed from cam_array[].isPresent)
 
 #endif /* INC_CAMERA_MANAGER_H_ */

--- a/Core/Inc/camera_manager.h
+++ b/Core/Inc/camera_manager.h
@@ -30,6 +30,7 @@ typedef struct {
 	bool 			isProgrammed;
 	bool 			isConfigured;
 	bool 			isPowered;
+	bool            isPresent;
 	uint8_t 		gain;
 	uint8_t 		exposure;
 	uint8_t *pRecieveHistoBuffer;
@@ -82,6 +83,7 @@ _Bool check_streaming(void);
 _Bool enable_camera_power(uint8_t cam_id);
 _Bool disable_camera_power(uint8_t cam_id);
 _Bool get_camera_power_status(uint8_t cam_id);
+void power_off_all_cameras(void);
 
 void Camera_USART_RxCpltCallback_Handler(USART_HandleTypeDef *husart);
 void Camera_SPI_RxCpltCallback_Handler(SPI_HandleTypeDef *hspi);
@@ -90,7 +92,7 @@ uint32_t read_usercode_fpga(uint8_t cam_id);
 _Bool program_sram_fpga(uint8_t cam_id, bool rom_bitstream, uint8_t* pData, uint32_t Data_Len, _Bool force_update);
 
 void fill_frame_buffers(void);
-void print_active_cameras(uint8_t cameras_present);
+void print_active_cameras(void);
 
 
 void CAM_UART_RxCpltCallback(USART_HandleTypeDef *husart);
@@ -98,6 +100,6 @@ void CAM_SPI_RxCpltCallback(SPI_HandleTypeDef *hspi);
 
 void poll_camera_temperatures(void);
 void scan_camera_sensors(bool scanI2cAtStart);
-uint8_t get_cameras_present(void);  // Get bitmask of present cameras
+uint8_t get_cameras_present(void);  // Get bitmask of present cameras (computed from cam_array[].isPresent)
 
 #endif /* INC_CAMERA_MANAGER_H_ */

--- a/Core/Inc/common.h
+++ b/Core/Inc/common.h
@@ -26,7 +26,6 @@
 #define DEBUG_FLAG_USB_PRINTF     (1u << 0)
 #define DEBUG_FLAG_HISTO_THROTTLE (1u << 1)  /* Only send histogram packet every 5s; others pretend success */
 #define DEBUG_FLAG_FAKE_DATA  (1u << 2)
-#define DEBUG_FLAG_USB_PRINTF (1u << 0)
 #define DEBUG_FLAG_HISTO_SPARSE (1u << 3)  /* Send histogram data in small chunks over ~15s to reduce EMI */
 
 

--- a/Core/Inc/common.h
+++ b/Core/Inc/common.h
@@ -25,6 +25,7 @@
 
 #define DEBUG_FLAG_USB_PRINTF     (1u << 0)
 #define DEBUG_FLAG_HISTO_THROTTLE (1u << 1)  /* Only send histogram packet every 5s; others pretend success */
+#define DEBUG_FLAG_FAKE_DATA  (1u << 2)
 
 
 #define I2C_IRQ_PRIORITY 0

--- a/Core/Inc/common.h
+++ b/Core/Inc/common.h
@@ -24,6 +24,7 @@
 #define CAM_TEMP_INTERVAL_MS   1000u          // 1 Hz
 
 #define DEBUG_FLAG_USB_PRINTF (1u << 0)
+#define DEBUG_FLAG_HISTO_SPARSE (1u << 3)  /* Send histogram data in small chunks over ~15s to reduce EMI */
 
 
 #define I2C_IRQ_PRIORITY 0

--- a/Core/Inc/i2c_master.h
+++ b/Core/Inc/i2c_master.h
@@ -20,5 +20,7 @@ uint8_t read_data_register_of_slave(I2C_HandleTypeDef * pI2c, uint8_t slave_addr
 void reset_slaves(I2C_HandleTypeDef * pI2c);
 HAL_StatusTypeDef TCA9548A_SelectChannel(I2C_HandleTypeDef *hi2c, uint8_t address, uint8_t channel);
 HAL_StatusTypeDef TCA9548A_SelectBroadcast(I2C_HandleTypeDef *hi2c, uint8_t address);
+HAL_StatusTypeDef TCA9548A_EnableChannel(I2C_HandleTypeDef *hi2c, uint8_t address, uint8_t channel);
+HAL_StatusTypeDef TCA9548A_DisableChannel(I2C_HandleTypeDef *hi2c, uint8_t address, uint8_t channel);
 
 #endif /* INC_I2C_MASTER_H_ */

--- a/Core/Src/0X02C1B.c
+++ b/Core/Src/0X02C1B.c
@@ -279,8 +279,8 @@ int X02C1B_get_gain(CameraDevice *cam)
 
 int X02C1B_FSIN_EXT_enable()
 {
-    printf("Enabling FSIN_EXT\r\n");
 	if(ext_fsin_enabled) return HAL_OK;
+    printf("Enabling FSIN_EXT\r\n");
 
     /*Configure GPIO pin Output Level */
     HAL_GPIO_WritePin(FSIN_EN_GPIO_Port, FSIN_EN_Pin, GPIO_PIN_RESET);

--- a/Core/Src/0X02C1B.c
+++ b/Core/Src/0X02C1B.c
@@ -300,6 +300,13 @@ int X02C1B_FSIN_EXT_enable()
     return HAL_OK;
 }
 
+int X02C1B_FSIN_EXT_status(bool *is_enabled)
+{
+    if (is_enabled == NULL) return -1;
+    *is_enabled = ext_fsin_enabled;
+    return HAL_OK;
+}
+
 int X02C1B_FSIN_EXT_disable()
 {
 	if(!ext_fsin_enabled) return HAL_OK;

--- a/Core/Src/0X02C1B.c
+++ b/Core/Src/0X02C1B.c
@@ -279,6 +279,7 @@ int X02C1B_get_gain(CameraDevice *cam)
 
 int X02C1B_FSIN_EXT_enable()
 {
+    printf("Enabling FSIN_EXT\r\n");
 	if(ext_fsin_enabled) return HAL_OK;
 
     /*Configure GPIO pin Output Level */
@@ -309,6 +310,7 @@ int X02C1B_FSIN_EXT_status(bool *is_enabled)
 
 int X02C1B_FSIN_EXT_disable()
 {
+    printf("Disabling FSIN_EXT\r\n");
 	if(!ext_fsin_enabled) return HAL_OK;
     /*Configure GPIO pin : FSIN_EN_Pin */
     GPIO_InitTypeDef GPIO_InitStruct = {0};

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -278,6 +278,9 @@ void init_camera_sensors() {
 	event_bits = 0x00;
 	event_bits_enabled = 0x00;
 
+	/* Start with all cameras powered off; scan will power on only those needed. */
+	power_off_all_cameras();
+
 	fill_frame_buffers();
 }
 
@@ -740,54 +743,55 @@ _Bool program_fpga(uint8_t cam_id, _Bool force_update)
 /* -------- END FPGA FUNCTIONS -------- */
 
 /* -------- START CAMERA I2C FUNCTIONS -------- */
-void scan_camera_sensors(bool scanI2cAtStart){
-  // Scan for I2C cameras
-  for (int i = 0; i < CAMERA_COUNT; i++)
-  {
+
+/** Scan a single camera slot for I2C camera (0x36) and FPGA (0x40); sets cam_array[cam_id].isPresent. */
+void scan_camera_sensor(uint8_t cam_id) {
+	if (cam_id >= CAMERA_COUNT) {
+		return;
+	}
 	uint8_t addresses_found[10];
 	uint8_t found;
 	bool camera_found = false, fpga_found = false;
 
-	TCA9548A_SelectChannel(&hi2c1, 0x70, i);
+	TCA9548A_SelectChannel(&hi2c1, 0x70, cam_id);
 	delay_ms(10);
 
-	if (scanI2cAtStart)
-	  printf("I2C Scanning bus %d\r\n", i + 1);
-	found = I2C_scan(&hi2c1, addresses_found, sizeof(addresses_found), scanI2cAtStart);
+	found = I2C_scan(&hi2c1, addresses_found, sizeof(addresses_found), true);
 
-	for (int j = 0; j < found; j++)
-	{
-	  if (addresses_found[j] == 0x36)
-		camera_found = true;
-	  else if (addresses_found[j] == 0x40)
-		fpga_found = true;
+	for (uint8_t j = 0; j < found; j++) {
+		if (addresses_found[j] == 0x36) {
+			camera_found = true;
+		} else if (addresses_found[j] == 0x40) {
+			fpga_found = true;
+		}
 	}
 
-	if (camera_found && fpga_found)
-	{
-	  cam_array[i].isPresent = true;
+	if (camera_found && fpga_found) {
+		cam_array[cam_id].isPresent = true;
+	} else {
+		cam_array[cam_id].isPresent = false;
+		printf("Camera %d not found\r\n", cam_id + 1);
 	}
-	else
-	{
-	  cam_array[i].isPresent = false;
-	  printf("Camera %d not found\r\n", i + 1);
+}
+
+void scan_camera_sensors(void) {
+	for (int i = 0; i < CAMERA_COUNT; i++) {
+		scan_camera_sensor((uint8_t)i);
 	}
-  }
 
-  bool all_present = true;
-  for (int i = 0; i < CAMERA_COUNT; ++i) {
-	  if (!cam_array[i].isPresent) {
-		  all_present = false;
-		  break;
-	  }
-  }
+	bool all_present = true;
+	for (int i = 0; i < CAMERA_COUNT; ++i) {
+		if (!cam_array[i].isPresent) {
+			all_present = false;
+			break;
+		}
+	}
 
-  if (all_present)
-  {
-	printf("All cameras found\r\n");
-  }else{
-	  print_active_cameras();
-  }
+	if (all_present) {
+		printf("All cameras found\r\n");
+	} else {
+		print_active_cameras();
+	}
 }
 
 _Bool configure_camera_sensor(uint8_t cam_id)

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -6,6 +6,7 @@
  */
 
 #include "main.h"
+#include "logging.h"
 #include "crosslink.h"
 #include "0X02C1B.h"
 #include "i2c_master.h"
@@ -33,7 +34,6 @@ static uint8_t  next_cam_idx = 0;
 CameraDevice cam_array[CAMERA_COUNT];	// array of all the cameras
 
 static int _active_cam_idx = 0;
-static uint8_t cameras_present = 0x00;
 
 volatile bool usb_failed = false;
 
@@ -44,7 +44,6 @@ static uint8_t _active_buffer = 0; // Index of the buffer currently being writte
 volatile uint8_t frame_id = 0;
 extern volatile uint8_t event_bits_enabled; // holds the event bits for the cameras to be enabled
 extern uint8_t event_bits;
-extern bool fake_data_gen;
 extern USBD_HandleTypeDef hUsbDeviceHS;
 extern uint32_t pulse_count;
 
@@ -65,6 +64,24 @@ static uint8_t camera_failure_counters[CAMERA_COUNT] = {0};  // Track consecutiv
 static bool camera_failure_detected[CAMERA_COUNT] = {false};  // Track if failure has been detected
 
  __ALIGN_BEGIN __attribute__((section(".sram4"))) volatile uint8_t spi6_buffer[SPI_PACKET_LENGTH] __ALIGN_END;
+
+
+static bool camera_is_present(uint8_t cam_id) {
+	CameraDevice *cam = &cam_array[cam_id];
+	if (!cam->isPresent) {
+		printf("Camera %d not present\r\n", cam_id + 1);
+		return false;
+	}
+	return true;
+}
+
+static bool camera_request_is_valid(uint8_t cam_id) {
+	if (cam_id >= CAMERA_COUNT) {
+		printf("Camera %d index out of range\r\n", cam_id + 1);
+		return false;
+	}
+	return camera_is_present(cam_id);
+}
 
 
 static void init_camera(CameraDevice *cam){
@@ -98,6 +115,8 @@ static void init_camera(CameraDevice *cam){
 	cam->streaming_enabled = false;
 	cam->isConfigured = false;
 	cam->isProgrammed = false;
+	cam->isPowered = true;
+	cam->isPresent = false;
 }
 
 void init_camera_sensors() {
@@ -248,9 +267,9 @@ void init_camera_sensors() {
 	cam_array[7].i2c_target = 7;
 	cam_array[7].pRecieveHistoBuffer = NULL;
 
+
 	for(i=0; i<CAMERA_COUNT; i++){
 		cam_array[i].pRecieveHistoBuffer =(uint8_t *)&frame_buffer[_active_buffer][i * HISTOGRAM_DATA_SIZE];
-		cam_array[i].isPowered = true; // Initialize all cameras as powered on
 		init_camera(&cam_array[i]);
 	}
 
@@ -280,7 +299,13 @@ CameraDevice* get_camera_byID(int id) {
 }
 
 uint8_t get_cameras_present(void) {
-	return cameras_present;
+	uint8_t mask = 0;
+	for (int i = 0; i < CAMERA_COUNT; ++i) {
+		if (cam_array[i].isPresent) {
+			mask |= (uint8_t)(1u << i);
+		}
+	}
+	return mask;
 }
 
 // Get SPI/USART status for the specified camera ID
@@ -294,12 +319,11 @@ uint8_t get_cameras_present(void) {
 // Bits 3–6: Reserved (unused)
 //
 uint8_t get_camera_status(uint8_t cam_id) {
-	
 	uint8_t status_flags = 0x00;
 
 	if (cam_id < 0 || cam_id >= CAMERA_COUNT) {
 		printf("Get Camera %d Status Failed\r\n", cam_id + 1);
-		return false;
+		return 0x00;
 	}
 
 	CameraDevice *cam = get_camera_byID(cam_id);
@@ -385,12 +409,12 @@ uint8_t get_camera_status(uint8_t cam_id) {
 	return status_flags;
 }
 
-void print_active_cameras(uint8_t cameras_present)
+void print_active_cameras(void)
 {
     printf("Active cameras: ");
-    for (int i = 0; i < 8; ++i)
+    for (int i = 0; i < CAMERA_COUNT; ++i)
     {
-        if (cameras_present & (1 << i))
+        if (cam_array[i].isPresent)
         {
             printf("%d ", i + 1);  // Cameras are 1-based
         }
@@ -402,8 +426,7 @@ void print_active_cameras(uint8_t cameras_present)
 /* -------- START FPGA FUNCTIONS -------- */
 _Bool reset_camera(uint8_t cam_id)
 {
-	if(cam_id < 0 || cam_id >= CAMERA_COUNT)
-	{
+	if (!camera_request_is_valid(cam_id)) {
 		printf("Hard Reset Camera %d Failed\r\n", cam_id+1);
 		return false;
 	}
@@ -426,8 +449,7 @@ _Bool reset_camera(uint8_t cam_id)
 
 _Bool enable_fpga(uint8_t cam_id)
 {
-	if(cam_id < 0 || cam_id >= CAMERA_COUNT)
-	{
+	if (!camera_request_is_valid(cam_id)) {
 		printf("Enable FPGA Camera %d Failed\r\n", cam_id+1);
 		return false;
 	}
@@ -443,8 +465,7 @@ _Bool enable_fpga(uint8_t cam_id)
 
 _Bool disable_fpga(uint8_t cam_id)
 {
-	if(cam_id < 0 || cam_id >= CAMERA_COUNT)
-	{
+	if (!camera_request_is_valid(cam_id)) {
 		printf("Disable FPGA Camera %d Failed\r\n", cam_id+1);
 		return false;
 	}
@@ -461,8 +482,7 @@ _Bool disable_fpga(uint8_t cam_id)
 
 _Bool activate_fpga(uint8_t cam_id)
 {
-	if(cam_id < 0 || cam_id >= CAMERA_COUNT)
-	{
+	if (!camera_request_is_valid(cam_id)) {
 		printf("Activate FPGA Camera %d Failed\r\n", cam_id+1);
 		return false;
 	}
@@ -487,8 +507,7 @@ _Bool activate_fpga(uint8_t cam_id)
 
 _Bool verify_fpga(uint8_t cam_id)
 {
-	if(cam_id < 0 || cam_id >= CAMERA_COUNT)
-	{
+	if (!camera_request_is_valid(cam_id)) {
 		printf("Activate FPGA Camera %d Failed\r\n", cam_id+1);
 		return false;
 	}
@@ -513,8 +532,7 @@ _Bool verify_fpga(uint8_t cam_id)
 
 _Bool enter_sram_prog_fpga(uint8_t cam_id)
 {
-	if(cam_id < 0 || cam_id >= CAMERA_COUNT)
-	{
+	if (!camera_request_is_valid(cam_id)) {
 		printf("Activate FPGA Camera %d Failed\r\n", cam_id+1);
 		return false;
 	}
@@ -539,8 +557,7 @@ _Bool enter_sram_prog_fpga(uint8_t cam_id)
 
 _Bool exit_sram_prog_fpga(uint8_t cam_id)
 {
-	if(cam_id < 0 || cam_id >= CAMERA_COUNT)
-	{
+	if (!camera_request_is_valid(cam_id)) {
 		printf("Activate FPGA Camera %d Failed\r\n", cam_id+1);
 		return false;
 	}
@@ -565,8 +582,7 @@ _Bool exit_sram_prog_fpga(uint8_t cam_id)
 
 _Bool erase_sram_fpga(uint8_t cam_id)
 {
-	if(cam_id < 0 || cam_id >= CAMERA_COUNT)
-	{
+	if (!camera_request_is_valid(cam_id)) {
 		printf("Activate FPGA Camera %d Failed\r\n", cam_id+1);
 		return false;
 	}
@@ -594,8 +610,7 @@ _Bool erase_sram_fpga(uint8_t cam_id)
 uint32_t read_status_fpga(uint8_t cam_id)
 {
 	uint32_t ret_val = 0;
-	if(cam_id < 0 || cam_id >= CAMERA_COUNT)
-	{
+	if (!camera_request_is_valid(cam_id)) {
 		printf("Activate FPGA Camera %d Failed\r\n", cam_id+1);
 		return ret_val;
 	}
@@ -618,8 +633,7 @@ uint32_t read_status_fpga(uint8_t cam_id)
 uint32_t read_usercode_fpga(uint8_t cam_id)
 {
 	uint32_t ret_val = 0;
-	if(cam_id < 0 || cam_id >= CAMERA_COUNT)
-	{
+	if (!camera_request_is_valid(cam_id)) {
 		printf("Activate FPGA Camera %d Failed\r\n", cam_id+1);
 		return ret_val;
 	}
@@ -642,12 +656,10 @@ uint32_t read_usercode_fpga(uint8_t cam_id)
 _Bool program_sram_fpga(uint8_t cam_id, bool rom_bitstream, uint8_t* pData, uint32_t Data_Len, _Bool force_update)
 {
 	printf("C%d: programming...", cam_id+1);
-	if(cam_id < 0 || cam_id >= CAMERA_COUNT)
-	{
+	if (!camera_request_is_valid(cam_id)) {
 		printf("Program FPGA Camera %d Failed\r\n", cam_id+1);
 		return false;
 	}
-
 	// printf("Program FPGA Camera %d Started\r\n", cam_id+1);
 	_active_cam_idx = cam_id;
 	CameraDevice *cam = &cam_array[_active_cam_idx];
@@ -679,22 +691,13 @@ _Bool program_sram_fpga(uint8_t cam_id, bool rom_bitstream, uint8_t* pData, uint
 _Bool program_fpga(uint8_t cam_id, _Bool force_update)
 {
 	// printf("C%d: programming...", cam_id+1);
-	if(cam_id < 0 || cam_id >= CAMERA_COUNT)
-	{
+	if (!camera_request_is_valid(cam_id)) {
 		printf("Program FPGA Camera %d Failed\r\n", cam_id+1);
 		return false;
 	}
 
 	_active_cam_idx = cam_id;
 	CameraDevice *cam = &cam_array[_active_cam_idx];
-
-	// Check if camera is powered on before attempting to program
-	if(!cam->isPowered)
-	{
-		printf("Cannot program FPGA - Camera %d is powered off\r\n", cam_id+1);
-		cam->isProgrammed = false;
-		return false;
-	}
 
 	if(!force_update)
 	{
@@ -761,24 +764,36 @@ void scan_camera_sensors(bool scanI2cAtStart){
 	}
 
 	if (camera_found && fpga_found)
-	  cameras_present |= 0x01 << i;
+	{
+	  cam_array[i].isPresent = true;
+	}
 	else
+	{
+	  cam_array[i].isPresent = false;
 	  printf("Camera %d not found\r\n", i + 1);
+	}
   }
 
-  if (cameras_present == 0xFF)
+  bool all_present = true;
+  for (int i = 0; i < CAMERA_COUNT; ++i) {
+	  if (!cam_array[i].isPresent) {
+		  all_present = false;
+		  break;
+	  }
+  }
+
+  if (all_present)
   {
 	printf("All cameras found\r\n");
   }else{
-	  print_active_cameras(cameras_present);
+	  print_active_cameras();
   }
 }
 
 _Bool configure_camera_sensor(uint8_t cam_id)
 {
 	// printf("C%d: configuring...", cam_id+1);
-	if(cam_id < 0 || cam_id >= CAMERA_COUNT)
-	{
+	if (!camera_request_is_valid(cam_id)) {
 		printf("Configure Camera %d Registers Failed\r\n", cam_id+1);
 		return false;
 	}
@@ -823,8 +838,7 @@ _Bool configure_camera_sensor(uint8_t cam_id)
 
 _Bool configure_camera_testpattern(uint8_t cam_id, uint8_t test_pattern)
 {
-	if(cam_id < 0 || cam_id >= CAMERA_COUNT)
-	{
+	if (!camera_request_is_valid(cam_id)) {
 		printf("Configure Camera %d Registers Failed\r\n", cam_id+1);
 		return false;
 	}
@@ -866,7 +880,7 @@ void poll_camera_temperatures(void)
             uint8_t cam = next_cam_idx;
             next_cam_idx = (next_cam_idx + 1) % CAM_TEMP_TOTAL_CAMS;
 
-            if (cameras_present & (1 << cam))
+            if (cam_array[cam].isPresent)
             {
                 CameraDevice *pCam = get_camera_byID(cam);
                 if (pCam != NULL)
@@ -933,8 +947,7 @@ void fill_frame_buffers(void) {
 /* -------- START HISTOGRAM TRANSFER FUNCTIONS -------- */
 _Bool get_single_histogram(uint8_t cam_id, uint8_t* data, uint16_t* data_len)
 {
-	if(cam_id < 0 || cam_id >= CAMERA_COUNT)
-	{
+	if (!camera_request_is_valid(cam_id)) {
 		printf("Capture HISTO for Camera %d Failed\r\n", cam_id+1);
 		return false;
 	}
@@ -959,8 +972,7 @@ _Bool get_single_histogram(uint8_t cam_id, uint8_t* data, uint16_t* data_len)
 _Bool capture_single_histogram(uint8_t cam_id)
 {
 	_Bool ret = true;
-	if(cam_id < 0 || cam_id >= CAMERA_COUNT)
-	{
+	if (!camera_request_is_valid(cam_id)) {
 		printf("Capture HISTO for Camera %d Failed\r\n", cam_id+1);
 		return false;
 	}
@@ -1023,6 +1035,9 @@ _Bool capture_single_histogram(uint8_t cam_id)
 
 // Check for cameras that have stopped posting data
 static void check_camera_failures(void) {
+	if ((logging_get_debug_flags() & DEBUG_FLAG_FAKE_DATA) != 0u) {
+		return;  /* No hardware posting data in fake data mode */
+	}
 	// Check each camera that is supposed to be enabled
 	for (uint8_t cam_id = 0; cam_id < CAMERA_COUNT; cam_id++) {
 		bool is_enabled = (event_bits_enabled & (1 << cam_id)) != 0;
@@ -1080,13 +1095,11 @@ _Bool send_data(void) {
 	check_camera_failures();
 	
 	bool success = false;
-	if (fake_data_gen) // Call FAKE data sender if enabled)
-    {
-        success = send_fake_data();
-    }
-    else {
-       success = send_histogram_data();
-    }
+	if ((logging_get_debug_flags() & DEBUG_FLAG_FAKE_DATA) != 0u) {
+		success = send_fake_data();
+	} else {
+		success = send_histogram_data();
+	}
 	poll_camera_temperatures();
 
     if (success) {
@@ -1109,8 +1122,10 @@ _Bool check_streaming(void){
 		}
 		if((current_time - most_recent_frame_time_local) > STREAMING_TIMEOUT_MS){
 			uint32_t elapsed = current_time - streaming_start_time;
-			send_data(); // send data one last frame to finish the buffers 
-			total_frames_failed = total_frames_failed - 1; // subtract one from the total frames failed because the first frame is a skip and the last frame is an extra
+			send_data(); // send data one last frame to finish the buffers
+			if (total_frames_failed > 0) {
+				total_frames_failed--;  // first frame skip / last frame extra
+			}
 			printf("Scan finished (%lu ms, %lu frames)\r\n", elapsed, total_frames_sent);
 			if(total_frames_failed > 0){
 				printf("%lu frames failed\r\n", total_frames_failed);
@@ -1258,8 +1273,8 @@ _Bool send_fake_data(void) {
 	packet_buffer[offset++] = (uint8_t)((timestamp >> 16) & 0xFF);
 	packet_buffer[offset++] = (uint8_t)((timestamp >> 24) & 0xFF);
 
-	// --- Data ---
-	for (uint8_t cam_id = 0; cam_id < count; ++cam_id) {
+	// --- Data --- (iterate over all cameras so payload length matches header)
+	for (uint8_t cam_id = 0; cam_id < CAMERA_COUNT; ++cam_id) {
 		if((event_bits_enabled & (0x01 << cam_id)) != 0) {
 			uint32_t *histo_ptr = (uint32_t *) cam_array[cam_id].pRecieveHistoBuffer;
 			packet_buffer[offset++] = HISTO_SOH;
@@ -1307,6 +1322,11 @@ _Bool send_fake_data(void) {
 _Bool start_data_reception(uint8_t cam_id){
 	if(verbose_on) printf("Start data reception on camera: %d... ",cam_id+1);
 	HAL_StatusTypeDef status;
+
+	if (!camera_request_is_valid(cam_id)) {
+		return false;
+	}
+
 	CameraDevice cam = cam_array[cam_id];
 
     // Check if the device is BUSY
@@ -1366,6 +1386,11 @@ _Bool start_data_reception(uint8_t cam_id){
 _Bool abort_data_reception(uint8_t cam_id){
 	if(verbose_on) printf("Abort data reception C: %d... ",cam_id);
 	HAL_StatusTypeDef status;
+
+	if (!camera_request_is_valid(cam_id)) {
+		return false;
+	}
+
 	// disable the reception
 	CameraDevice* cam = get_camera_byID(cam_id);
 	if(cam->useUsart) {
@@ -1404,6 +1429,10 @@ _Bool abort_data_reception(uint8_t cam_id){
 
 _Bool enable_camera_stream(uint8_t cam_id){
 	// printf("C%d: enable...", cam_id+1);
+
+	if (!camera_request_is_valid(cam_id)) {
+		return false;
+	}
 
 	bool status = false;
 	bool enabled = (event_bits_enabled & (1 << cam_id)) != 0;
@@ -1454,6 +1483,10 @@ _Bool enable_camera_stream(uint8_t cam_id){
 
 _Bool disable_camera_stream(uint8_t cam_id){
 	// printf("C%d: disable...", cam_id+1);
+	if (!camera_request_is_valid(cam_id)) {
+		return false;
+	}
+
 	bool enabled = (event_bits_enabled & (1 << cam_id)) != 0;
 	if(!enabled){
 		printf("already done\r\n");
@@ -1519,6 +1552,7 @@ _Bool disable_camera_power(uint8_t cam_id){
 
 	HAL_GPIO_WritePin(cam->power_port, cam->power_pin, GPIO_PIN_RESET); // Set power pin low
 	cam->isPowered = false;
+	cam->isPresent = false;
 	cam->isProgrammed = false; // Clear programmed status when power is off
 	cam->isConfigured = false; // Clear configured status when power is off
 	cam->streaming_enabled = false; // Clear streaming status when power is off
@@ -1528,7 +1562,7 @@ _Bool disable_camera_power(uint8_t cam_id){
 }
 
 _Bool get_camera_power_status(uint8_t cam_id){
-	if(cam_id < 0 || cam_id >= CAMERA_COUNT)
+	if(cam_id >= CAMERA_COUNT)
 	{
 		printf("Get Power Status for Camera %d Failed\r\n", cam_id+1);
 		return false;
@@ -1536,4 +1570,20 @@ _Bool get_camera_power_status(uint8_t cam_id){
 
 	CameraDevice *cam = get_camera_byID(cam_id);
 	return cam->isPowered;
+}
+
+void power_off_all_cameras(void) {
+	/* Physically power off all cameras (GPIO low) and clear state. Used when entering fake data mode. */
+	event_bits_enabled = 0x00;
+	for (uint8_t i = 0; i < CAMERA_COUNT; i++) {
+		CameraDevice *cam = &cam_array[i];
+		HAL_GPIO_WritePin(cam->power_port, cam->power_pin, GPIO_PIN_RESET);
+		cam->isPowered = false;
+		cam->isPresent = false;
+		cam->isProgrammed = false;
+		cam->isConfigured = false;
+		cam->streaming_enabled = false;
+		cam_temp[i] = 25.0f;
+	}
+	printf("All cameras powered off (fake data mode)\r\n");
 }

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -1456,7 +1456,7 @@ _Bool enable_camera_stream(uint8_t cam_id){
 		}
 	}
 
-	delay_us(200);
+	delay_us(10);
 
 	if(TCA9548A_SelectChannel(&hi2c1, 0x70, cam->i2c_target) != HAL_OK)
 		{

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -1540,6 +1540,10 @@ _Bool enable_camera_power(uint8_t cam_id){
 
 	HAL_GPIO_WritePin(cam->power_port, cam->power_pin, GPIO_PIN_SET); // Set power pin high
 	cam->isPowered = true;
+	if (TCA9548A_EnableChannel(&hi2c1, 0x70, cam->i2c_target) != HAL_OK) {
+		printf("Failed to enable mux channel for Camera %d\r\n", cam_id + 1);
+		return false;
+	}
 
 	printf("Enabled Power for Camera %d\r\n", cam_id+1);
 	return true;
@@ -1553,6 +1557,10 @@ _Bool disable_camera_power(uint8_t cam_id){
 	}
 
 	CameraDevice *cam = get_camera_byID(cam_id);
+	if (TCA9548A_DisableChannel(&hi2c1, 0x70, cam->i2c_target) != HAL_OK) {
+		printf("Failed to disable mux channel for Camera %d\r\n", cam_id + 1);
+		return false;
+	}
 
 	HAL_GPIO_WritePin(cam->power_port, cam->power_pin, GPIO_PIN_RESET); // Set power pin low
 	cam->isPowered = false;
@@ -1581,6 +1589,8 @@ void power_off_all_cameras(void) {
 	event_bits_enabled = 0x00;
 	for (uint8_t i = 0; i < CAMERA_COUNT; i++) {
 		CameraDevice *cam = &cam_array[i];
+		/* Disconnect this camera's mux channel before cutting camera power. */
+		(void)TCA9548A_DisableChannel(&hi2c1, 0x70, cam->i2c_target);
 		HAL_GPIO_WritePin(cam->power_port, cam->power_pin, GPIO_PIN_RESET);
 		cam->isPowered = false;
 		cam->isPresent = false;

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -1599,5 +1599,5 @@ void power_off_all_cameras(void) {
 		cam->streaming_enabled = false;
 		cam_temp[i] = 25.0f;
 	}
-	printf("All cameras powered off (fake data mode)\r\n");
+	printf("All cameras powered off\r\n");
 }

--- a/Core/Src/i2c_master.c
+++ b/Core/Src/i2c_master.c
@@ -17,6 +17,24 @@
 
 uint8_t I2C_current_target = 0x00; // Default target address
 
+static HAL_StatusTypeDef TCA9548A_WriteControl(I2C_HandleTypeDef *hi2c, uint8_t address, uint8_t data)
+{
+    if (I2C_current_target == data) {
+        return HAL_OK; // no need to change
+    }
+
+    HAL_StatusTypeDef ret = HAL_I2C_Master_Transmit(hi2c, address << 1, &data, 1, HAL_MAX_DELAY);
+    if (ret == HAL_OK) {
+        I2C_current_target = data;
+    } else {
+        printf("TCA9548A control write failed\r\n");
+        printf("requested: 0x%02X current: 0x%02X addr: 0x%02X ret: %d err: %lu\r\n",
+               data, I2C_current_target, address, ret, hi2c->ErrorCode);
+    }
+
+    return ret;
+}
+
 uint8_t I2C_scan(I2C_HandleTypeDef * pI2c, uint8_t* addr_list, size_t list_size, bool display) {
 
 	uint8_t found = 0;
@@ -155,18 +173,31 @@ HAL_StatusTypeDef TCA9548A_SelectChannel(I2C_HandleTypeDef *hi2c, uint8_t addres
     }
 
     uint8_t data = (1 << channel);  // Set the corresponding bit for the channel
-
-    if(I2C_current_target == data) return HAL_OK; // no need to change
-    
-    I2C_current_target = data;
-    return HAL_I2C_Master_Transmit(hi2c, address << 1, &data, 1, HAL_MAX_DELAY);
+    return TCA9548A_WriteControl(hi2c, address, data);
 }
 
 HAL_StatusTypeDef TCA9548A_SelectBroadcast(I2C_HandleTypeDef *hi2c, uint8_t address)
 {
     uint8_t data = 0xFF;  // Set the corresponding bit for the channel
-    if(I2C_current_target == data) return HAL_OK; // no need to change
+    return TCA9548A_WriteControl(hi2c, address, data);
+}
 
-    I2C_current_target = data;
-    return HAL_I2C_Master_Transmit(hi2c, address << 1, &data, 1, HAL_MAX_DELAY);
+HAL_StatusTypeDef TCA9548A_EnableChannel(I2C_HandleTypeDef *hi2c, uint8_t address, uint8_t channel)
+{
+    if (channel > 7) {
+        return HAL_ERROR;
+    }
+
+    uint8_t data = (uint8_t)(I2C_current_target | (1u << channel));
+    return TCA9548A_WriteControl(hi2c, address, data);
+}
+
+HAL_StatusTypeDef TCA9548A_DisableChannel(I2C_HandleTypeDef *hi2c, uint8_t address, uint8_t channel)
+{
+    if (channel > 7) {
+        return HAL_ERROR;
+    }
+
+    uint8_t data = (uint8_t)(I2C_current_target & (uint8_t)~(1u << channel));
+    return TCA9548A_WriteControl(hi2c, address, data);
 }

--- a/Core/Src/if_commands.c
+++ b/Core/Src/if_commands.c
@@ -368,7 +368,7 @@ static void process_fpga_commands(UartPacket *uartResp, UartPacket cmd)
 	    		if(!func_ret)
 	    		{
 	    			uartResp->packet_type = OW_ERROR;
-	    			printf("Failed to Program FPGA on camera %d\r\n", i);
+	    			printf("Failed to Program FPGA on camera %d\r\n", i+1);
 	    		}
 	        }
 	    }
@@ -797,6 +797,23 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 			}
 			break;
 		}
+		// Before changing power state, discover whether or not the FSIN_ext is enabled or disabled. Disable it if it is not already disabled, and re-enable it after power on sequence is complete. 
+		// This is required to prevent FSIN from triggering spuriously during power state changes
+		bool fsin_ext_was_enabled = false;
+		if(X02C1B_FSIN_EXT_status(&fsin_ext_was_enabled) != 0){
+			printf("Failed to read FSIN_EXT status\r\n");
+			uartResp->packet_type = OW_ERROR;
+			break;
+		}
+		if(fsin_ext_was_enabled){
+			if(X02C1B_FSIN_EXT_disable() != 0){
+				printf("Failed to disable FSIN_EXT\r\n");
+				uartResp->packet_type = OW_ERROR;
+				break;
+			}
+		}
+		delay_ms(10); // Short delay to ensure FSIN_ext is fully disabled before power state changes
+
 		/* 1) Enable power for all cameras in the mask */
 		for (uint8_t i = 0; i < 8; i++) {
 			if ((cmd.addr >> i) & 0x01) {
@@ -817,8 +834,16 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 		// delay_ms(1000);
 		// /* 3) Scan all camera slots to set isPresent */
 		// scan_camera_sensors();
-
 		//TODO due to a bug in the scan camera sensors, we will just set the isPresent for each of these to TRUE if it is powered and assume that the cameras are always OK.
+
+		// Restore FSIN_ext to its previous state if it was originally enabled
+		delay_ms(10); // Short delay to ensure FSIN_ext is fully disabled before power state changes
+		if(fsin_ext_was_enabled){
+			if(X02C1B_FSIN_EXT_enable() != 0){
+				printf("Failed to re-enable FSIN_EXT\r\n");
+				uartResp->packet_type = OW_ERROR;
+			}
+		}
 		break;
 
 	case OW_CAMERA_POWER_OFF:
@@ -833,6 +858,22 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 			}
 			break;
 		}
+		// Before changing power state, discover whether or not the FSIN_ext is enabled or disabled. Disable it if it is not already disabled, and re-enable it after power off sequence is complete.
+		// This is required to prevent FSIN from triggering spuriously during power state changes
+		fsin_ext_was_enabled = false;
+		if(X02C1B_FSIN_EXT_status(&fsin_ext_was_enabled) != 0){
+			printf("Failed to read FSIN_EXT status\r\n");
+			uartResp->packet_type = OW_ERROR;
+			break;
+		}
+		if(fsin_ext_was_enabled){
+			if(X02C1B_FSIN_EXT_disable() != 0){
+				printf("Failed to disable FSIN_EXT\r\n");
+				uartResp->packet_type = OW_ERROR;
+				break;
+			}
+		}
+		delay_ms(10); // Short delay to ensure FSIN_ext is fully disabled before power state changes
 	    for (uint8_t i = 0; i < 8; i++) {
 	        if ((cmd.addr >> i) & 0x01) {
 	        	if(!disable_camera_power(i))
@@ -847,6 +888,14 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 	        	}
 	        }
 	    }
+		// Restore FSIN_ext to its previous state if it was originally enabled
+		delay_ms(10);
+		if(fsin_ext_was_enabled){
+			if(X02C1B_FSIN_EXT_enable() != 0){
+				printf("Failed to re-enable FSIN_EXT\r\n");
+				uartResp->packet_type = OW_ERROR;
+			}
+		}
 		break;
 
 	case OW_CAMERA_POWER_STATUS:

--- a/Core/Src/if_commands.c
+++ b/Core/Src/if_commands.c
@@ -21,7 +21,7 @@
 #include <inttypes.h>
 #include <string.h>
 
-extern uint8_t event_bits_enabled;
+extern volatile uint8_t event_bits_enabled;
 
 static uint32_t id_words[3] = {0};
 static uint8_t camera_status[8] = {0};

--- a/Core/Src/if_commands.c
+++ b/Core/Src/if_commands.c
@@ -256,7 +256,7 @@ static void process_fpga_commands(UartPacket *uartResp, UartPacket cmd)
 		uartResp->data = NULL;
 		return;
 	}
-	
+
 	CameraDevice* pCam = get_active_cam();
 
 	switch (cmd.command)
@@ -797,21 +797,28 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 			}
 			break;
 		}
-	    for (uint8_t i = 0; i < 8; i++) {
-	        if ((cmd.addr >> i) & 0x01) {
-	        	if(!enable_camera_power(i))
-	        	{
-	    			uartResp->packet_type = OW_ERROR;
-	    			printf("Failed to power on camera %d\r\n", i);
+		/* 1) Enable power for all cameras in the mask */
+		for (uint8_t i = 0; i < 8; i++) {
+			if ((cmd.addr >> i) & 0x01) {
+				if (!enable_camera_power(i)) {
+					uartResp->packet_type = OW_ERROR;
+					printf("Failed to power on camera %d\r\n", i);
+					break;
+				}
+				camera_status[i] = 0x00;
+				CameraDevice *cam = get_camera_byID(i);
+				cam->isPresent = true;
+			}
+		}
+		if (uartResp->packet_type != OW_RESP) {
+			break;
+		}
+		// /* 2) Wait 1 s for power to settle */
+		// delay_ms(1000);
+		// /* 3) Scan all camera slots to set isPresent */
+		// scan_camera_sensors();
 
-	        	}
-	        	else
-	        	{
-	        		// Clear camera status when power is turned on (camera state unknown until initialized)
-	        		camera_status[i] = 0x00;
-	        	}
-	        }
-	    }
+		//TODO due to a bug in the scan camera sensors, we will just set the isPresent for each of these to TRUE if it is powered and assume that the cameras are always OK.
 		break;
 
 	case OW_CAMERA_POWER_OFF:

--- a/Core/Src/if_commands.c
+++ b/Core/Src/if_commands.c
@@ -21,6 +21,8 @@
 #include <inttypes.h>
 #include <string.h>
 
+extern uint8_t event_bits_enabled;
+
 static uint32_t id_words[3] = {0};
 static uint8_t camera_status[8] = {0};
 static uint8_t camera_power_status = 0;
@@ -87,6 +89,9 @@ static void process_basic_command(UartPacket *uartResp, UartPacket cmd)
 			uint32_t new_flags = 0;
 			memcpy(&new_flags, cmd.data, sizeof(new_flags));
 			logging_set_debug_flags(new_flags);
+			if ((new_flags & DEBUG_FLAG_FAKE_DATA) != 0u) {
+				power_off_all_cameras();
+			}
 		}
 		uartResp->packet_type = OW_RESP;
 		static uint32_t debug_flags_resp;
@@ -244,6 +249,14 @@ void I2C_DisableEnableReset(I2C_HandleTypeDef *hi2c)
 
 static void process_fpga_commands(UartPacket *uartResp, UartPacket cmd)
 {
+	if ((logging_get_debug_flags() & DEBUG_FLAG_FAKE_DATA) != 0u) {
+		uartResp->command = cmd.command;
+		uartResp->packet_type = OW_RESP;
+		uartResp->data_len = 0;
+		uartResp->data = NULL;
+		return;
+	}
+	
 	CameraDevice* pCam = get_active_cam();
 
 	switch (cmd.command)
@@ -342,7 +355,7 @@ static void process_fpga_commands(UartPacket *uartResp, UartPacket cmd)
 	case OW_FPGA_PROG_SRAM:
 		uartResp->command = OW_FPGA_PROG_SRAM;
 		uartResp->packet_type = OW_RESP;
-		// TODO: Adde parameter to force update currently defaults to false
+		// TODO: Add parameter to force update currently defaults to false
 	    for (uint8_t i = 0; i < 8; i++) {
 	        if ((cmd.addr >> i) & 0x01) {
 	        	_Bool func_ret = false;
@@ -529,18 +542,22 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 		}
 		break;
 	case OW_CAMERA_ON:
-		// printf("Setting Camera %d Stream on\r\n",pCam->id+1);
 		uartResp->command = OW_CAMERA_ON;
 		uartResp->packet_type = OW_RESP;
-		if(X02C1B_stream_on(pCam)){
-			// error
-			printf("Failed Setting Camera %d Stream on\r\n",pCam->id+1);
-			uartResp->packet_type = OW_ERROR;
+		if ((logging_get_debug_flags() & DEBUG_FLAG_FAKE_DATA) == 0u) {
+			if(X02C1B_stream_on(pCam)){
+				printf("Failed Setting Camera %d Stream on\r\n",pCam->id+1);
+				uartResp->packet_type = OW_ERROR;
+			}
 		}
 		break;
 	case OW_CAMERA_SET_CONFIG:
 		uartResp->command = OW_CAMERA_SET_CONFIG;
 		uartResp->packet_type = OW_RESP;
+		/* In fake data mode, treat as no-op success and skip hardware */
+		if ((logging_get_debug_flags() & DEBUG_FLAG_FAKE_DATA) != 0u) {
+			break;
+		}
 	    for (uint8_t i = 0; i < 8; i++) {
 	        if ((cmd.addr >> i) & 0x01) {
 	        	if(!configure_camera_sensor(i))
@@ -555,6 +572,16 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 	case OW_CAMERA_STREAM:
 		uartResp->command = OW_CAMERA_STREAM;
 		uartResp->packet_type = OW_RESP;
+		/* In fake data mode, just update logical enable mask and skip hardware */
+		if ((logging_get_debug_flags() & DEBUG_FLAG_FAKE_DATA) != 0u) {
+			if (cmd.reserved == 1) {
+				event_bits_enabled |= cmd.addr;
+			} else {
+				event_bits_enabled &= (uint8_t)~cmd.addr;
+			}
+			uartResp->packet_type = OW_ACK;
+			break;
+		}
 		uint8_t status = 0;
 		for (uint8_t i = 0; i < 8; i++) {
 	        if ((cmd.addr >> i) & 0x01) {
@@ -577,6 +604,10 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 		// printf("Capture single histogram frame\r\n");
 		uartResp->command = OW_CAMERA_SINGLE_HISTOGRAM;
 		uartResp->packet_type = OW_RESP;
+		if ((logging_get_debug_flags() & DEBUG_FLAG_FAKE_DATA) != 0u) {
+			/* Not meaningful in fake data mode; report success without hardware */
+			break;
+		}
 	    for (uint8_t i = 0; i < 8; i++) {
 	        if ((cmd.addr >> i) & 0x01) {
 	        	if(!capture_single_histogram(i))
@@ -594,6 +625,10 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 		uartResp->packet_type = OW_RESP;
 		uartResp->addr = cmd.addr;
 		uartResp->reserved = 0;
+		if ((logging_get_debug_flags() & DEBUG_FLAG_FAKE_DATA) != 0u) {
+			/* Not meaningful in fake data mode; report success without hardware */
+			break;
+		}
 	    for (uint8_t i = 0; i < 8; i++) {
 	        if ((cmd.addr >> i) & 0x01) {
 	        	if(!get_single_histogram(i, uartResp->data, &uartResp->data_len))
@@ -618,6 +653,10 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 		uint8_t test_pattern = cmd.data[0];
 		uartResp->command = OW_CAMERA_SET_TESTPATTERN;
 		uartResp->packet_type = OW_RESP;
+		if ((logging_get_debug_flags() & DEBUG_FLAG_FAKE_DATA) != 0u) {
+			/* Not meaningful in fake data mode; report success without hardware */
+			break;
+		}
 	    for (uint8_t i = 0; i < 8; i++) {
 	        if ((cmd.addr >> i) & 0x01) {
 	        	if(!configure_camera_testpattern(i,test_pattern))
@@ -630,13 +669,13 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 	    }
 		break;
 	case OW_CAMERA_OFF:
-		// printf("Setting Camera %d Stream off\r\n",pCam->id+1);
 		uartResp->command = OW_CAMERA_OFF;
 		uartResp->packet_type = OW_RESP;
-		if(X02C1B_stream_off(pCam)<0){
-			// error
-			printf("Failed Setting Camera %d Stream off\r\n",pCam->id+1);
-			uartResp->packet_type = OW_ERROR;
+		if ((logging_get_debug_flags() & DEBUG_FLAG_FAKE_DATA) == 0u) {
+			if(X02C1B_stream_off(pCam)<0){
+				printf("Failed Setting Camera %d Stream off\r\n",pCam->id+1);
+				uartResp->packet_type = OW_ERROR;
+			}
 		}
 		break;
 	case OW_CAMERA_STATUS:
@@ -749,6 +788,15 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 	case OW_CAMERA_POWER_ON:
 		uartResp->command = OW_CAMERA_POWER_ON;
 		uartResp->packet_type = OW_RESP;
+		/* In fake data mode, cameras remain powered off; treat as no-op success */
+		if ((logging_get_debug_flags() & DEBUG_FLAG_FAKE_DATA) != 0u) {
+			for (uint8_t i = 0; i < 8; i++) {
+				if ((cmd.addr >> i) & 0x01) {
+					camera_status[i] = 0x00;
+				}
+			}
+			break;
+		}
 	    for (uint8_t i = 0; i < 8; i++) {
 	        if ((cmd.addr >> i) & 0x01) {
 	        	if(!enable_camera_power(i))
@@ -769,6 +817,15 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 	case OW_CAMERA_POWER_OFF:
 		uartResp->command = OW_CAMERA_POWER_OFF;
 		uartResp->packet_type = OW_RESP;
+		/* In fake data mode, cameras are already powered off; treat as no-op success */
+		if ((logging_get_debug_flags() & DEBUG_FLAG_FAKE_DATA) != 0u) {
+			for (uint8_t i = 0; i < 8; i++) {
+				if ((cmd.addr >> i) & 0x01) {
+					camera_status[i] = 0x00;
+				}
+			}
+			break;
+		}
 	    for (uint8_t i = 0; i < 8; i++) {
 	        if ((cmd.addr >> i) & 0x01) {
 	        	if(!disable_camera_power(i))

--- a/Core/Src/logging.c
+++ b/Core/Src/logging.c
@@ -102,10 +102,11 @@ void logging_set_debug_flags(uint32_t flags) {
 	uint32_t prev_flags = debug_flags;
 	debug_flags = flags;
 	if (prev_flags != debug_flags) {
-		printf("Debug flags changed: 0x%08lX -> 0x%08lX%s\r\n",
+		printf("Debug flags changed: 0x%08lX -> 0x%08lX%s%s\r\n",
 		       (unsigned long)prev_flags,
 		       (unsigned long)debug_flags,
-		       (debug_flags & DEBUG_FLAG_USB_PRINTF) ? " (USB printf ON)" : " (USB printf OFF)");
+		       (debug_flags & DEBUG_FLAG_USB_PRINTF) ? " (USB printf ON)" : " (USB printf OFF)",
+			   (debug_flags & DEBUG_FLAG_HISTO_SPARSE) ? " (HISTO sparse ON)" : "");
 	}
 	if ((debug_flags & DEBUG_FLAG_USB_PRINTF) == 0u) {
 		// Drop any buffered log data so it doesn't flush later.

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -120,7 +120,6 @@ float t;
 char usb_buf[128];
 // Debug flags (sensor debug and fake data are controlled via OW_CMD_DEBUG_FLAGS)
 bool uart_stream = false;
-bool scanI2cAtStart = false;
 
 uint16_t fail_count = 0;
 
@@ -310,9 +309,6 @@ int main(void)
   HAL_GPIO_WritePin(ERROR_LED_GPIO_Port, ERROR_LED_Pin, GPIO_PIN_SET);
 
   init_camera_sensors(); // init structures and camera configs
-  delay_ms(100);
-
-  scan_camera_sensors(scanI2cAtStart);
 
   // Select default camera
   TCA9548A_SelectChannel(&hi2c1, 0x70, get_active_cam()->i2c_target);

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -118,9 +118,8 @@ ICM_Axis3D m;
 ICM_Axis3D g;
 float t;
 char usb_buf[128];
-// Debug flags
+// Debug flags (sensor debug and fake data are controlled via OW_CMD_DEBUG_FLAGS)
 bool uart_stream = false;
-bool fake_data_gen = false;
 bool scanI2cAtStart = false;
 
 uint16_t fail_count = 0;

--- a/Core/Src/uart_comms.c
+++ b/Core/Src/uart_comms.c
@@ -27,6 +27,7 @@ volatile uint32_t ptrReceive;
 volatile uint8_t rx_flag = 0; // start in idle state (0)
 volatile uint8_t tx_flag = 1; // Start in idle state (1)
 const uint32_t zero_val = 0;
+static uint8_t cmd_data_buf[COMMAND_MAX_SIZE];
 
 extern USBD_HandleTypeDef hUsbDeviceHS;
 
@@ -212,8 +213,12 @@ void comms_host_check_received(void) {
 		goto NextDataPacket;
 	}
 
-	// Extract data pointer
-	cmd.data = &rxBuffer[bufferIndex];
+	// Copy data payload out of rxBuffer so rxBuffer is no longer aliased during processing
+	uint16_t copy_len = (cmd.data_len > COMMAND_MAX_SIZE)
+	                    ? (COMMAND_MAX_SIZE - 3 - bufferIndex)
+	                    : cmd.data_len;
+	memcpy(cmd_data_buf, &rxBuffer[bufferIndex], copy_len);
+	cmd.data = cmd_data_buf;
 	if (cmd.data_len > COMMAND_MAX_SIZE) {
 		bufferIndex = COMMAND_MAX_SIZE - 3; // [3 bytes from the end should be the crc for a continuation packet]
 	} else {
@@ -280,6 +285,7 @@ void USBD_COMMS_RxCpltCallback(uint8_t *Buf, uint32_t Len, uint8_t epnum) {
 		printf("COMM RX OVERRUN: count=%lu len=%lu\r\n",
 			   (unsigned long)rx_overrun_count,
 			   (unsigned long)Len);
+		return;
 	}
 
 	memcpy(rxBuffer, Buf, Len);

--- a/Core/Src/uart_comms.c
+++ b/Core/Src/uart_comms.c
@@ -261,18 +261,20 @@ void comms_host_check_received(void) {
 	resp = process_if_command(cmd);
 
 NextDataPacket:
-	if(comms_interface_send(&resp)){
-		printf(".\r\n");
-	}
-	else {
-		printf("!\r\n");
-	}
+    const bool success = comms_interface_send(&resp);
 	// printf("[RESP] ID:0x%04X Cmd:0x%02X Type:0x%02X -> Resp:0x%02X Len:%d\r\n",
 	// 	   cmd.id, cmd.command, cmd.packet_type, resp.packet_type, resp.data_len);
 	memset(rxBuffer, 0, sizeof(rxBuffer));
 	// ClearBuffer_DMA();
 	ptrReceive = 0;
 	rx_flag = 0;
+	if(success){
+		printf(".\r\n");
+	}
+	else {
+		printf("!\r\n");
+	}
+
 }
 
 


### PR DESCRIPTION
- Enable fake data gen flag - powers down cameras and generates fake data in whatever configuration of cameras are enabled
- Enable histoThrottle flag - allows the config file to toggle whether or not the usb transmits every 5 seconds for debug purposes
- Enable proper powering on and off of cameras - should help with thermals
- Improve USB reliability