### PR TITLE
fix: -Os/Release correctness bugs (cross-TU volatile mismatch + init/bounds)

### DIFF
--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -52,9 +52,9 @@ __ALIGN_BEGIN uint8_t uncmp_payload[HISTO_JSON_BUFFER_SIZE] __ALIGN_END;  // Sta
 static uint8_t _active_buffer = 0; // Index of the buffer currently being written to
 volatile uint8_t frame_id = 0;
 extern volatile uint8_t event_bits_enabled; // holds the event bits for the cameras to be enabled
-extern uint8_t event_bits;
+extern volatile uint8_t event_bits;
 extern USBD_HandleTypeDef hUsbDeviceHS;
-extern uint32_t pulse_count;
+extern volatile uint16_t pulse_count;
 
 
 // Variables for keeping track of statisticss

--- a/Core/Src/if_commands.c
+++ b/Core/Src/if_commands.c
@@ -32,7 +32,7 @@ extern volatile uint8_t event_bits_enabled;
 	} \
 } while(0)
 
-static uint32_t id_words[3] = {0};
+static uint32_t id_words[4] = {0};  /* 3 UID words + 1 zero-pad: HWID reply is 16B, so [3] would over-read 4B past the array */
 static uint8_t camera_status[8] = {0};
 static uint8_t camera_power_status = 0;
 static float cam_temp;
@@ -41,7 +41,7 @@ static ICM_Axis3D accel;
 static ICM_Axis3D gyro;
 volatile uint32_t imu_frame_counter = 0;
 
-extern bool _enter_dfu;
+extern volatile bool _enter_dfu;
 extern USBD_HandleTypeDef hUsbDeviceHS;
 
 static void process_basic_command(UartPacket *uartResp, UartPacket cmd)

--- a/Core/Src/if_factory_prog.c
+++ b/Core/Src/if_factory_prog.c
@@ -144,6 +144,7 @@ _Bool process_factory_command(UartPacket *response, UartPacket *cmd)
                         response->data = NULL;
                     }else{                        
                         uint16_t read_len = cmd->data[0] << 8 | cmd->data[1];
+                        if (read_len > sizeof(i2c_read_buf)) read_len = sizeof(i2c_read_buf);  /* bound host-supplied length to the 256B buffer */
                         
                         memset(i2c_read_buf, 0, sizeof(i2c_read_buf));
                         iRet = xi2c_read_bytes(_active_cam->pI2c, _active_cam->device_address, i2c_read_buf, read_len);

--- a/Core/Src/uart_comms.c
+++ b/Core/Src/uart_comms.c
@@ -217,7 +217,7 @@ void comms_host_start(void) {
 // This is the FreeRTOS task
 void comms_host_check_received(void) {
 	UartPacket cmd;
-	UartPacket resp;
+	UartPacket resp = {0};   /* zero-init: error/NAK paths don't set every field (e.g. resp.command); avoids -Os uninitialized read */
 	uint16_t calculated_crc;
 	uint16_t rx_len;
 


### PR DESCRIPTION
Static divergence hunt for why the firmware works at `-O0` (Debug) but breaks at `-Os` (Release).

**Root cause (Release-only):** `event_bits` (the ISR-set camera frame-ready bitmask) is defined `volatile` in `main.c` but was declared `extern uint8_t event_bits;` (non-`volatile`) in `camera_manager.c`. At `-Os` that TU may cache the flag in a register and miss ISR updates → dropped/timed-out histograms. Restored `volatile`.

**Sibling declaration mismatches fixed:**
- `pulse_count` was `extern uint32_t` vs `volatile uint16_t` definition → a 32-bit store into a 16-bit object (2-byte OOB write). Now `extern volatile uint16_t`.
- `_enter_dfu` `extern bool` → `extern volatile bool` (write-only here, UB; fixed for parity).

**Other genuine bugs (build-independent):**
- `uart_comms.c`: `UartPacket resp = {0}` (uninitialised `resp.command` on NAK/ERROR replies).
- `if_commands.c`: HWID reply over-read — `id_words[3]` → `[4]` (was sending 16B from a 12B array).
- `if_factory_prog.c`: bounded `OW_FACTORY_I2C_RD` `read_len` to the 256B buffer.

Compiles + links at `-Os`. Hardware confirmation in progress (probe now on a real sensor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)