### PR TITLE
Feature/compression

### DIFF
--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -1803,8 +1803,17 @@ _Bool enable_camera_stream(uint8_t cam_id){
 
 _Bool disable_camera_stream(uint8_t cam_id){
 	// printf("C%d: disable...", cam_id+1);
-	if (!camera_request_is_valid(cam_id)) {
+	if (cam_id >= CAMERA_COUNT) {
+		printf("Camera %d index out of range\r\n", cam_id + 1);
 		return false;
+	}
+
+	/* A camera that is not present is already stopped — treat disable as a
+	 * no-op success.  Returning false here would cause OW_CAMERA_STREAM to
+	 * report OW_ERROR when the host tries to disable all cameras at the end
+	 * of a scan, even though the failed camera is already fully quiesced. */
+	if (!cam_array[cam_id].isPresent) {
+		return true;
 	}
 
 	bool enabled = (event_bits_enabled & (1 << cam_id)) != 0;

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -68,7 +68,6 @@ bool streaming_first_frame = false;
 // Camera failure detection
 #define CAMERA_FAILURE_THRESHOLD_CYCLES 3  // Number of consecutive cycles before reporting failure
 static uint8_t camera_failure_counters[CAMERA_COUNT] = {0};  // Track consecutive cycles without event bits
-static bool camera_failure_detected[CAMERA_COUNT] = {false};  // Track if failure has been detected
 
  __ALIGN_BEGIN __attribute__((section(".sram4"))) volatile uint8_t spi6_buffer[SPI_PACKET_LENGTH] __ALIGN_END;
 
@@ -1114,20 +1113,42 @@ static void check_camera_failures(void) {
 			if (has_event_bit) {
 				// Camera set its event bit, reset failure counter
 				camera_failure_counters[cam_id] = 0;
-				if(camera_failure_detected[cam_id]){
-					camera_failure_detected[cam_id] = false;
-					printf("Camera %d has recovered from failure\r\n", cam_id + 1);
-				}
 			} else {
 				// Camera didn't set its event bit, increment failure counter
 				camera_failure_counters[cam_id]++;
-				
+
 				// Check if threshold reached
 				if (camera_failure_counters[cam_id] >= CAMERA_FAILURE_THRESHOLD_CYCLES) {
-					// Only print once per failure (when threshold is exactly reached)
+					// Only act once per failure (when threshold is exactly reached)
 					if (camera_failure_counters[cam_id] == CAMERA_FAILURE_THRESHOLD_CYCLES) {
-						camera_failure_detected[cam_id] = true;
+						cam_array[cam_id].isPresent = false;
 						printf("Camera %d has stopped posting data\r\n", cam_id + 1);
+
+						/* ── Cleanly isolate the failed camera ────────────────────────
+						 * 1. Remove from event_bits_enabled so subsequent frames never
+						 *    wait for it (and the temperature poller skips it).
+						 * 2. Tell the TCA9548A I2C mux to disconnect that channel.
+						 *    This prevents poll_camera_temperatures() from ever
+						 *    selecting it and getting the I2C bus stuck if the sensor
+						 *    is holding SDA low (the root cause of COMM going dark). */
+
+						/* 1. Clear the camera's event-enable bit (atomic) */
+						__disable_irq();
+						event_bits_enabled &= ~(uint8_t)(1u << cam_id);
+						__enable_irq();
+
+						/* 2. Deselect the camera's I2C mux channel.
+						 *    Uses the bounded TCA9548A_I2C_TIMEOUT_MS timeout (50 ms)
+						 *    so this is a one-time bounded stall, not a hang. */
+						CameraDevice *pFailed = get_camera_byID(cam_id);
+						if (pFailed != NULL) {
+							HAL_StatusTypeDef mux_ret =
+								TCA9548A_DisableChannel(&hi2c1, 0x70, pFailed->i2c_target);
+							if (mux_ret != HAL_OK) {
+								printf("Camera %d: failed to disable TCA mux channel %u (ret=%d)\r\n",
+								       cam_id + 1, (unsigned)pFailed->i2c_target, (int)mux_ret);
+							}
+						}
 					}
 				}
 			}

--- a/Core/Src/i2c_master.c
+++ b/Core/Src/i2c_master.c
@@ -110,7 +110,7 @@ uint8_t send_buffer_to_slave(I2C_HandleTypeDef * pI2c, uint8_t slave_addr, uint8
     }
 
 	// printf("===> Sending Packet %d Bytes\r\n", buf_len);
-    if(HAL_I2C_Master_Transmit(pI2c, (uint16_t)(slave_addr << 1), pBuffer, buf_len, I2C_SLAVE_TIMEOUT_MS)!= HAL_OK)
+    if(HAL_I2C_Master_Transmit(pI2c, (uint16_t)(slave_addr << 1), pBuffer, buf_len, HAL_MAX_DELAY)!= HAL_OK)
 	{
         return 1; // I2C is not in a ready state
 	}
@@ -140,7 +140,7 @@ uint8_t read_status_register_of_slave(I2C_HandleTypeDef * pI2c, uint8_t slave_ad
 
 #else
 
-    if(HAL_I2C_Mem_Read(pI2c, (uint16_t)(slave_addr << 1), 0x00, I2C_MEMADD_SIZE_8BIT, pBuffer, rx_len, I2C_SLAVE_TIMEOUT_MS)!= HAL_OK)
+    if(HAL_I2C_Mem_Read(pI2c, (uint16_t)(slave_addr << 1), 0x00, I2C_MEMADD_SIZE_8BIT, pBuffer, rx_len, HAL_MAX_DELAY)!= HAL_OK)
     {
         return 1; // I2C is not in a ready state
     }
@@ -160,7 +160,7 @@ uint8_t read_data_register_of_slave(I2C_HandleTypeDef * pI2c, uint8_t slave_addr
 
 	// printf("===> Receive Data Packet %d Bytes\r\n", rx_len);
 
-    if(HAL_I2C_Mem_Read(pI2c, (uint16_t)(slave_addr << 1), 0x01, I2C_MEMADD_SIZE_8BIT, pBuffer, rx_len, I2C_SLAVE_TIMEOUT_MS)!= HAL_OK)
+    if(HAL_I2C_Mem_Read(pI2c, (uint16_t)(slave_addr << 1), 0x01, I2C_MEMADD_SIZE_8BIT, pBuffer, rx_len, HAL_MAX_DELAY)!= HAL_OK)
     {
         return 1; // I2C is not in a ready state
     }

--- a/Core/Src/i2c_master.c
+++ b/Core/Src/i2c_master.c
@@ -28,6 +28,19 @@ static void TCA9548A_ResetHardware(void)
     I2C_current_target = 0x00;
 }
 
+/* Maximum time to wait for one I2C mux write.  HAL_MAX_DELAY must NEVER be
+ * used here because TCA9548A_WriteControl is called from interrupt context
+ * (via poll_camera_temperatures → send_data → FSIN IRQ).  A stuck I2C bus
+ * (e.g. a failed camera sensor holding SDA low after its channel is selected)
+ * would otherwise block the CPU forever, making COMM unresponsive. */
+#define TCA9548A_I2C_TIMEOUT_MS  50U
+
+/* Bounded timeout for all general slave read/write operations.  Using
+ * HAL_MAX_DELAY on any I2C call risks a permanent hang if the slave holds
+ * SDA low or the peripheral locks up.  100 ms is generous for normal I2C
+ * traffic but still guarantees the system stays responsive. */
+#define I2C_SLAVE_TIMEOUT_MS     100U
+
 static HAL_StatusTypeDef TCA9548A_WriteControl(I2C_HandleTypeDef *hi2c, uint8_t address, uint8_t data)
 {
     if (I2C_current_target == data) {
@@ -36,7 +49,7 @@ static HAL_StatusTypeDef TCA9548A_WriteControl(I2C_HandleTypeDef *hi2c, uint8_t 
 
     HAL_StatusTypeDef ret = HAL_ERROR;
     for (uint8_t attempt = 0; attempt < 3; attempt++) {
-        ret = HAL_I2C_Master_Transmit(hi2c, address << 1, &data, 1, HAL_MAX_DELAY);
+        ret = HAL_I2C_Master_Transmit(hi2c, address << 1, &data, 1, TCA9548A_I2C_TIMEOUT_MS);
         if (ret == HAL_OK) {
             I2C_current_target = data;
             return HAL_OK;
@@ -97,7 +110,7 @@ uint8_t send_buffer_to_slave(I2C_HandleTypeDef * pI2c, uint8_t slave_addr, uint8
     }
 
 	// printf("===> Sending Packet %d Bytes\r\n", buf_len);
-    if(HAL_I2C_Master_Transmit(pI2c, (uint16_t)(slave_addr << 1), pBuffer, buf_len, HAL_MAX_DELAY)!= HAL_OK)
+    if(HAL_I2C_Master_Transmit(pI2c, (uint16_t)(slave_addr << 1), pBuffer, buf_len, I2C_SLAVE_TIMEOUT_MS)!= HAL_OK)
 	{
         return 1; // I2C is not in a ready state
 	}
@@ -127,7 +140,7 @@ uint8_t read_status_register_of_slave(I2C_HandleTypeDef * pI2c, uint8_t slave_ad
 
 #else
 
-    if(HAL_I2C_Mem_Read(pI2c, (uint16_t)(slave_addr << 1), 0x00, I2C_MEMADD_SIZE_8BIT, pBuffer, rx_len, HAL_MAX_DELAY)!= HAL_OK)
+    if(HAL_I2C_Mem_Read(pI2c, (uint16_t)(slave_addr << 1), 0x00, I2C_MEMADD_SIZE_8BIT, pBuffer, rx_len, I2C_SLAVE_TIMEOUT_MS)!= HAL_OK)
     {
         return 1; // I2C is not in a ready state
     }
@@ -147,7 +160,7 @@ uint8_t read_data_register_of_slave(I2C_HandleTypeDef * pI2c, uint8_t slave_addr
 
 	// printf("===> Receive Data Packet %d Bytes\r\n", rx_len);
 
-    if(HAL_I2C_Mem_Read(pI2c, (uint16_t)(slave_addr << 1), 0x01, I2C_MEMADD_SIZE_8BIT, pBuffer, rx_len, HAL_MAX_DELAY)!= HAL_OK)
+    if(HAL_I2C_Mem_Read(pI2c, (uint16_t)(slave_addr << 1), 0x01, I2C_MEMADD_SIZE_8BIT, pBuffer, rx_len, I2C_SLAVE_TIMEOUT_MS)!= HAL_OK)
     {
         return 1; // I2C is not in a ready state
     }


### PR DESCRIPTION
minor cleanups to ensure that camera failures do not lead to a frozen system
- fix bug in disable camera where a dead camera will cause disable to fail 
- fix bug where temperature poll loop will poll failed cameras and cause the system to hang