### PR TITLE
fix(i2c): keep all hi2c1 traffic out of the frame ISRs

### DIFF
--- a/Core/Inc/camera_manager.h
+++ b/Core/Inc/camera_manager.h
@@ -112,7 +112,7 @@ void print_active_cameras(void);
 void CAM_UART_RxCpltCallback(USART_HandleTypeDef *husart);
 void CAM_SPI_RxCpltCallback(SPI_HandleTypeDef *hspi);
 
-void poll_camera_temperatures(void);
+void camera_i2c_service(void);  /* Main-loop service for hi2c1 work deferred from the frame ISRs (temp poll, failed-camera mux disables) */
 void scan_camera_sensor(uint8_t cam_id);  /* Scan single camera slot; sets isPresent */
 void scan_camera_sensors(void);
 uint8_t get_cameras_present(void);  // Get bitmask of present cameras (computed from cam_array[].isPresent)

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -26,6 +26,16 @@ volatile float cam_temp[CAMERA_COUNT] = {0};   // °C ×100
 static uint32_t next_temp_ms = 0;
 static uint8_t  next_cam_idx = 0;
 
+/* hi2c1 is shared by the camera mux/sensors, the ICM IMU and the CrossLink
+ * config port, and the HAL I2C driver is not re-entrant: if the FSIN/TIM4
+ * frame ISRs started a transaction while a main-loop command handler had one
+ * in flight, the handle state machine gets corrupted (NACKs, stuck bus).
+ * The frame ISRs therefore never touch hi2c1 — they only set these flags,
+ * and camera_i2c_service() does the bus work from the main loop, where it
+ * is naturally serialized with every other hi2c1 user. */
+static volatile bool    cam_temp_poll_due = false;     /* set by send_data() */
+static volatile uint8_t cam_mux_disable_pending = 0;   /* set by check_camera_failures() */
+
 #define FPGA_I2C_ADDRESS 0x40  // Replace with your FPGA's I2C address
 #define HISTO_JSON_BUFFER_SIZE 34000
 #define HISTO_SIZE_32B 1024
@@ -1042,7 +1052,7 @@ _Bool configure_camera_testpattern(uint8_t cam_id, uint8_t test_pattern)
 	return true;
 }
 
-void poll_camera_temperatures(void)
+static void poll_camera_temperatures(void)
 {
     uint32_t now = get_timestamp_ms();
 
@@ -1084,6 +1094,38 @@ void poll_camera_temperatures(void)
         {
             TCA9548A_SelectChannel(&hi2c1, 0x70, active_cam->i2c_target);
         }
+    }
+}
+
+void camera_i2c_service(void)
+{
+    /* Disconnect the mux channels of failed cameras before the temperature
+     * poll, so a sensor holding SDA low can't wedge the reads below. */
+    if (cam_mux_disable_pending != 0u) {
+        __disable_irq();
+        uint8_t pending = cam_mux_disable_pending;
+        cam_mux_disable_pending = 0u;
+        __enable_irq();
+
+        for (uint8_t cam_id = 0; cam_id < CAMERA_COUNT; cam_id++) {
+            if ((pending & (1u << cam_id)) == 0u) {
+                continue;
+            }
+            CameraDevice *pFailed = get_camera_byID(cam_id);
+            if (pFailed != NULL) {
+                HAL_StatusTypeDef mux_ret =
+                    TCA9548A_DisableChannel(&hi2c1, 0x70, pFailed->i2c_target);
+                if (mux_ret != HAL_OK) {
+                    printf("Camera %d: failed to disable TCA mux channel %u (ret=%d)\r\n",
+                           cam_id + 1, (unsigned)pFailed->i2c_target, (int)mux_ret);
+                }
+            }
+        }
+    }
+
+    if (cam_temp_poll_due) {
+        cam_temp_poll_due = false;
+        poll_camera_temperatures();
     }
 }
 /* -------- END CAMERA I2C FUNCTIONS -------- */
@@ -1260,18 +1302,12 @@ static void check_camera_failures(void) {
 						event_bits_enabled &= ~(uint8_t)(1u << cam_id);
 						__enable_irq();
 
-						/* 2. Deselect the camera's I2C mux channel.
-						 *    Uses the bounded TCA9548A_I2C_TIMEOUT_MS timeout (50 ms)
-						 *    so this is a one-time bounded stall, not a hang. */
-						CameraDevice *pFailed = get_camera_byID(cam_id);
-						if (pFailed != NULL) {
-							HAL_StatusTypeDef mux_ret =
-								TCA9548A_DisableChannel(&hi2c1, 0x70, pFailed->i2c_target);
-							if (mux_ret != HAL_OK) {
-								printf("Camera %d: failed to disable TCA mux channel %u (ret=%d)\r\n",
-								       cam_id + 1, (unsigned)pFailed->i2c_target, (int)mux_ret);
-							}
-						}
+						/* 2. Queue the camera's I2C mux channel for deselect.
+						 *    This runs in the FSIN/TIM4 frame ISR, which must not
+						 *    touch hi2c1 (a main-loop transaction may be mid-flight);
+						 *    camera_i2c_service() does the mux write from the main
+						 *    loop with the bounded TCA9548A timeout. */
+						cam_mux_disable_pending |= (uint8_t)(1u << cam_id);
 					}
 				}
 			}
@@ -1322,7 +1358,9 @@ _Bool send_data(void) {
 	} else {
 		success = send_histogram_data();
 	}
-	poll_camera_temperatures();
+	/* Temperature polling does hi2c1 traffic, so it can't run here in the
+	 * frame ISR — flag it for camera_i2c_service() in the main loop. */
+	cam_temp_poll_due = true;
 
     if (success) {
 		total_frames_sent++;

--- a/Core/Src/i2c_master.c
+++ b/Core/Src/i2c_master.c
@@ -29,10 +29,9 @@ static void TCA9548A_ResetHardware(void)
 }
 
 /* Maximum time to wait for one I2C mux write.  HAL_MAX_DELAY must NEVER be
- * used here because TCA9548A_WriteControl is called from interrupt context
- * (via poll_camera_temperatures → send_data → FSIN IRQ).  A stuck I2C bus
- * (e.g. a failed camera sensor holding SDA low after its channel is selected)
- * would otherwise block the CPU forever, making COMM unresponsive. */
+ * used here: a stuck I2C bus (e.g. a failed camera sensor holding SDA low
+ * after its channel is selected) would otherwise block the main loop
+ * forever, starving the IWDG refresh and leaving COMM unresponsive. */
 #define TCA9548A_I2C_TIMEOUT_MS  50U
 
 /* Bounded timeout for all general slave read/write operations.  Using

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -419,6 +419,7 @@ int main(void)
     /* USER CODE BEGIN 3 */
   	comms_host_check_received(); // check comms
     imu_service();           /* Sample the ICM if the 200 Hz timer ticked */
+    camera_i2c_service();    /* Camera-bus work deferred from the frame ISRs (temp poll, mux disables) */
     logging_pump();          /* Flush USB log data buffered from ISR context */
     check_streaming();
     poll_mcu_temperature();  /* Print warning if MCU junction temp above threshold */
@@ -2076,19 +2077,11 @@ static void imu_service(void)
   }
   imu_sample_due = 0;
 
-  /* hi2c1 is shared with the TCA9548A camera mux, which the FSIN EXTI ISR
-   * uses for temperature polling during streaming — mask that IRQ for the
-   * duration of the read so the two transactions can't interleave. The
-   * EXTI pending bit latches, so a frame sync arriving meanwhile is
-   * serviced right after, just delayed by the read. */
-  bool fsin_irq_was_enabled = (NVIC_GetEnableIRQ(EXTI15_10_IRQn) != 0U);
-  if (fsin_irq_was_enabled) {
-    HAL_NVIC_DisableIRQ(EXTI15_10_IRQn);
-  }
+  /* hi2c1 is shared with the TCA9548A camera mux and the camera sensors,
+   * but every user runs here in the main loop — the frame ISRs only set
+   * flags (see camera_i2c_service()) — so this blocking read can't
+   * interleave with another transaction and needs no IRQ masking. */
   uint8_t read_status = ICM_GetAllRawData(&a, &t, &g, &m);
-  if (fsin_irq_was_enabled) {
-    HAL_NVIC_EnableIRQ(EXTI15_10_IRQn);
-  }
 
   if (read_status != HAL_OK) {
     /* A flaky ICM fails every tick at 200 Hz — keep the signal, drop the

--- a/tests/test_i2c_serialization_hil.py
+++ b/tests/test_i2c_serialization_hil.py
@@ -1,0 +1,270 @@
+"""HIL regression for hi2c1 serialization between the frame ISRs and the
+main-loop command handlers.
+
+Pre-fix firmware ran camera temperature polling (TCA9548A channel select +
+OV02C1B temp read) inside the FSIN/TIM4 frame ISR at 40 Hz during
+streaming, and the failed-camera mux disable also lived in that ISR. A
+frame sync landing while a main-loop command handler (OW_CAMERA_*,
+OW_IMU_*) had its own hi2c1 transaction in flight re-entered the
+non-reentrant HAL I2C driver on the same handle — corrupted transfers,
+NACKs, stuck bus. Fixed by deferring all ISR-side bus work to
+camera_i2c_service() in the main loop, which serializes every hi2c1 user
+by construction.
+
+This test brings up camera 1, starts continuous internal-FSIN streaming
+(40 Hz frames keep the main-loop temperature poller hammering hi2c1) and
+concurrently spams I2C-heavy commands on IF0. Every command must succeed
+and histogram frames must keep flowing the whole time.
+
+Run on a bench with a sensor attached (WinUSB via Zadig):
+
+    OPENMOTION_HIL=1 pytest tests/test_i2c_serialization_hil.py
+    (PowerShell: $env:OPENMOTION_HIL = "1")
+
+Select the sensor side with OW_SENSOR_SIDE=left|right (default: right).
+
+The sensor must be freshly power-cycled: a previous streaming session
+(this test, or any scan) can leave the firmware's HISTO bulk endpoint
+wedged (histo_ep_data stuck — pre-existing bug, needs a separate fix),
+which starves this test's stream check. Set OPENMOTION_POWER_CYCLE_CMD
+to a shell command (e.g. the bench Shelly script) and the fixture cycles
+the sensor automatically:
+
+    OPENMOTION_POWER_CYCLE_CMD="python ...\\tests\\shelly.py cycle"
+"""
+import logging
+import os
+import queue
+import re
+import subprocess
+import threading
+import time
+
+import pytest
+
+requires_bench = pytest.mark.skipif(
+    os.environ.get("OPENMOTION_HIL") != "1",
+    reason="hardware-in-the-loop test; set OPENMOTION_HIL=1 on the bench",
+)
+
+CONNECT_TIMEOUT_S = 15.0
+STRESS_SECONDS = 20.0
+
+# Two cameras, not one: with a single powered camera the temperature
+# poller's mux select usually short-circuits on the I2C_current_target
+# cache and never touches the bus, which hides the race. With two, the
+# poller alternates channels and does a real mux write on every poll.
+CAM_MASK = 0x03
+
+# One aggregated frame: 10-byte header (SOF, type, size, timestamp) +
+# per camera (SOH + cam_id + 4096 histogram + 4 temp + EOH) + CRC16 +
+# EOF — see send_histogram_data() in Core/Src/camera_manager.c.
+FRAME_BYTES = 10 + 2 * (1 + 1 + 4096 + 4 + 1) + 3
+# 40 Hz * 20 s = 800 frames nominal; demand a quarter of that so USB
+# hiccups don't flake the test while a dead stream still fails it.
+MIN_STREAM_BYTES = 200 * FRAME_BYTES
+
+# Firmware log lines that betray an I2C collision even when command-level
+# retries hide it from the SDK: HAL re-entry (ret=2 HAL_BUSY) on the mux
+# write, the ISR's TCA reset / bus recovery escalation, and the resulting
+# failed sensor reads. The SDK relays firmware printf as "[... PRINTF]"
+# log warnings when debug flag 0x01 is set.
+I2C_CORRUPTION = re.compile(
+    r"TCA9548A control write failed|bus recovery|Not in ready state|"
+    r"failed to select|Failed to read|X02C1B_TEMP",
+    re.I,
+)
+
+
+class _PrintfTap(logging.Handler):
+    """Collect firmware printf lines the SDK relays as log warnings."""
+
+    def __init__(self):
+        super().__init__()
+        self.lines = []
+        self.armed = False
+
+    def emit(self, record):
+        msg = record.getMessage()
+        if self.armed and "PRINTF" in msg:
+            self.lines.append(msg)
+
+
+@pytest.fixture
+def sensor():
+    """Connect to the bench sensor (OW_SENSOR_SIDE, default right)."""
+    from omotion import MotionInterface
+
+    cycle_cmd = os.environ.get("OPENMOTION_POWER_CYCLE_CMD")
+    if cycle_cmd:
+        # Fresh boot clears a HISTO endpoint wedged by a prior session
+        # (see module docstring).
+        subprocess.run(cycle_cmd, shell=True, check=True, timeout=60)
+        time.sleep(8.0)  # re-enumeration settle
+
+    side = os.environ.get("OW_SENSOR_SIDE", "right")
+    interface = MotionInterface()
+    interface.start(wait=False)
+    handle = interface.left if side == "left" else interface.right
+    deadline = time.monotonic() + CONNECT_TIMEOUT_S
+    while time.monotonic() < deadline and not handle.is_connected():
+        time.sleep(0.2)
+    if not handle.is_connected():
+        interface.stop()
+        pytest.fail(
+            f"{side} sensor not reachable in {CONNECT_TIMEOUT_S:.0f}s — "
+            "not plugged in, no WinUSB driver, or wedged from a previous "
+            "run (power-cycle it)."
+        )
+    yield handle
+    # Best-effort cleanup; failures here mean the assertions already fired.
+    try:
+        handle.disable_aggregator_fsin()
+        handle.disable_camera(CAM_MASK)
+        handle.uart.histo.stop_streaming()
+        # Recover transfers still sitting in the host endpoint buffer —
+        # without this the leftover bytes corrupt the NEXT run's stream
+        # (same reason LiveUsbSource.close() drains after stop).
+        from omotion.MotionProcessing import HISTOGRAM_BYTES
+
+        handle.uart.histo.drain_final(HISTOGRAM_BYTES)
+        handle.disable_camera_power(CAM_MASK)
+        handle.set_debug_flags(0x00)
+    except Exception:
+        pass
+    interface.stop()
+
+
+def _drain(q, stop_evt, counter):
+    """Pull raw stream chunks off the packet queue, tallying bytes."""
+    while not stop_evt.is_set():
+        try:
+            chunk = q.get(timeout=0.2)
+        except queue.Empty:
+            continue
+        if chunk:
+            counter["bytes"] += len(chunk)
+
+
+@requires_bench
+def test_i2c_commands_during_streaming_do_not_collide(sensor):
+    """Hammer hi2c1 command handlers while 40 Hz streaming is active.
+
+    On pre-fix firmware the frame ISR's temperature poll interleaves with
+    the handlers' transactions and some of these calls fail (NACK /
+    corrupted response / stuck bus). Post-fix, every call succeeds and the
+    stream keeps flowing.
+    """
+    from omotion import config
+    from omotion.MotionProcessing import HISTOGRAM_BYTES
+
+    assert sensor.ping() is True, "sensor not healthy before test"
+
+    # USB printf on — the mode the historical I2C/USB death cascades ran
+    # in. The log pump keeps the main loop (and IF0) busier, which raises
+    # the collision rate on pre-fix firmware, and it lets the host see the
+    # firmware's own I2C error messages.
+    assert sensor.set_debug_flags(0x01) is True
+    tap = _PrintfTap()
+    logging.getLogger().addHandler(tap)
+
+    # --- bring-up: power -> FPGA -> configure (matches ScanWorkflow) ---
+    assert sensor.enable_camera_power(CAM_MASK) is True
+    time.sleep(0.5)
+    assert sensor.program_fpga(camera_position=CAM_MASK, manual_process=False) is True
+    time.sleep(0.1)
+    assert sensor.camera_configure_registers(CAM_MASK) is True
+
+    # --- start continuous streaming: arm IF1, enable cameras, internal FSIN ---
+    pkt_queue = queue.Queue(maxsize=64)
+    stop_evt = threading.Event()
+    counter = {"bytes": 0}
+    drainer = threading.Thread(
+        target=_drain, args=(pkt_queue, stop_evt, counter), daemon=True
+    )
+    drainer.start()
+    # Discard leftovers from any prior session before arming the stream
+    # (same hygiene as the production ScanWorkflow startup).
+    sensor.uart.histo.flush_stale_data(HISTOGRAM_BYTES)
+    sensor.uart.histo.start_streaming(pkt_queue, expected_size=HISTOGRAM_BYTES)
+    assert sensor.enable_camera(CAM_MASK) is True
+    assert sensor.enable_aggregator_fsin() is True
+
+    failures = []
+    iterations = 0
+    try:
+        # Let the stream settle so the temp poller is provably running.
+        time.sleep(1.0)
+        tap.armed = True
+
+        deadline = time.monotonic() + STRESS_SECONDS
+        while time.monotonic() < deadline:
+            iterations += 1
+
+            # Mux channel select churn (OW_CAMERA_SWITCH).
+            for cam_id in (1, 0):
+                try:
+                    r = sensor.switch_camera(cam_id)
+                    if r is None or r.packetType == config.OW_ERROR:
+                        failures.append(
+                            f"iter {iterations}: switch_camera({cam_id}) failed"
+                        )
+                except Exception as exc:
+                    failures.append(
+                        f"iter {iterations}: switch_camera({cam_id}) raised {exc!r}"
+                    )
+
+            # Camera status (OW_CAMERA_STATUS, mux select + FPGA query).
+            try:
+                if sensor.get_camera_status(CAM_MASK) is None:
+                    failures.append(f"iter {iterations}: get_camera_status -> None")
+            except Exception as exc:
+                failures.append(f"iter {iterations}: get_camera_status raised {exc!r}")
+
+            # Full register-table rewrite (OW_CAMERA_SET_CONFIG) — the
+            # longest-running hi2c1 user among the command handlers, so it
+            # maximizes the window for a frame ISR to land mid-transaction.
+            try:
+                if sensor.camera_configure_registers(CAM_MASK) is not True:
+                    failures.append(
+                        f"iter {iterations}: camera_configure_registers failed"
+                    )
+            except Exception as exc:
+                failures.append(
+                    f"iter {iterations}: camera_configure_registers raised {exc!r}"
+                )
+
+            # ICM read on the same bus (OW_IMU_GET_TEMP) — the PR #48 path,
+            # now without EXTI masking.
+            try:
+                sensor.imu_get_temperature()
+            except ValueError as exc:
+                failures.append(f"iter {iterations}: imu_get_temperature: {exc}")
+            except Exception as exc:
+                failures.append(
+                    f"iter {iterations}: imu_get_temperature raised {exc!r}"
+                )
+    finally:
+        tap.armed = False
+        logging.getLogger().removeHandler(tap)
+        sensor.disable_aggregator_fsin()
+        sensor.disable_camera(CAM_MASK)
+        time.sleep(0.2)
+        stop_evt.set()
+        drainer.join(timeout=2.0)
+
+    corruption = [line for line in tap.lines if I2C_CORRUPTION.search(line)]
+    assert not corruption, (
+        f"firmware reported {len(corruption)} I2C corruption events during "
+        f"streaming + command stress:\n" + "\n".join(corruption[:20])
+    )
+    assert iterations >= 10, f"stress loop only ran {iterations} iterations"
+    assert not failures, (
+        f"{len(failures)}/{iterations} iterations had I2C command failures "
+        f"during streaming:\n" + "\n".join(failures[:20])
+    )
+    assert counter["bytes"] >= MIN_STREAM_BYTES, (
+        f"histogram stream starved during stress: got {counter['bytes']} B, "
+        f"expected >= {MIN_STREAM_BYTES} B (~200 frames)"
+    )
+    assert sensor.ping() is True, "command interface unhealthy after stress"


### PR DESCRIPTION
## Problem

The FSIN EXTI / TIM4 frame ISRs did `hi2c1` traffic at 40 Hz during streaming — `TCA9548A_SelectChannel` + `X02C1B_read_temp` in `poll_camera_temperatures()`, plus the failed-camera mux disable in `check_camera_failures()`. Main-loop command handlers (`OW_CAMERA_SET_CONFIG`, `OW_CAMERA_STATUS`, mux selects, IMU reads) use the same handle, and the HAL I2C driver is not re-entrant: a frame sync landing mid-transaction re-enters the driver, gets `HAL_BUSY`, and the mux-write retry path then escalates to a TCA hardware reset and a full `I2C_BusRecovery` (`HAL_I2C_DeInit`!) **from inside the ISR, while the main-loop transfer is still in flight**. Captured live on the bench: `TCA9548A control write failed ... ret: 2` (HAL_BUSY re-entry), `I2C bus recovery complete`, `===> ERROR: I2C Not in ready state`, failed camera temp reads, ending in the familiar USB death cascade.

#48 fixed this for the IMU only by masking EXTI15_10 around the ICM read. This PR extends serialization to every `hi2c1` user.

## Fix

Same flag pattern as `imu_service()`, applied to the camera bus:

- `send_data()` (ISR) no longer polls temperatures — it sets `cam_temp_poll_due`.
- `check_camera_failures()` (ISR) no longer writes the mux — it queues the channel in `cam_mux_disable_pending`.
- New `camera_i2c_service()` (main loop) services both. **No ISR touches `hi2c1` anymore**, so every bus user runs in thread context and is serialized by construction — no per-handler guards needed.
- The EXTI15_10 masking in `imu_service()` is now unnecessary and removed, which also removes the up-to-1.4 ms frame-sync delay it imposed during IMU streaming.

Stacked on #48 (`claude/focused-austin-2ad89c`); retarget to `next` once that merges.

## Verification (bench, right sensor)

New HIL regression `tests/test_i2c_serialization_hil.py`: streams 40 Hz histograms from **two** cameras (so the temp poller does a real mux write every poll — with one camera the `I2C_current_target` cache hides the race) while hammering `camera_configure_registers` / `switch_camera` / `get_camera_status` / `imu_get_temperature`, with USB printf tapped so firmware I2C errors fail the test.

- **Pre-fix firmware (#48 head): FAIL** — HISTO endpoint starved, COMM write timeouts (USB death cascade).
- **This branch: PASS**, repeatedly.
- Full SDK HIL suite (`openmotion-sdk pytest tests/test_sensor.py`): **64 passed** on both sensors.

While validating, found a pre-existing, unrelated bug: the HISTO bulk endpoint wedges permanently (`histo_ep_data` stuck) if the host abandons the stream mid-transfer; only a power cycle clears it. Tracked separately — the new test power-cycles the DUT via `OPENMOTION_POWER_CYCLE_CMD` to stay independent of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)