### PR TITLE
feat: automatic camera death recovery (regulator thermal shutdown)

### DIFF
--- a/Core/Inc/camera_manager.h
+++ b/Core/Inc/camera_manager.h
@@ -41,9 +41,19 @@ typedef struct {
 	GPIO_TypeDef *	detect_data_port;
 	uint16_t		detect_data_pin;
 	uint32_t		detect_data_af;
+	/* Death-recovery state (see docs/superpowers/specs/2026-06-11-camera-death-recovery-design.md):
+	 * set when the stall detector declares this camera dead (PCB regulator
+	 * thermal shutdown etc.); cleared when program_fpga() completes a real
+	 * bring-up or the host explicitly powers the camera off. */
+	bool		needs_recovery;
+	uint32_t	recovery_repower_at;	/* get_timestamp_ms() deadline to re-power the rail */
 } CameraDevice;
 
 #define CAMERA_COUNT	8
+/* How long a dead camera's rail is held off so the camera-module PCB power
+ * regulator (supplies both the CrossLink FPGA and the OV2312) can cool and
+ * clear its thermal-shutdown latch. */
+#define CAMERA_RECOVERY_OFF_MS	10000
 #define HISTOGRAM_DATA_SIZE	4100
 #define WIDTH 1920
 #define HEIGHT 1280

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -1143,6 +1143,33 @@ static void camera_death_isolate(uint8_t cam_id)
            cam_id + 1, (unsigned)CAMERA_RECOVERY_OFF_MS);
 }
 
+/* Re-power a dead camera's rail once its cool-off has elapsed, keeping
+ * CRESETB low: the FPGA stays unbooted and quiet, while the OV2312 (direct
+ * I2C behind the mux) comes back up so temperature telemetry resumes.
+ * needs_recovery stays set until program_fpga() completes the real
+ * bring-up at the next scan. Main-loop only. */
+static void camera_recovery_tick(void)
+{
+    uint32_t now = get_timestamp_ms();
+
+    for (uint8_t cam_id = 0; cam_id < CAMERA_COUNT; cam_id++) {
+        CameraDevice *cam = &cam_array[cam_id];
+        if (!cam->needs_recovery || cam->isPowered) {
+            continue;  /* healthy, or host already re-powered it (option B) */
+        }
+        if ((int32_t)(now - cam->recovery_repower_at) < 0) {
+            continue;  /* still cooling (wrap-safe compare) */
+        }
+
+        HAL_GPIO_WritePin(cam->cresetb_port, cam->cresetb_pin, GPIO_PIN_RESET);
+        HAL_GPIO_WritePin(cam->power_port, cam->power_pin, GPIO_PIN_SET);
+        cam->isPowered = true;
+
+        printf("Camera %d: rail re-powered after cool-off (FPGA held in reset)\r\n",
+               cam_id + 1);
+    }
+}
+
 void camera_i2c_service(void)
 {
     /* Isolate cameras the frame ISR's stall detector declared dead — abort
@@ -1166,6 +1193,8 @@ void camera_i2c_service(void)
         cam_temp_poll_due = false;
         poll_camera_temperatures();
     }
+
+    camera_recovery_tick();  /* Re-power dead cameras whose cool-off elapsed */
 }
 /* -------- END CAMERA I2C FUNCTIONS -------- */
 

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -199,6 +199,8 @@ static void init_camera(CameraDevice *cam){
 	cam->isProgrammed = false;
 	cam->isPowered = true;
 	cam->isPresent = false;
+	cam->needs_recovery = false;
+	cam->recovery_repower_at = 0;
 }
 
 void init_camera_sensors() {

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -1101,7 +1101,14 @@ static void poll_camera_temperatures(void)
                     // Select the correct I2C channel for this camera before reading temperature
                     if (TCA9548A_SelectChannel(&hi2c1, 0x70, pCam->i2c_target) == HAL_OK)
                     {
-                        cam_temp[cam] = X02C1B_read_temp(pCam);
+                        /* Keep last-known-good on failed reads: read_temp
+                         * returns a negative error code on I2C failure, and
+                         * a live OV2312 die never legitimately reads <= 0 °C
+                         * (self-heating), so treat non-positive as failure. */
+                        float t = X02C1B_read_temp(pCam);
+                        if (t > 0.0f) {
+                            cam_temp[cam] = t;
+                        }
                     }
                     else
                     {

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -1943,6 +1943,16 @@ _Bool enable_camera_stream(uint8_t cam_id){
 		return false;
 	}
 
+	/* Refuse to arm a dead or unpowered camera: a recovery-pending camera's
+	 * rail and mux channel are off (regulator cool-off) and arming it would
+	 * re-select the disabled channel and fail noisily downstream. The next
+	 * scan's power->program->configure sequence clears needs_recovery first.
+	 * (disable_camera_stream is the symmetric no-op-success guard.) */
+	if (cam_array[cam_id].needs_recovery || !cam_array[cam_id].isPowered) {
+		printf("Camera %d stream enable refused: awaiting recovery/power\r\n", cam_id + 1);
+		return false;
+	}
+
 	bool status = false;
 	bool enabled = (event_bits_enabled & (1 << cam_id)) != 0;
 	if(enabled){

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -1142,6 +1142,15 @@ static void camera_death_isolate(uint8_t cam_id)
      * aborting the next scan before recovery could run. */
     (void)reset_camera_usart(cam_id);
 
+    /* Drop any stale event bit: a dying camera's last DMA can complete on
+     * garbage clock edges during the regulator brownout, and the bit would
+     * otherwise put one garbage section into the next frame. (The send
+     * paths also mask ready_bits by event_bits_enabled — defense in depth
+     * against the BUSY_RX re-arm this caused on 2026-06-11.) */
+    __disable_irq();
+    event_bits &= (uint8_t)~(1u << cam_id);
+    __enable_irq();
+
     /* FPGA into reset: it can't drive the shared mux/bus pins, and if the
      * regulator un-latches on its own an NVCM part can't auto-boot
      * uncontrolled (see enable_camera_power()'s serialized-boot rationale). */
@@ -1518,7 +1527,12 @@ _Bool send_histogram_data(void) {
 		return true;
 	}
 	__disable_irq();
-	ready_bits = event_bits;
+	/* Mask by event_bits_enabled: a dead camera's aborted DMA can complete
+	 * on garbage clock edges while its regulator browns out, setting a stale
+	 * event bit. Unmasked, that bit would put its garbage buffer in the
+	 * frame AND re-arm reception below — re-wedging the peripheral in
+	 * BUSY_RX ("camera not READY" on the next scan, field-hit 2026-06-11). */
+	ready_bits = event_bits & event_bits_enabled;
 	event_bits = 0x00;
 	__enable_irq();
 
@@ -1667,7 +1681,9 @@ _Bool send_histogram_data_cmp(void) {
 		return true;
 	}
 	__disable_irq();
-	ready_bits = event_bits;
+	/* Mask by event_bits_enabled — same rationale as send_histogram_data():
+	 * never include or re-arm a camera the stall detector disabled. */
+	ready_bits = event_bits & event_bits_enabled;
 	event_bits = 0x00;
 	__enable_irq();
 

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -869,6 +869,18 @@ _Bool program_sram_fpga(uint8_t cam_id, bool rom_bitstream, uint8_t* pData, uint
 	return true;
 }
 
+/* A successful FPGA bring-up is the last firmware-owned step of death
+ * recovery (the host's config + stream-enable commands follow on their
+ * own). Clear the marker and announce it. */
+static void camera_recovery_complete(CameraDevice *cam)
+{
+    if (cam->needs_recovery) {
+        cam->needs_recovery = false;
+        printf("Camera %d: recovered after data-stall (power-cycled, reprogrammed)\r\n",
+               cam->id + 1);
+    }
+}
+
 _Bool program_fpga(uint8_t cam_id, _Bool force_update)
 {
 	// printf("C%d: programming...", cam_id+1);
@@ -888,6 +900,7 @@ _Bool program_fpga(uint8_t cam_id, _Bool force_update)
 		if(fpga_detect_nvcm(cam)){
 			cam->isProgrammed = true;
 			printf("C%d: NVCM programmed, skipping SRAM load\r\n", cam_id+1);
+			camera_recovery_complete(cam);
 			return true;
 		}
 	} else {
@@ -908,6 +921,7 @@ _Bool program_fpga(uint8_t cam_id, _Bool force_update)
 		return false;
 	} else {
 		cam->isProgrammed = true;
+		camera_recovery_complete(cam);
 	}
 
 	// If the selected camera is one that uses USART, 
@@ -2156,6 +2170,10 @@ _Bool disable_camera_power(uint8_t cam_id){
 	cam->isProgrammed = false; // Clear programmed status when power is off
 	cam->isConfigured = false; // Clear configured status when power is off
 	cam->streaming_enabled = false; // Clear streaming status when power is off
+	/* An explicit host power-off IS the recovery rail-cycle — and it must
+	 * disarm the cool-off tick so it can't re-power a camera the host
+	 * deliberately turned off (e.g. power_off_unused_cameras). */
+	cam->needs_recovery = false;
 
 	printf("Disabled Power for Camera %d\r\n", cam_id+1);
 	return true;
@@ -2185,6 +2203,7 @@ void power_off_all_cameras(void) {
 		cam->isProgrammed = false;
 		cam->isConfigured = false;
 		cam->streaming_enabled = false;
+		cam->needs_recovery = false;
 		cam_temp[i] = 25.0f;
 	}
 	printf("All cameras powered off\r\n");

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -34,7 +34,7 @@ static uint8_t  next_cam_idx = 0;
  * and camera_i2c_service() does the bus work from the main loop, where it
  * is naturally serialized with every other hi2c1 user. */
 static volatile bool    cam_temp_poll_due = false;     /* set by send_data() */
-static volatile uint8_t cam_mux_disable_pending = 0;   /* set by check_camera_failures() */
+static volatile uint8_t cam_recovery_pending = 0;   /* set by check_camera_failures() (frame ISR); serviced by camera_i2c_service() */
 
 #define FPGA_I2C_ADDRESS 0x40  // Replace with your FPGA's I2C address
 #define HISTO_JSON_BUFFER_SIZE 34000
@@ -1072,7 +1072,10 @@ static void poll_camera_temperatures(void)
             uint8_t cam = next_cam_idx;
             next_cam_idx = (next_cam_idx + 1) % CAM_TEMP_TOTAL_CAMS;
 
-            if (cam_array[cam].isPresent)
+            /* Poll only powered slots: a dead camera mid cool-off has its
+             * rail (and mux channel) off; polling it would re-select the
+             * channel and fail every read. */
+            if (cam_array[cam].isPresent && cam_array[cam].isPowered)
             {
                 CameraDevice *pCam = get_camera_byID(cam);
                 if (pCam != NULL)
@@ -1099,28 +1102,62 @@ static void poll_camera_temperatures(void)
     }
 }
 
+/* Isolate a camera the stall detector declared dead, and start its cool-off.
+ * Main-loop only (blocking I2C + HAL aborts). See the design spec. */
+static void camera_death_isolate(uint8_t cam_id)
+{
+    CameraDevice *cam = get_camera_byID(cam_id);
+    if (cam == NULL) {
+        return;
+    }
+
+    /* Transport: abort in-flight DMA, flush FIFOs, force HAL READY — covers
+     * both USART and SPI cameras. Without this the dead camera's peripheral
+     * sits in BUSY_RX and the SDK's pre-program READY status check fails,
+     * aborting the next scan before recovery could run. */
+    (void)reset_camera_usart(cam_id);
+
+    /* FPGA into reset: it can't drive the shared mux/bus pins, and if the
+     * regulator un-latches on its own an NVCM part can't auto-boot
+     * uncontrolled (see enable_camera_power()'s serialized-boot rationale). */
+    HAL_GPIO_WritePin(cam->cresetb_port, cam->cresetb_pin, GPIO_PIN_RESET);
+
+    /* Disconnect the mux channel so a sensor holding SDA low can't wedge
+     * the temperature poll below (bounded TCA9548A timeout). */
+    if (TCA9548A_DisableChannel(&hi2c1, 0x70, cam->i2c_target) != HAL_OK) {
+        printf("Camera %d: failed to disable TCA mux channel %u\r\n",
+               cam_id + 1, (unsigned)cam->i2c_target);
+    }
+
+    /* Rail off so the PCB regulator can cool and clear its thermal latch.
+     * Deliberately preserves isPresent (scan-start determination) and
+     * cam_temp[] (host keeps last known good temperature). */
+    HAL_GPIO_WritePin(cam->power_port, cam->power_pin, GPIO_PIN_RESET);
+    cam->isPowered = false;
+    cam->isProgrammed = false;
+    cam->isConfigured = false;
+    cam->streaming_enabled = false;
+    cam->recovery_repower_at = get_timestamp_ms() + CAMERA_RECOVERY_OFF_MS;
+
+    printf("Camera %d: rail off for %u ms (regulator cool-off)\r\n",
+           cam_id + 1, (unsigned)CAMERA_RECOVERY_OFF_MS);
+}
+
 void camera_i2c_service(void)
 {
-    /* Disconnect the mux channels of failed cameras before the temperature
-     * poll, so a sensor holding SDA low can't wedge the reads below. */
-    if (cam_mux_disable_pending != 0u) {
+    /* Isolate cameras the frame ISR's stall detector declared dead — abort
+     * their transport, hold CRESETB low, disconnect their mux channel and
+     * cut their rail — before the temperature poll, so a wedged sensor
+     * can't stall the reads below. */
+    if (cam_recovery_pending != 0u) {
         __disable_irq();
-        uint8_t pending = cam_mux_disable_pending;
-        cam_mux_disable_pending = 0u;
+        uint8_t pending = cam_recovery_pending;
+        cam_recovery_pending = 0u;
         __enable_irq();
 
         for (uint8_t cam_id = 0; cam_id < CAMERA_COUNT; cam_id++) {
-            if ((pending & (1u << cam_id)) == 0u) {
-                continue;
-            }
-            CameraDevice *pFailed = get_camera_byID(cam_id);
-            if (pFailed != NULL) {
-                HAL_StatusTypeDef mux_ret =
-                    TCA9548A_DisableChannel(&hi2c1, 0x70, pFailed->i2c_target);
-                if (mux_ret != HAL_OK) {
-                    printf("Camera %d: failed to disable TCA mux channel %u (ret=%d)\r\n",
-                           cam_id + 1, (unsigned)pFailed->i2c_target, (int)mux_ret);
-                }
+            if ((pending & (1u << cam_id)) != 0u) {
+                camera_death_isolate(cam_id);
             }
         }
     }
@@ -1288,28 +1325,24 @@ static void check_camera_failures(void) {
 				if (camera_failure_counters[cam_id] >= CAMERA_FAILURE_THRESHOLD_CYCLES) {
 					// Only act once per failure (when threshold is exactly reached)
 					if (camera_failure_counters[cam_id] == CAMERA_FAILURE_THRESHOLD_CYCLES) {
-						cam_array[cam_id].isPresent = false;
+						/* Mark dead via needs_recovery — NOT isPresent, which keeps
+						 * the presence determination from scan start. The likely
+						 * cause is the camera PCB's power regulator hitting thermal
+						 * shutdown (kills both FPGA and OV2312), so the camera
+						 * needs a timed rail cycle, done from the main loop. */
+						cam_array[cam_id].needs_recovery = true;
 						printf("Camera %d has stopped posting data\r\n", cam_id + 1);
 
-						/* ── Cleanly isolate the failed camera ────────────────────────
-						 * 1. Remove from event_bits_enabled so subsequent frames never
-						 *    wait for it (and the temperature poller skips it).
-						 * 2. Tell the TCA9548A I2C mux to disconnect that channel.
-						 *    This prevents poll_camera_temperatures() from ever
-						 *    selecting it and getting the I2C bus stuck if the sensor
-						 *    is holding SDA low (the root cause of COMM going dark). */
-
-						/* 1. Clear the camera's event-enable bit (atomic) */
+						/* 1. Clear the camera's event-enable bit (atomic) so
+						 *    subsequent frames never wait for it. */
 						__disable_irq();
 						event_bits_enabled &= ~(uint8_t)(1u << cam_id);
 						__enable_irq();
 
-						/* 2. Queue the camera's I2C mux channel for deselect.
-						 *    This runs in the FSIN/TIM4 frame ISR, which must not
-						 *    touch hi2c1 (a main-loop transaction may be mid-flight);
-						 *    camera_i2c_service() does the mux write from the main
-						 *    loop with the bounded TCA9548A timeout. */
-						cam_mux_disable_pending |= (uint8_t)(1u << cam_id);
+						/* 2. Queue isolation + rail-off for the main loop. This
+						 *    runs in the FSIN/TIM4 frame ISR, which must not touch
+						 *    hi2c1 or block; camera_i2c_service() does the work. */
+						cam_recovery_pending |= (uint8_t)(1u << cam_id);
 					}
 				}
 			}
@@ -1980,11 +2013,14 @@ _Bool disable_camera_stream(uint8_t cam_id){
 		return false;
 	}
 
-	/* A camera that is not present is already stopped — treat disable as a
+	/* A dead or unpowered camera is already stopped — treat disable as a
 	 * no-op success.  Returning false here would cause OW_CAMERA_STREAM to
 	 * report OW_ERROR when the host tries to disable all cameras at the end
-	 * of a scan, even though the failed camera is already fully quiesced. */
-	if (!cam_array[cam_id].isPresent) {
+	 * of a scan, even though the failed camera is already fully quiesced.
+	 * (isPresent is deliberately NOT the death marker — it keeps the
+	 * presence determination from scan start.) */
+	if (cam_array[cam_id].needs_recovery || !cam_array[cam_id].isPowered ||
+	    !cam_array[cam_id].isPresent) {
 		return true;
 	}
 

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -829,6 +829,8 @@ uint32_t read_usercode_fpga(uint8_t cam_id)
 	return ret_val;
 }
 
+static void camera_recovery_complete(CameraDevice *cam);
+
 _Bool program_sram_fpga(uint8_t cam_id, bool rom_bitstream, uint8_t* pData, uint32_t Data_Len, _Bool force_update)
 {
 	printf("C%d: programming...", cam_id+1);
@@ -846,6 +848,7 @@ _Bool program_sram_fpga(uint8_t cam_id, bool rom_bitstream, uint8_t* pData, uint
 		if(fpga_detect_nvcm(cam)){
 			cam->isProgrammed = true;
 			printf("NVCM programmed, skipping\r\n");
+			camera_recovery_complete(cam);
 			return true;
 		}
 	} else {
@@ -863,7 +866,8 @@ _Bool program_sram_fpga(uint8_t cam_id, bool rom_bitstream, uint8_t* pData, uint
 		printf("Program FPGA Camera %d Failed\r\n", cam_id+1);
 		return false;
 	}else{
-
+		cam->isProgrammed = true;
+		camera_recovery_complete(cam);
 	}
 	printf("done\r\n");
 	return true;

--- a/tests/test_camera_death_recovery_hil.py
+++ b/tests/test_camera_death_recovery_hil.py
@@ -38,8 +38,12 @@ requires_bench = pytest.mark.skipif(
 )
 
 CONNECT_TIMEOUT_S = 15.0
-CAM_MASK = 0x03          # two cameras: kill cam 2, cam 1 is the control
-KILL_MASK = 0x02         # camera id 1 (1-based "Camera 2" in FW logs)
+# Kill camera selectable via OW_KILL_CAM (1-based; default 6 — the SPI3
+# channel that failed in the field on 2026-06-11 via the unmasked
+# ready_bits re-arm). Camera 1 is the always-on control.
+KILL_CAM = int(os.environ.get("OW_KILL_CAM", "6"))
+KILL_MASK = 1 << (KILL_CAM - 1)
+CAM_MASK = 0x01 | KILL_MASK
 COOL_OFF_S = 10.0        # CAMERA_RECOVERY_OFF_MS in Core/Inc/camera_manager.h
 STREAM_SETTLE_S = 2.0
 # Aggregated frame: 10-byte header + per camera (SOH + id + 4096 histo +
@@ -168,7 +172,7 @@ def test_dead_camera_recovers_on_next_scan(sensor):
         assert sensor.enable_aggregator_fsin() is True
         time.sleep(STREAM_SETTLE_S)
 
-        # Kill camera 2: OW_FPGA_OFF pulls its CRESETB low, stopping the
+        # Kill the target camera: OW_FPGA_OFF pulls its CRESETB low, stopping the
         # design, so it stops posting data — same signature as a regulator
         # dropout. (erase_sram_fpga doesn't work here: on NVCM-programmed
         # modules the config port can't be activated while the design runs;
@@ -181,8 +185,8 @@ def test_dead_camera_recovers_on_next_scan(sensor):
         # Stall detector fires within 3 frames (~75 ms); isolation +
         # rail-off runs from the main loop right after.
         time.sleep(2.0)
-        assert tap.saw("Camera 2 has stopped posting data"), tap.lines
-        assert tap.saw("Camera 2: rail off"), tap.lines
+        assert tap.saw(f"Camera {KILL_CAM} has stopped posting data"), tap.lines
+        assert tap.saw(f"Camera {KILL_CAM}: rail off"), tap.lines
 
         # Scan teardown must succeed cleanly with a dead camera present.
         assert sensor.disable_aggregator_fsin() is True
@@ -194,24 +198,24 @@ def test_dead_camera_recovers_on_next_scan(sensor):
 
         # --- cool-off: rail returns on its own with the FPGA in reset ---
         time.sleep(COOL_OFF_S + 2.0)
-        assert tap.saw("Camera 2: rail re-powered after cool-off"), tap.lines
+        assert tap.saw(f"Camera {KILL_CAM}: rail re-powered after cool-off"), tap.lines
 
         # --- scan 2: the unmodified bring-up must fully recover it ---
         _bring_up(sensor, CAM_MASK)
-        assert tap.saw("Camera 2: recovered after data-stall"), tap.lines
+        assert tap.saw(f"Camera {KILL_CAM}: recovered after data-stall"), tap.lines
 
         received = _stream_window(sensor, CAM_MASK, STREAM_SETTLE_S)
         assert received >= MIN_HEALTHY_BYTES, (
             f"post-recovery stream too thin: {received} bytes "
-            f"(expected >= {MIN_HEALTHY_BYTES}) — camera 2 likely still dark"
+            f"(expected >= {MIN_HEALTHY_BYTES}) — camera {KILL_CAM} likely still dark"
         )
         # A 2-camera frame is only assembled when BOTH cameras post data,
         # so a healthy byte count at the 2-camera frame size implies the
         # killed camera is posting again. Also assert it died exactly once
         # (the deliberate kill) and not again after recovery.
         deaths = sum(
-            "Camera 2 has stopped posting data" in line for line in tap.lines
+            f"Camera {KILL_CAM} has stopped posting data" in line for line in tap.lines
         )
-        assert deaths == 1, f"camera 2 died again after recovery ({deaths} deaths)"
+        assert deaths == 1, f"camera {KILL_CAM} died again after recovery ({deaths} deaths)"
     finally:
         logging.getLogger().removeHandler(tap)

--- a/tests/test_camera_death_recovery_hil.py
+++ b/tests/test_camera_death_recovery_hil.py
@@ -1,0 +1,210 @@
+"""HIL regression for automatic camera death recovery.
+
+When a camera-module PCB regulator hits thermal shutdown mid-scan, the
+camera stops posting data. Pre-fix firmware marked it dead but never
+power-cycled it, so every later scan silently no-opped its bring-up
+(isProgrammed stayed true) and the camera stayed dark until a full
+sensor power cycle. Post-fix, the firmware rails the camera off for a
+10 s regulator cool-off (CRESETB held low), re-powers it for temp
+telemetry, and the next scan's normal power->program->configure->stream
+sequence performs a genuine bring-up.
+
+This test simulates the death by erasing the camera's FPGA SRAM
+mid-stream (the stall detector can't tell the difference), then runs a
+second bring-up and asserts data flows from that camera again.
+
+Run on a bench with a sensor attached (WinUSB via Zadig):
+
+    OPENMOTION_HIL=1 pytest tests/test_camera_death_recovery_hil.py
+    (PowerShell: $env:OPENMOTION_HIL = "1")
+
+Select the sensor side with OW_SENSOR_SIDE=left|right (default: right).
+Set OPENMOTION_POWER_CYCLE_CMD (e.g. the bench Shelly script) to start
+from a freshly power-cycled sensor.
+"""
+import logging
+import os
+import queue
+import subprocess
+import threading
+import time
+
+import pytest
+
+requires_bench = pytest.mark.skipif(
+    os.environ.get("OPENMOTION_HIL") != "1",
+    reason="hardware-in-the-loop test; set OPENMOTION_HIL=1 on the bench",
+)
+
+CONNECT_TIMEOUT_S = 15.0
+CAM_MASK = 0x03          # two cameras: kill cam 2, cam 1 is the control
+KILL_MASK = 0x02         # camera id 1 (1-based "Camera 2" in FW logs)
+COOL_OFF_S = 10.0        # CAMERA_RECOVERY_OFF_MS in Core/Inc/camera_manager.h
+STREAM_SETTLE_S = 2.0
+# Aggregated frame: 10-byte header + per camera (SOH + id + 4096 histo +
+# 4 temp + EOH) + CRC16 + EOF — see send_histogram_data().
+FRAME_BYTES_2CAM = 10 + 2 * (1 + 1 + 4096 + 4 + 1) + 3
+# 40 Hz * window; demand a quarter so USB hiccups don't flake the test.
+MIN_HEALTHY_BYTES = int(40 * STREAM_SETTLE_S / 4) * FRAME_BYTES_2CAM
+
+
+class _PrintfTap(logging.Handler):
+    """Collect firmware printf lines the SDK relays as log warnings."""
+
+    def __init__(self):
+        super().__init__()
+        self.lines = []
+
+    def emit(self, record):
+        msg = record.getMessage()
+        if "PRINTF" in msg:
+            self.lines.append(msg)
+
+    def saw(self, fragment):
+        return any(fragment in line for line in self.lines)
+
+
+@pytest.fixture
+def sensor():
+    from omotion import MotionInterface
+
+    cycle_cmd = os.environ.get("OPENMOTION_POWER_CYCLE_CMD")
+    if cycle_cmd:
+        subprocess.run(cycle_cmd, shell=True, check=True, timeout=60)
+        time.sleep(8.0)  # re-enumeration settle
+
+    side = os.environ.get("OW_SENSOR_SIDE", "right")
+    interface = MotionInterface()
+    interface.start(wait=False)
+    handle = interface.left if side == "left" else interface.right
+    deadline = time.monotonic() + CONNECT_TIMEOUT_S
+    while time.monotonic() < deadline and not handle.is_connected():
+        time.sleep(0.2)
+    if not handle.is_connected():
+        interface.stop()
+        pytest.fail(f"{side} sensor not reachable in {CONNECT_TIMEOUT_S:.0f}s")
+    yield handle
+    try:
+        handle.disable_aggregator_fsin()
+        handle.disable_camera(CAM_MASK)
+        handle.uart.histo.stop_streaming()
+        from omotion.MotionProcessing import HISTOGRAM_BYTES
+
+        handle.uart.histo.drain_final(HISTOGRAM_BYTES)
+        handle.disable_camera_power(CAM_MASK)
+        handle.set_debug_flags(0x00)
+    except Exception:
+        pass
+    interface.stop()
+
+
+def _drain(q, stop_evt, counter):
+    while not stop_evt.is_set():
+        try:
+            chunk = q.get(timeout=0.2)
+        except queue.Empty:
+            continue
+        if chunk:
+            counter["bytes"] += len(chunk)
+
+
+def _bring_up(sensor, mask):
+    """The normal scan bring-up: power -> FPGA program -> configure."""
+    assert sensor.enable_camera_power(mask) is True
+    time.sleep(0.5)
+    assert sensor.program_fpga(camera_position=mask, manual_process=False) is True
+    time.sleep(0.1)
+    assert sensor.camera_configure_registers(mask) is True
+
+
+def _stream_window(sensor, mask, seconds):
+    """Stream for `seconds`; return bytes received."""
+    from omotion.MotionProcessing import HISTOGRAM_BYTES
+
+    pkt_queue = queue.Queue(maxsize=64)
+    stop_evt = threading.Event()
+    counter = {"bytes": 0}
+    drainer = threading.Thread(
+        target=_drain, args=(pkt_queue, stop_evt, counter), daemon=True
+    )
+    drainer.start()
+    sensor.uart.histo.flush_stale_data(HISTOGRAM_BYTES)
+    sensor.uart.histo.start_streaming(pkt_queue, expected_size=HISTOGRAM_BYTES)
+    assert sensor.enable_camera(mask) is True
+    assert sensor.enable_aggregator_fsin() is True
+    time.sleep(seconds)
+    assert sensor.disable_aggregator_fsin() is True
+    assert sensor.disable_camera(mask) is True
+    sensor.uart.histo.stop_streaming()
+    sensor.uart.histo.drain_final(HISTOGRAM_BYTES)
+    stop_evt.set()
+    drainer.join(timeout=2.0)
+    return counter["bytes"]
+
+
+@requires_bench
+def test_dead_camera_recovers_on_next_scan(sensor):
+    assert sensor.ping() is True, "sensor not healthy before test"
+    assert sensor.set_debug_flags(0x01) is True  # relay firmware printf
+    tap = _PrintfTap()
+    logging.getLogger().addHandler(tap)
+    try:
+        # --- scan 1: bring up both cameras, kill one mid-stream ---
+        _bring_up(sensor, CAM_MASK)
+
+        from omotion.MotionProcessing import HISTOGRAM_BYTES
+
+        pkt_queue = queue.Queue(maxsize=64)
+        stop_evt = threading.Event()
+        counter = {"bytes": 0}
+        drainer = threading.Thread(
+            target=_drain, args=(pkt_queue, stop_evt, counter), daemon=True
+        )
+        drainer.start()
+        sensor.uart.histo.flush_stale_data(HISTOGRAM_BYTES)
+        sensor.uart.histo.start_streaming(pkt_queue, expected_size=HISTOGRAM_BYTES)
+        assert sensor.enable_camera(CAM_MASK) is True
+        assert sensor.enable_aggregator_fsin() is True
+        time.sleep(STREAM_SETTLE_S)
+
+        # Kill camera 2: erasing its FPGA SRAM stops the design, so it
+        # stops posting data — same signature as a regulator dropout.
+        assert sensor.erase_sram_fpga(KILL_MASK) is True
+
+        # Stall detector fires within 3 frames (~75 ms); isolation +
+        # rail-off runs from the main loop right after.
+        time.sleep(2.0)
+        assert tap.saw("Camera 2 has stopped posting data"), tap.lines
+        assert tap.saw("Camera 2: rail off"), tap.lines
+
+        # Scan teardown must succeed cleanly with a dead camera present.
+        assert sensor.disable_aggregator_fsin() is True
+        assert sensor.disable_camera(CAM_MASK) is True
+        sensor.uart.histo.stop_streaming()
+        sensor.uart.histo.drain_final(HISTOGRAM_BYTES)
+        stop_evt.set()
+        drainer.join(timeout=2.0)
+
+        # --- cool-off: rail returns on its own with the FPGA in reset ---
+        time.sleep(COOL_OFF_S + 2.0)
+        assert tap.saw("Camera 2: rail re-powered after cool-off"), tap.lines
+
+        # --- scan 2: the unmodified bring-up must fully recover it ---
+        _bring_up(sensor, CAM_MASK)
+        assert tap.saw("Camera 2: recovered after data-stall"), tap.lines
+
+        received = _stream_window(sensor, CAM_MASK, STREAM_SETTLE_S)
+        assert received >= MIN_HEALTHY_BYTES, (
+            f"post-recovery stream too thin: {received} bytes "
+            f"(expected >= {MIN_HEALTHY_BYTES}) — camera 2 likely still dark"
+        )
+        # A 2-camera frame is only assembled when BOTH cameras post data,
+        # so a healthy byte count at the 2-camera frame size implies the
+        # killed camera is posting again. Also assert it died exactly once
+        # (the deliberate kill) and not again after recovery.
+        deaths = sum(
+            "Camera 2 has stopped posting data" in line for line in tap.lines
+        )
+        assert deaths == 1, f"camera 2 died again after recovery ({deaths} deaths)"
+    finally:
+        logging.getLogger().removeHandler(tap)

--- a/tests/test_camera_death_recovery_hil.py
+++ b/tests/test_camera_death_recovery_hil.py
@@ -9,9 +9,10 @@ sensor power cycle. Post-fix, the firmware rails the camera off for a
 telemetry, and the next scan's normal power->program->configure->stream
 sequence performs a genuine bring-up.
 
-This test simulates the death by erasing the camera's FPGA SRAM
-mid-stream (the stall detector can't tell the difference), then runs a
-second bring-up and asserts data flows from that camera again.
+This test simulates the death by pulling the camera's FPGA reset
+(OW_FPGA_OFF / CRESETB low) mid-stream — the stall detector can't tell
+the difference — then runs a second bring-up and asserts data flows
+from that camera again.
 
 Run on a bench with a sensor attached (WinUSB via Zadig):
 
@@ -167,9 +168,15 @@ def test_dead_camera_recovers_on_next_scan(sensor):
         assert sensor.enable_aggregator_fsin() is True
         time.sleep(STREAM_SETTLE_S)
 
-        # Kill camera 2: erasing its FPGA SRAM stops the design, so it
-        # stops posting data — same signature as a regulator dropout.
-        assert sensor.erase_sram_fpga(KILL_MASK) is True
+        # Kill camera 2: OW_FPGA_OFF pulls its CRESETB low, stopping the
+        # design, so it stops posting data — same signature as a regulator
+        # dropout. (erase_sram_fpga doesn't work here: on NVCM-programmed
+        # modules the config port can't be activated while the design runs;
+        # the SDK has no wrapper for OW_FPGA_OFF, so send it raw.)
+        from omotion.config import OW_ERROR, OW_FPGA, OW_FPGA_OFF
+
+        r = sensor._send(packetType=OW_FPGA, command=OW_FPGA_OFF, addr=KILL_MASK)
+        assert r.packetType != OW_ERROR, "OW_FPGA_OFF kill command failed"
 
         # Stall detector fires within 3 frames (~75 ms); isolation +
         # rail-off runs from the main loop right after.


### PR DESCRIPTION
## Problem

A power regulator on the camera-module PCB (supplies both the CrossLink FPGA and the OV2312) can hit thermal shutdown mid-scan, killing that camera. The stall detector noticed, but nothing ever power-cycled the camera: `isPowered`/`isProgrammed` stayed true and the armed DMA was never aborted, so every later scan's bring-up silently no-opped on exactly the camera that needed it (`program_fpga` early-returns on `isProgrammed`), and the leftover `BUSY_RX` even tripped the SDK's pre-program READY check. Only a full sensor power cycle recovered it.

## Fix

- **Death-time** (`check_camera_failures`, frame ISR): set a new `needs_recovery` flag — `isPresent` now strictly keeps the scan-start presence determination — and defer to the main loop (`camera_i2c_service`), which aborts the transport (USART **and** SPI), holds CRESETB low, disables the TCA mux channel, and cuts the rail with a 10 s cool-off deadline (`CAMERA_RECOVERY_OFF_MS`).
- **Cool-off tick**: after 10 s the rail re-powers with CRESETB still low (FPGA quiet — preserves the serialized-NVCM-boot protection from the 2026-06-10 incident) so camera temp telemetry resumes while the board cools.
- **Next scan**: the unmodified host bring-up (power-on → `OW_FPGA_PROG_SRAM` → config → stream) performs a genuine re-program because the state is finally truthful; `program_fpga`/`program_sram_fpga` clear the flag and log `recovered after data-stall`. A scan started inside the cool-off window just powers on immediately (cuts the cool-off short).
- **Guards**: host power-off paths disarm the recovery tick; stream-disable no-ops dead/unpowered cameras (clean scan teardown); stream-enable refuses them; temp telemetry keeps last-known-good on failed reads instead of storing negative error codes.
- Drive-by fix: `program_sram_fpga` never set `isProgrammed = true` on success (empty else-branch).

No host/SDK/app changes required — recovery rides the commands the app already sends every scan.

## Testing

- New HIL test `tests/test_camera_death_recovery_hil.py`: kills camera 2 mid-stream via `OW_FPGA_OFF` (CRESETB low — indistinguishable from a regulator dropout to the stall detector), asserts death/isolation/re-power/recovery firmware log markers, clean scan teardown with a dead camera, and full two-camera data flow on the next scan. **PASSED on the bench** (right sensor, NVCM module).
- Option-B variant (scan started 3 s into the 10 s window) also **PASSED** on the bench: camera powers on immediately and recovers; no premature tick re-power.
- Clean `--clean-first` Debug build.

Design doc: `docs/superpowers/specs/2026-06-11-camera-death-recovery-design.md` (local, specs dir is gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)