### PR TITLE
fix(imu): move IMU sampling out of the TIM14 ISR; ISR-safe USB log path

### DIFF
--- a/Core/Inc/logging.h
+++ b/Core/Inc/logging.h
@@ -15,6 +15,7 @@
 
  void init_dma_logging();
  bool is_using_dma();
+ void logging_pump(void);
  void logging_set_debug_flags(uint32_t flags);
  uint32_t logging_get_debug_flags(void);
  void logging_UART_TxCpltCallback(UART_HandleTypeDef *huart);

--- a/Core/Src/if_commands.c
+++ b/Core/Src/if_commands.c
@@ -486,6 +486,18 @@ static void process_imu_commands(UartPacket *uartResp, UartPacket cmd)
 {
 	switch (cmd.command)
 	{
+	case OW_IMU_INIT:
+		VERBOSE_CMD("[CMD] OW_IMU_INIT\r\n");
+		uartResp->command = OW_IMU_INIT;
+		uartResp->packet_type = OW_RESP;
+		uartResp->data_len = 0;
+		uartResp->data = NULL;
+		if (ICM_WHOAMI() != ICM20948_EXPECTED_ID || ICM_Init() != HAL_OK)
+		{
+			uartResp->packet_type = OW_ERROR;
+			VERBOSE_CMD("Failed to initialize IMU\r\n");
+		}
+		break;
 	case OW_IMU_GET_TEMP:
 		VERBOSE_CMD("[CMD] OW_IMU_GET_TEMP\r\n");
 		uartResp->command = OW_IMU_GET_TEMP;

--- a/Core/Src/logging.c
+++ b/Core/Src/logging.c
@@ -202,9 +202,27 @@ void logging_UART_TxCpltCallback(UART_HandleTypeDef *huart)
 
 /* Send accumulated log message over command and control endpoint */
 static void send_log_message_over_comms(void) {
+	static volatile bool log_send_in_progress = false;
+
 	if (!log_msg_rb_initialized) {
 		lwrb_init(&log_msg_rb, log_msg_buffer, sizeof(log_msg_buffer));
 		log_msg_rb_initialized = true;
+	}
+
+	/* Never transmit from interrupt context: comms_interface_send busy-waits
+	 * on tx_flag, which only the USB OTG_HS IRQ sets — and that IRQ shares
+	 * preemption priority 0 with several ISRs that printf, so the wait can
+	 * never complete (2026-06-11 IMU streaming wedge). Keep the data
+	 * buffered; the main loop flushes it via logging_pump(). */
+	if (__get_IPSR() != 0U) {
+		return;
+	}
+
+	/* Re-entry guard: comms_interface_send's failure paths printf, which
+	 * lands back here on the newline. Recursing would clobber the shared
+	 * txBuffer mid-build — keep the new data buffered instead. */
+	if (log_send_in_progress) {
+		return;
 	}
 
 	size_t linear_len = lwrb_get_linear_block_read_length(&log_msg_rb);
@@ -238,15 +256,26 @@ static void send_log_message_over_comms(void) {
 	// Note: This may fail silently if USB is not initialized, which is acceptable
 	// comms_interface_send handles packet building, CRC calculation, and transmission
 	// For logging, we use a non-blocking approach - if it times out, we just skip
+	log_send_in_progress = true;
 	_Bool sent = comms_interface_send(&log_packet);
+	log_send_in_progress = false;
 	if (!sent) {
 		// Transmission failed or timed out - keep message in buffer to retry later
 		// Don't remove data from the buffer, so it can be retried on next call
 		return;
 	}
-	
+
 	// Remove only the bytes that were successfully sent
 	lwrb_skip(&log_msg_rb, linear_len);
+}
+
+/* Flush USB log data that was buffered while in interrupt context.
+ * Called from the main loop; no-op when there is nothing pending. */
+void logging_pump(void) {
+	if ((debug_flags & DEBUG_FLAG_USB_PRINTF) == 0u) {
+		return;
+	}
+	send_log_message_over_comms();
 }
 
 /* Add character to log message buffer and send if newline encountered */

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -126,8 +126,9 @@ __attribute__((section(".RAM_D1"))) uint8_t bitstream_buffer[MAX_BITSTREAM_SIZE]
 volatile uint8_t event_bits = 0x00;         // holds the event bits to be flipped
 volatile uint8_t event_bits_enabled = 0x00; // holds the event bits for the cameras to be enabled
 volatile uint16_t pulse_count = 0;
-extern uint32_t imu_frame_counter;
+extern volatile uint32_t imu_frame_counter;
 volatile bool _enter_dfu = false;
+volatile uint8_t imu_sample_due = 0; // set by the TIM14 ISR, serviced by imu_service()
 
 ICM_Axis3D a;
 ICM_Axis3D m;
@@ -178,7 +179,7 @@ static void MX_TIM15_Init(void);
 static void MX_IWDG1_Init(void);
 static void MX_RAMECC_Init(void);
 /* USER CODE BEGIN PFP */
-
+static void imu_service(void);
 /* USER CODE END PFP */
 
 /* Private user code ---------------------------------------------------------*/
@@ -416,7 +417,9 @@ int main(void)
     /* USER CODE END WHILE */
 
     /* USER CODE BEGIN 3 */
-  	comms_host_check_received(); // check comms  
+  	comms_host_check_received(); // check comms
+    imu_service();           /* Sample the ICM if the 200 Hz timer ticked */
+    logging_pump();          /* Flush USB log data buffered from ISR context */
     check_streaming();
     poll_mcu_temperature();  /* Print warning if MCU junction temp above threshold */
     USB_RecoveryCheck();     /* EFT/lock-up watchdog: rebuild USB stack if bus goes dead */
@@ -2059,6 +2062,59 @@ static void wait_for_usb_queues_to_finish(void)
 
 /* HAL_RAMECC_DetectErrorCallback is implemented in system_monitor.c */
 
+/**
+ * @brief Service one pending IMU sample (set by the TIM14 ISR at 200 Hz).
+ * @note  Runs in the main loop so the ~1.4 ms blocking ICM read and any
+ *        error printf happen in thread context, where the USB IRQ can
+ *        preempt. If the loop is busy for more than one tick the missed
+ *        samples are dropped (visible as gaps in the stream's F counter).
+ */
+static void imu_service(void)
+{
+  if (!imu_sample_due) {
+    return;
+  }
+  imu_sample_due = 0;
+
+  /* hi2c1 is shared with the TCA9548A camera mux, which the FSIN EXTI ISR
+   * uses for temperature polling during streaming — mask that IRQ for the
+   * duration of the read so the two transactions can't interleave. The
+   * EXTI pending bit latches, so a frame sync arriving meanwhile is
+   * serviced right after, just delayed by the read. */
+  bool fsin_irq_was_enabled = (NVIC_GetEnableIRQ(EXTI15_10_IRQn) != 0U);
+  if (fsin_irq_was_enabled) {
+    HAL_NVIC_DisableIRQ(EXTI15_10_IRQn);
+  }
+  uint8_t read_status = ICM_GetAllRawData(&a, &t, &g, &m);
+  if (fsin_irq_was_enabled) {
+    HAL_NVIC_EnableIRQ(EXTI15_10_IRQn);
+  }
+
+  if (read_status != HAL_OK) {
+    /* A flaky ICM fails every tick at 200 Hz — keep the signal, drop the
+     * volume (same pattern as the FSIN debounce warning). */
+    static uint32_t imu_read_err_count = 0;
+    imu_read_err_count++;
+    if ((imu_read_err_count & 0xFF) == 1) {
+      printf("IMU Read Error (%lu so far)\r\n", (unsigned long)imu_read_err_count);
+    }
+    return;
+  }
+
+  uint32_t frame = imu_frame_counter;
+  memset(usb_buf, 0, 128);
+  int len = snprintf(
+      usb_buf, sizeof(usb_buf),
+      "{\"F\":%lu,\"G\":[%d,%d,%d],\"M\":[%d,%d,%d],\"A\":[%d,%d,%d],\"T\":%d.%02d}\r\n",
+      (unsigned long)frame,
+      g.x, g.y, g.z,
+      m.x, m.y, m.z,
+      a.x, a.y, a.z,
+      (int)t, (int)((t - (int)t) * 100.0f)
+  );
+  USBD_IMU_SetTxBuffer(&hUsbDeviceHS, (uint8_t *)usb_buf, len);
+}
+
 /* USER CODE END 4 */
 
  /* MPU Configuration */
@@ -2114,23 +2170,14 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
 
   if (htim->Instance == TIM14)
   {
+	  /* No I2C and no printf in here: this ISR runs at preemption priority
+	   * 0, same as the USB OTG_HS IRQ, so anything that waits on USB (the
+	   * USB log path does) can never complete and wedges the CPU in this
+	   * ISR (2026-06-11 IMU streaming wedge). The main loop samples via
+	   * imu_service(). Counting ticks here keeps frame numbers honest:
+	   * gaps in F reveal samples the main loop couldn't service in time. */
 	  imu_frame_counter++;
-	  // call imu
-	  if(ICM_GetAllRawData(&a,&t, &g, &m) != HAL_OK){
-		  printf("IMU Read Error\r\n");
-	  }else{
-		  memset(usb_buf,0,128);
-		  int len = snprintf(
-		      usb_buf, sizeof(usb_buf),
-		      "{\"F\":%ld,\"G\":[%d,%d,%d],\"M\":[%d,%d,%d],\"A\":[%d,%d,%d],\"T\":%d.%02d}\r\n",
-			  imu_frame_counter,
-		      g.x, g.y, g.z,
-		      m.x, m.y, m.z,
-		      a.x, a.y, a.z,
-			  (int)t, (int)((t - (int)t) * 100.0f)
-		  );
-		  USBD_IMU_SetTxBuffer(&hUsbDeviceHS, (uint8_t *)usb_buf, len);
-	  }
+	  imu_sample_due = 1;
   }
 
   if (htim->Instance == TIM15) {

--- a/Core/Src/uart_comms.c
+++ b/Core/Src/uart_comms.c
@@ -96,8 +96,25 @@ void ClearBuffer_DMA(void)
 }
 
 _Bool comms_interface_send(UartPacket *pResp) {
+	static volatile _Bool send_in_progress = false;
+
+	if (__get_IPSR() != 0U) {
+		/* Interrupt context: the USB OTG_HS IRQ shares preemption priority
+		 * 0 with several ISRs, so the tx_flag wait below could never
+		 * complete — refuse instead of busy-waiting into a wedge. */
+		return false;
+	}
+	if (send_in_progress) {
+		/* Re-entered via a printf inside this function (the USB log path
+		 * routes printf back here). No printf in this branch — that is
+		 * exactly the recursion being refused. */
+		return false;
+	}
+	send_in_progress = true;
+
 	if(!tx_flag){
 		printf("Comm tx not complete from last time");
+		send_in_progress = false;
 		return false;
 	}
 
@@ -120,6 +137,7 @@ _Bool comms_interface_send(UartPacket *pResp) {
 	if (pkt_size > sizeof(txBuffer)) {
 		printf("Packet too large to send, len=%lu\r\n", pkt_size);
 		// Handle error: packet too large for txBuffer
+		send_in_progress = false;
 		return false;
 	}
 
@@ -153,6 +171,7 @@ _Bool comms_interface_send(UartPacket *pResp) {
 		}
 		tx_flag = 1; // reset to idle on failure
 		USB_NotifyTxFailure();
+		send_in_progress = false;
 		return false;
 	}
 
@@ -167,12 +186,16 @@ _Bool comms_interface_send(UartPacket *pResp) {
 	while (!tx_flag) {
 		if ((get_timestamp_ms() - start_time) >= TX_TIMEOUT) {
 			// Timeout handling: Log error and break out or reset the flag.
+			// printf before releasing send_in_progress so the message only
+			// buffers instead of re-entering this function.
 			printf("COMM USB TX Timeout\r\n");
 			tx_flag = 1; // reset to idle on timeout
 			USB_NotifyTxFailure();
+			send_in_progress = false;
 			return false;
 		}
 	}
+	send_in_progress = false;
 	return true;
 }
 

--- a/tests/test_imu_wedge_hil.py
+++ b/tests/test_imu_wedge_hil.py
@@ -1,0 +1,116 @@
+"""HIL regression for the 2026-06-11 IMU streaming wedge.
+
+Repro (pre-fix firmware): with DEBUG_FLAG_USB_PRINTF set, OW_IMU_ON starts
+the 200 Hz TIM14 ISR which does blocking I2C and printf()s on any ICM read
+error; the USB log path then busy-waits on a tx_flag only the (equal
+priority) USB IRQ can set, and the CPU never leaves the ISR. The command
+interface is dead until power cycle.
+
+These tests bypass the SDK's IMU guards on purpose (raw _send calls):
+they must exercise the firmware path even after the SDK refuses to.
+
+Run on a bench with a sensor attached (WinUSB via Zadig):
+
+    OPENMOTION_HIL=1 pytest tests/test_imu_wedge_hil.py
+    (PowerShell: $env:OPENMOTION_HIL = "1")
+
+Select the sensor side with OW_SENSOR_SIDE=left|right (default: right).
+A wedged run leaves the sensor needing a power cycle (YKUSH/Shelly).
+"""
+import os
+import time
+
+import pytest
+
+requires_bench = pytest.mark.skipif(
+    os.environ.get("OPENMOTION_HIL") != "1",
+    reason="hardware-in-the-loop test; set OPENMOTION_HIL=1 on the bench",
+)
+
+DEBUG_FLAG_USB_PRINTF = 0x01
+CONNECT_TIMEOUT_S = 15.0
+
+
+@pytest.fixture
+def sensor():
+    """Connect to the bench sensor (OW_SENSOR_SIDE, default right)."""
+    from omotion import MotionInterface
+
+    side = os.environ.get("OW_SENSOR_SIDE", "right")
+    interface = MotionInterface()
+    interface.start(wait=False)
+    handle = interface.left if side == "left" else interface.right
+    deadline = time.monotonic() + CONNECT_TIMEOUT_S
+    while time.monotonic() < deadline and not handle.is_connected():
+        time.sleep(0.2)
+    if not handle.is_connected():
+        interface.stop()
+        pytest.fail(
+            f"{side} sensor not reachable in {CONNECT_TIMEOUT_S:.0f}s — "
+            "not plugged in, no WinUSB driver, or wedged from a previous "
+            "run (power-cycle it)."
+        )
+    yield handle
+    # Best-effort cleanup: IMU off, debug flags cleared. May fail if the
+    # firmware wedged — the assertions have already failed by then.
+    try:
+        _imu_raw(handle, "OW_IMU_OFF")
+        handle.set_debug_flags(0x00)
+    except Exception:
+        pass
+    interface.stop()
+
+
+def _imu_raw(handle, command_name):
+    """Send an OW_IMU command without any SDK-side guard logic."""
+    from omotion import config
+
+    return handle._send(
+        packetType=config.OW_IMU, command=getattr(config, command_name)
+    )
+
+
+@requires_bench
+def test_imu_stream_with_usb_printf_does_not_wedge_comm(sensor):
+    """The exact 2026-06-11 wedge sequence must leave IF0 alive.
+
+    debug flags 0x01 -> OW_IMU_ON -> OW_IMU_GET_TEMP. On pre-fix firmware
+    the GET_TEMP (or merely a flaky ICM) printf-storms from the TIM14 ISR
+    and the command interface never answers again.
+    """
+    assert sensor.ping() is True, "sensor not healthy before test"
+    assert sensor.set_debug_flags(DEBUG_FLAG_USB_PRINTF) is True
+
+    r = _imu_raw(sensor, "OW_IMU_ON")
+    assert r is not None, "no response to OW_IMU_ON"
+
+    # The poll that used to start the wedge. A response of any type is
+    # fine (flaky ICM may NAK); what matters is that one comes back and
+    # the interface survives.
+    try:
+        _imu_raw(sensor, "OW_IMU_GET_TEMP")
+    except Exception as exc:
+        pytest.fail(f"OW_IMU_GET_TEMP got no response (wedge): {exc!r}")
+
+    # Let the 200 Hz sample timer run; on pre-fix firmware with a flaky
+    # ICM this alone printf-storms the ISR.
+    time.sleep(2.0)
+
+    assert sensor.ping() is True, "command interface died during IMU streaming"
+
+    r = _imu_raw(sensor, "OW_IMU_OFF")
+    assert r is not None, "no response to OW_IMU_OFF"
+    assert sensor.ping() is True, "command interface died after IMU off"
+
+
+@requires_bench
+def test_imu_init_command_is_implemented(sensor):
+    """OW_IMU_INIT must be a real command, not fall through to OW_UNKNOWN."""
+    from omotion.config import OW_UNKNOWN
+
+    r = _imu_raw(sensor, "OW_IMU_INIT")
+    assert r is not None, "no response to OW_IMU_INIT"
+    assert r.packetType != OW_UNKNOWN, (
+        "OW_IMU_INIT is unimplemented in firmware (OW_UNKNOWN response)"
+    )
+    assert sensor.ping() is True


### PR DESCRIPTION
## Summary

Fixes the 2026-06-11 IMU streaming wedge: `OW_IMU_ON` + a poll attempt (or merely a flaky ICM) killed the sensor command interface until power cycle.

**Root cause:** the 200 Hz TIM14 ISR (NVIC priority 0) did ~1.4 ms of blocking I2C per tick and `printf()`ed on every ICM read error. With `DEBUG_FLAG_USB_PRINTF` set, printf routes into `comms_interface_send`, which busy-waits on `tx_flag` — set only by the USB OTG_HS IRQ, **also priority 0**, which can never preempt. The 500 ms timeout then printf'd "COMM USB TX Timeout", re-entering the send path. The CPU never left the ISR; main loop, USB stack, and IWDG refresh all starved.

## Changes

- **TIM14 ISR → flag only.** The main loop samples the ICM via `imu_service()`. Frame-counter gaps reveal dropped samples.
- **hi2c1 serialization.** `imu_service` masks the FSIN EXTI (camera temp polling, the only other ISR-context hi2c1 user) around the ICM read; everything else on hi2c1 already runs in the main loop.
- **ISR-safe USB log path.** `send_log_message_over_comms` refuses to transmit from interrupt context (`__get_IPSR()`); buffered data is flushed from the main loop by the new `logging_pump()`. This also covers the FSIN ISR printfs (`send_data`), which had the same latent wedge.
- **Recursion guards in `comms_interface_send`** — its failure-path printfs used to re-enter and clobber the shared `txBuffer`.
- **Implement `OW_IMU_INIT`** (WHOAMI + `ICM_Init`) instead of falling through to `OW_UNKNOWN`.
- Rate-limited the "IMU Read Error" print (1-in-256, same pattern as the FSIN debounce warning).

## Verification (right bench sensor, WinUSB)

- New HIL regression `tests/test_imu_wedge_hil.py` (`OPENMOTION_HIL=1`) replays the raw field sequence: debug flags 0x01 → `OW_IMU_ON` → `OW_IMU_GET_TEMP` → ping. **RED on unfixed firmware** (wedged exactly as in the field, "IMU Read Error"/"COMM USB TX Timeout" storm) → **GREEN on this branch** (2 passed in 3.1 s).
- SDK HIL `pytest tests/test_sensor.py -m imu`: `test_imu_streaming_does_not_wedge_comm` and `test_imu_temperature` pass. The accel/gyro/stream-delivers tests fail **on this bench unit only** — its ICM NACKs the accel/gyro register block (temperature reads fine), reproduced identically on unfixed firmware after a fresh power cycle. Hardware fault, pre-existing; the wedge fix makes it surface as clean `OW_ERROR` responses instead of killing the sensor.
- Host-side unit tests: 10 passed, 2 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
