### PR TITLE
chore: safe MISRA C:2012 fixes for project-owned code

### DIFF
--- a/Core/Inc/0X02C1B.h
+++ b/Core/Inc/0X02C1B.h
@@ -40,11 +40,11 @@ int X02C1B_stream_off(CameraDevice *cam);
 int X02C1B_configure_sensor(CameraDevice *cam);
 int X02C1B_set_test_pattern(CameraDevice *cam, uint8_t test_pattern);
 int X02C1B_detect(CameraDevice *cam);
-int X02C1B_fsin_on();
-int X02C1B_fsin_off();
+int X02C1B_fsin_on(void);
+int X02C1B_fsin_off(void);
 float X02C1B_read_temp(CameraDevice *cam);
-int X02C1B_FSIN_EXT_enable();
-int X02C1B_FSIN_EXT_disable();
+int X02C1B_FSIN_EXT_enable(void);
+int X02C1B_FSIN_EXT_disable(void);
 int X02C1B_FSIN_EXT_status(bool *is_enabled);
 int X02C1B_read_security_uid(CameraDevice *cam, uint8_t uid_bytes[6], uint64_t *uid_value);
 #endif /* INC_0X02C1B_H_ */

--- a/Core/Inc/X02C1B_Sensor_Config.h
+++ b/Core/Inc/X02C1B_Sensor_Config.h
@@ -10,69 +10,69 @@
 
 #include "0X02C1B.h"
 
-struct regval_list X02C1B_test_gradient_bar[] = {
+static struct regval_list X02C1B_test_gradient_bar[] = {
 		{0x5000, 0x3f},
 		{0x5100, 0x80},
 		{0x5102, 0x20},
 		{0x5103, 0x04},
 };
 
-struct regval_list X02C1B_test_gradient_rgb_bar[] = {
+static struct regval_list X02C1B_test_gradient_rgb_bar[] = {
 		{0x5100, 0x80},
 		{0x5103, 0x00},
 };
 
-struct regval_list X02C1B_test_solid_a[] = {
+static struct regval_list X02C1B_test_solid_a[] = {
 		{0x5000, 0x3f},
 		{0x5100, 0x80},
 		{0x5102, 0x00},
 		{0x5103, 0x01},
 };
-struct regval_list X02C1B_test_solid_b[] = {
+static struct regval_list X02C1B_test_solid_b[] = {
 		{0x5000, 0x3f},
 		{0x5100, 0x80},
 		{0x5102, 0x00},
 		{0x5103, 0x01},
 };
-struct regval_list X02C1B_test_solid_c[] = {
+static struct regval_list X02C1B_test_solid_c[] = {
 		{0x5000, 0x3f},
 		{0x5100, 0x80},
 		{0x5102, 0x00},
 		{0x5103, 0x01},
 };
-struct regval_list X02C1B_test_random_seed[] = {
+static struct regval_list X02C1B_test_random_seed[] = {
 		{0x5000, 0x3f},
 		{0x5100, 0x81},
 };
-struct regval_list X02C1B_test_square[] = {
+static struct regval_list X02C1B_test_square[] = {
 		{0x5000, 0x3f},
 		{0x5100, 0x82},
 		{0x5103, 0x04},
 };
-struct regval_list X02C1B_test_disable[] = {
+static struct regval_list X02C1B_test_disable[] = {
 		{0x5000, 0x3e},
 		{0x5100, 0x00},
 };
-struct regval_list X02C1B_test_gradient_cont[] = {
+static struct regval_list X02C1B_test_gradient_cont[] = {
 		{0x5000, 0x3f},
 		{0x5100, 0x80},
 		{0x5102, 0x30},
 		{0x5103, 0x04},
 };
-struct regval_list X02C1B_test_gradient_bar_rolling[] = {
+static struct regval_list X02C1B_test_gradient_bar_rolling[] = {
 		{0x5000, 0x3f},
 		{0x5100, 0xC0},
 		{0x5102, 0x20},
 		{0x5103, 0x04},
 };
-struct regval_list X02C1B_exp_252[] = {
+static struct regval_list X02C1B_exp_252[] = {
 		{0x5000, 0x3f},
 		{0x5100, 0xC0},
 		{0x5102, 0x20},
 		{0x5103, 0x04},
 };
 
-struct regval_list X02C1B_SENSOR_CONFIG[] = {
+static struct regval_list X02C1B_SENSOR_CONFIG[] = {
 		{0x0105, 0x04},
 		{0x0104, 0x00},
 		{0x3d85, 0x0B},

--- a/Core/Inc/logging.h
+++ b/Core/Inc/logging.h
@@ -13,8 +13,8 @@
 #include <stdbool.h>
 #include <stdint.h>
 
- void init_dma_logging();
- bool is_using_dma();
+ void init_dma_logging(void);
+ bool is_using_dma(void);
  void logging_pump(void);
  void logging_set_debug_flags(uint32_t flags);
  uint32_t logging_get_debug_flags(void);

--- a/Core/Src/0X02C1B.c
+++ b/Core/Src/0X02C1B.c
@@ -9,7 +9,7 @@
 #include "utils.h"
 #include <stdio.h>
 
-volatile _Bool ext_fsin_enabled = false;
+static volatile _Bool ext_fsin_enabled = false;
 #define I2C_TIMEOUT 1000 // Set an appropriate timeout for I2C transactions
 
 static int X02C1B_write(I2C_HandleTypeDef * pI2c, uint16_t reg, uint8_t val)
@@ -271,13 +271,13 @@ float X02C1B_read_temp(CameraDevice *cam)
     return temperature;
 }
 
-int X02C1B_set_gain(CameraDevice *cam)
+static int X02C1B_set_gain(CameraDevice *cam)
 {
 
 	return 0;
 }
 
-int X02C1B_get_gain(CameraDevice *cam)
+static int X02C1B_get_gain(CameraDevice *cam)
 {
 
 	return 0;
@@ -286,7 +286,7 @@ int X02C1B_get_gain(CameraDevice *cam)
 
 int X02C1B_FSIN_EXT_enable()
 {
-	if(ext_fsin_enabled) return HAL_OK;
+	if(ext_fsin_enabled) { return HAL_OK; }
     printf("Enabling FSIN_EXT\r\n");
 
     /*Configure GPIO pin Output Level */
@@ -310,7 +310,7 @@ int X02C1B_FSIN_EXT_enable()
 
 int X02C1B_FSIN_EXT_status(bool *is_enabled)
 {
-    if (is_enabled == NULL) return -1;
+    if (is_enabled == NULL) { return -1; }
     *is_enabled = ext_fsin_enabled;
     return HAL_OK;
 }
@@ -318,7 +318,7 @@ int X02C1B_FSIN_EXT_status(bool *is_enabled)
 int X02C1B_FSIN_EXT_disable()
 {
     printf("Disabling FSIN_EXT\r\n");
-	if(!ext_fsin_enabled) return HAL_OK;
+	if(!ext_fsin_enabled) { return HAL_OK; }
     /*Configure GPIO pin : FSIN_EN_Pin */
     GPIO_InitTypeDef GPIO_InitStruct = {0};
     GPIO_InitStruct.Pin = FSIN_Pin;

--- a/Core/Src/ICM20948.c
+++ b/Core/Src/ICM20948.c
@@ -12,7 +12,7 @@
 #include <string.h>
 #include <stdio.h>
 
-volatile uint8_t current_bank = 0;
+static volatile uint8_t current_bank = 0;
 
 static inline HAL_StatusTypeDef ICM_readBytes(uint8_t reg, uint8_t *pData, uint16_t size)
 {
@@ -22,14 +22,23 @@ static inline HAL_StatusTypeDef ICM_readBytes(uint8_t reg, uint8_t *pData, uint1
     for (int attempt = 0; attempt < retries; attempt++)
     {
         result = HAL_I2C_Master_Transmit(&ICM_I2C, ICM20948_ADDR << 1, &reg, 1, 100);
-        if (result != HAL_BUSY) break;
+        if (result != HAL_BUSY)
+        {
+            break;
+        }
     }
-    if (result != HAL_OK) return result;
+    if (result != HAL_OK)
+    {
+        return result;
+    }
 
     for (int attempt = 0; attempt < retries; attempt++)
     {
         result = HAL_I2C_Master_Receive(&ICM_I2C, ICM20948_ADDR << 1, pData, size, 100);
-        if (result != HAL_BUSY) break;
+        if (result != HAL_BUSY)
+        {
+            break;
+        }
     }
     return result;
 }
@@ -40,7 +49,10 @@ static HAL_StatusTypeDef ICM_WriteBytes(uint8_t reg, uint8_t *pData, uint16_t si
     int retries = 3;
     uint8_t buffer[16];
 
-    if (size > sizeof(buffer) - 1) return HAL_ERROR; // prevent buffer overflow
+    if (size > sizeof(buffer) - 1)
+    {
+        return HAL_ERROR; // prevent buffer overflow
+    }
 
     buffer[0] = reg;
     memcpy(&buffer[1], pData, size);
@@ -48,7 +60,10 @@ static HAL_StatusTypeDef ICM_WriteBytes(uint8_t reg, uint8_t *pData, uint16_t si
     for (int attempt = 0; attempt < retries; attempt++)
     {
     	result = HAL_I2C_Master_Transmit(&ICM_I2C, ICM20948_ADDR << 1, buffer, size + 1, 100);
-        if (result != HAL_BUSY) break;
+        if (result != HAL_BUSY)
+        {
+            break;
+        }
     }
     return result;
 }
@@ -69,14 +84,23 @@ static HAL_StatusTypeDef AK_ReadBytes(uint8_t reg, uint8_t *pData, uint16_t size
     for (int attempt = 0; attempt < retries; attempt++)
     {
         result = HAL_I2C_Master_Transmit(&ICM_I2C, AK09916_I2C_ADDR << 1, &reg, 1, 100);
-        if (result != HAL_BUSY) break;
+        if (result != HAL_BUSY)
+        {
+            break;
+        }
     }
-    if (result != HAL_OK) return result;
+    if (result != HAL_OK)
+    {
+        return result;
+    }
 
     for (int attempt = 0; attempt < retries; attempt++)
     {
         result = HAL_I2C_Master_Receive(&ICM_I2C, AK09916_I2C_ADDR << 1, pData, size, 100);
-        if (result != HAL_BUSY) break;
+        if (result != HAL_BUSY)
+        {
+            break;
+        }
     }
     return result;
 }
@@ -90,7 +114,10 @@ static HAL_StatusTypeDef AK_WriteByte(uint8_t reg, uint8_t value)
     for (int attempt = 0; attempt < retries; attempt++)
     {
         result = HAL_I2C_Master_Transmit(&ICM_I2C, AK09916_I2C_ADDR << 1, buffer, 2, 100);
-        if (result != HAL_BUSY) break;
+        if (result != HAL_BUSY)
+        {
+            break;
+        }
     }
     return result;
 }
@@ -98,7 +125,10 @@ static HAL_StatusTypeDef AK_WriteByte(uint8_t reg, uint8_t value)
 
 static inline void ICM_SelectBank(uint8_t bank)
 {
-	if (current_bank == bank) return;
+	if (current_bank == bank)
+	{
+		return;
+	}
     uint8_t val = bank;
     if (HAL_I2C_Mem_Write(&ICM_I2C, ICM20948_ADDR << 1, ICM20948_REG_BANK_SEL, I2C_MEMADD_SIZE_8BIT, &val, 1, 5) == HAL_OK)
     {
@@ -139,33 +169,51 @@ uint8_t ICM_Init(void)
     uint8_t reset_cmd = 0x80;
     status = ICM_WriteBytes(ICM20948_PWR_MGMT_1, &reset_cmd, 1);
     delay_ms(100);  // Wait for reset
-    if (status != HAL_OK) return status;
+    if (status != HAL_OK)
+    {
+        return status;
+    }
 
     // 3. Wake up and set clock source
     uint8_t pwr_mgmt_1 = 0x01;  // sleep=0, clock=auto
     status = ICM_WriteBytes(ICM20948_PWR_MGMT_1, &pwr_mgmt_1, 1);
-    if (status != HAL_OK) return status;
+    if (status != HAL_OK)
+    {
+        return status;
+    }
     delay_ms(10);
 
     // 4. Enable all sensors (Accel, Gyro, Temp)
     uint8_t pwr_mgmt_2 = 0x00; // All on
     status = ICM_WriteBytes(ICM20948_PWR_MGMT_2, &pwr_mgmt_2, 1);
-    if (status != HAL_OK) return status;
+    if (status != HAL_OK)
+    {
+        return status;
+    }
 
     // 4.5 Disable Low Power Mode (LP_EN = 0)
     uint8_t lp_config = 0x00;
     status = ICM_WriteBytes(ICM20948_LP_CONFIG, &lp_config, 1);  // LP_CONFIG register (bank 0)
-    if (status != HAL_OK) return status;
+    if (status != HAL_OK)
+    {
+        return status;
+    }
 
     // 5. Keep the aux I2C master OFF and route the internal AK09916 onto
     // the host bus via BYPASS_EN (mag then answers directly at 0x0C).
     // BYPASS_EN only engages while I2C_MST_EN is clear.
     uint8_t user_ctrl = 0x00;
     status = ICM_WriteBytes(ICM20948_USER_CTRL, &user_ctrl, 1);
-    if (status != HAL_OK) return status;
+    if (status != HAL_OK)
+    {
+        return status;
+    }
     uint8_t int_pin_cfg = 0x02; // BYPASS_EN
     status = ICM_WriteBytes(ICM20948_INT_PIN_CFG, &int_pin_cfg, 1);
-    if (status != HAL_OK) return status;
+    if (status != HAL_OK)
+    {
+        return status;
+    }
     delay_ms(5);
 
     // 6. Select USER BANK 2 for gyro and accel config
@@ -175,12 +223,18 @@ uint8_t ICM_Init(void)
     // anti-aliasing for the 40 Hz sample stream (Nyquist 20 Hz).
     uint8_t gyro_config_1 = 0x2F; // DLPFCFG=5 (11.6Hz), FS_SEL=3 (±2000dps), FCHOICE=1
     status = ICM_WriteBytes(ICM20948_GYRO_CONFIG_1, &gyro_config_1, 1);
-    if (status != HAL_OK) return status;
+    if (status != HAL_OK)
+    {
+        return status;
+    }
 
     // 8. Configure accelerometer: ±16g, DLPF enabled at 11.5 Hz BW.
     uint8_t accel_config = 0x2F; // DLPFCFG=5 (11.5Hz), FS_SEL=3 (±16g), FCHOICE=1
     status = ICM_WriteBytes(ICM20948_ACCEL_CONFIG, &accel_config, 1);
-    if (status != HAL_OK) return status;
+    if (status != HAL_OK)
+    {
+        return status;
+    }
 
     // 8.5 Bring up the AK09916 magnetometer directly over the bypass bus.
     ICM_SelectBank(ICM20948_USER_BANK_0);
@@ -198,12 +252,18 @@ uint8_t ICM_Init(void)
     // and the AK09916 keeps its mode across MCU resets, so start from a
     // known state.
     status = AK_WriteByte(0x32, 0x01); // CNTL3 = SRST
-    if (status != HAL_OK) return status;
+    if (status != HAL_OK)
+    {
+        return status;
+    }
     delay_ms(10);
 
     // Continuous measurement mode at 100 Hz via CNTL2.
     status = AK_WriteByte(0x31, 0x08);
-    if (status != HAL_OK) return status;
+    if (status != HAL_OK)
+    {
+        return status;
+    }
     delay_ms(10); // Let mag config complete
 
     // 9. Return to USER BANK 0
@@ -240,7 +300,9 @@ uint8_t ICM_ReadAccel(ICM_Axis3D *accel)
     ICM_SelectBank(ICM20948_USER_BANK_0);
 
     if (ICM_readBytes(ICM20948_ACCEL_XOUT_H, rawData, 6) != HAL_OK)
+    {
         return HAL_ERROR;
+    }
 
     accel->x = (int16_t)((rawData[0] << 8) | rawData[1]);
     accel->y = (int16_t)((rawData[2] << 8) | rawData[3]);
@@ -255,7 +317,9 @@ uint8_t ICM_ReadGyro(ICM_Axis3D *gyro)
     ICM_SelectBank(ICM20948_USER_BANK_0);
 
     if (ICM_readBytes(ICM20948_GYRO_XOUT_H, rawData, 6) != HAL_OK)
+    {
         return HAL_ERROR;
+    }
 
     gyro->x = (int16_t)((rawData[0] << 8) | rawData[1]);
     gyro->y = (int16_t)((rawData[2] << 8) | rawData[3]);
@@ -271,7 +335,9 @@ uint8_t ICM_ReadMag(ICM_Axis3D *mag)
     uint8_t magData[9]; // ST1, HXL..HZH, TMPS, ST2
 
     if (AK_ReadBytes(0x10, magData, 9) != HAL_OK)
+    {
         return HAL_ERROR;
+    }
 
     mag->x = (int16_t)((magData[2] << 8) | magData[1]);
     mag->y = (int16_t)((magData[4] << 8) | magData[3]);
@@ -289,12 +355,16 @@ uint8_t ICM_GetAllRawData(ICM_Axis3D *accel, float * pTemp, ICM_Axis3D *gyro, IC
     ICM_SelectBank(ICM20948_USER_BANK_0);
 
     if (ICM_readBytes(ICM20948_ACCEL_XOUT_H, rawData, 14) != HAL_OK)
+    {
         return HAL_ERROR;
+    }
 
     // Direct mag read over the bypass bus. The burst must end at ST2:
     // the AK09916 latches measurement data until ST2 is read.
     if (AK_ReadBytes(0x10, magData, 9) != HAL_OK)
+    {
         return HAL_ERROR;
+    }
 
     accel->x = (int16_t)((rawData[0] << 8) | rawData[1]);
     accel->y = (int16_t)((rawData[2] << 8) | rawData[3]);

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -43,7 +43,7 @@ CameraDevice cam_array[CAMERA_COUNT];	// array of all the cameras
 
 static int _active_cam_idx = 0;
 
-volatile bool usb_failed = false;
+static volatile bool usb_failed = false;
 
 __ALIGN_BEGIN volatile uint8_t frame_buffer[1][CAMERA_COUNT * HISTOGRAM_DATA_SIZE] __ALIGN_END; // Double buffer
 __ALIGN_BEGIN uint8_t packet_buffer[HISTO_JSON_BUFFER_SIZE] __ALIGN_END;
@@ -58,8 +58,8 @@ extern uint32_t pulse_count;
 
 
 // Variables for keeping track of statisticss
-volatile uint32_t total_frames_sent = 0;
-volatile uint32_t total_frames_failed = 0;
+static volatile uint32_t total_frames_sent = 0;
+static volatile uint32_t total_frames_failed = 0;
 
 // Compression statistics (running averages)
 static uint32_t cmp_total_uncompressed = 0;  // Sum of all uncompressed payload sizes
@@ -70,10 +70,10 @@ static uint32_t cmp_usb_fail_count = 0;      // Number of USB send failures (com
 static uint32_t cmp_max_time_us = 0;         // Worst-case compression time in µs
 
 #define STREAMING_TIMEOUT_MS 150
-volatile uint32_t most_recent_frame_time = 0;
-volatile uint32_t streaming_start_time = 0;
-bool streaming_active = false;
-bool streaming_first_frame = false;
+static volatile uint32_t most_recent_frame_time = 0;
+static volatile uint32_t streaming_start_time = 0;
+static bool streaming_active = false;
+static bool streaming_first_frame = false;
 
 // Camera failure detection
 #define CAMERA_FAILURE_THRESHOLD_CYCLES 3  // Number of consecutive cycles before reporting failure
@@ -421,15 +421,16 @@ CameraDevice* get_active_cam(void) {
 }
 
 CameraDevice* set_active_camera(int id) {
-	if(id < 0 || id >= CAMERA_COUNT) return NULL;
+	if(id < 0 || id >= CAMERA_COUNT) { return NULL; }
 
 	_active_cam_idx = id;
 	return &cam_array[_active_cam_idx];
 }
 
 CameraDevice* get_camera_byID(int id) {
-	if(id < 0 || id >= CAMERA_COUNT)
+	if(id < 0 || id >= CAMERA_COUNT) {
 		return NULL;
+	}
 	return &cam_array[id];
 }
 
@@ -844,7 +845,7 @@ _Bool program_sram_fpga(uint8_t cam_id, bool rom_bitstream, uint8_t* pData, uint
 
 	if(!force_update)
 	{
-		if(cam->isProgrammed) return true;
+		if(cam->isProgrammed) { return true; }
 		if(fpga_detect_nvcm(cam)){
 			cam->isProgrammed = true;
 			printf("NVCM programmed, skipping\r\n");
@@ -1255,7 +1256,7 @@ static void generate_fake_histogram(uint8_t *histogram_data) {
 			break;
 		case 2:
     		for(int i=0;i<HISTOGRAM_BINS;i++){
-    			histogram[i] =  (uint32_t) 0xAAAAAAAA;
+    			histogram[i] =  (uint32_t) 0xAAAAAAAAU;
     		}
 			break;
 		case 3:
@@ -1474,7 +1475,7 @@ _Bool check_streaming(void){
 		uint32_t most_recent_frame_time_local = most_recent_frame_time;
 
 		if(current_time<most_recent_frame_time_local){
-			if(verbose_on) printf("Current time is less than most recent frame time, passing.\r\n");
+			if(verbose_on) { printf("Current time is less than most recent frame time, passing.\r\n"); }
 			// This is an edge case that seems to happen due to this function being interrupted by the interrupt that sets most_recent_frame_time.
 			return streaming_active;
 		}
@@ -1540,7 +1541,7 @@ _Bool send_histogram_data(void) {
 	bool skip_no_data_log = streaming_first_frame;
 	streaming_first_frame = false;
 	for (int i = 0; i < CAMERA_COUNT ; ++i) {
-		if (ready_bits & (1 << i)) {
+		if ((ready_bits & (1 << i)) != 0) {
 			count++;
 		}
 	}
@@ -1648,7 +1649,7 @@ static int rle_compress(const uint8_t *src, int src_len, uint8_t *dst, int dst_m
 
 		if (run_len >= 3) {
 			/* Encode as repeat run */
-			if (di + 2 > dst_max) return -1;
+			if (di + 2 > dst_max) { return -1; }
 			dst[di++] = (uint8_t)(0x80 + (run_len - 3));
 			dst[di++] = val;
 		} else {
@@ -1660,10 +1661,10 @@ static int rle_compress(const uint8_t *src, int src_len, uint8_t *dst, int dst_m
 					break;
 				}
 				si++;
-				if (si - lit_start >= 128) break;
+				if (si - lit_start >= 128) { break; }
 			}
 			int lit_len = si - lit_start;
-			if (di + 1 + lit_len > dst_max) return -1;
+			if (di + 1 + lit_len > dst_max) { return -1; }
 			dst[di++] = (uint8_t)(lit_len - 1);
 			memcpy(dst + di, src + lit_start, lit_len);
 			di += lit_len;
@@ -1691,7 +1692,7 @@ _Bool send_histogram_data_cmp(void) {
 	bool skip_no_data_log = streaming_first_frame;
 	streaming_first_frame = false;
 	for (int i = 0; i < CAMERA_COUNT; ++i) {
-		if (ready_bits & (1 << i)) {
+		if ((ready_bits & (1 << i)) != 0) {
 			count++;
 		}
 	}
@@ -1825,7 +1826,7 @@ _Bool send_fake_data(void) {
 
 	uint8_t count = 0;
 	for (int i = 0; i < CAMERA_COUNT ; ++i) {
-		if (event_bits_enabled & (1 << i)) {
+		if ((event_bits_enabled & (1 << i)) != 0) {
 			count++;
 		}
 	}
@@ -1899,7 +1900,7 @@ _Bool send_fake_data(void) {
 }
 
 _Bool start_data_reception(uint8_t cam_id){
-	if(verbose_on) printf("Start data reception on camera: %d... ",cam_id+1);
+	if(verbose_on) { printf("Start data reception on camera: %d... ",cam_id+1); }
 	HAL_StatusTypeDef status;
 
 	if (!camera_request_is_valid(cam_id)) {
@@ -1958,12 +1959,12 @@ _Bool start_data_reception(uint8_t cam_id){
 		abort_data_reception(cam_id);
 		return false;
 	}
-	if(verbose_on) printf("done\r\n");
+	if(verbose_on) { printf("done\r\n"); }
 	return true;
 }
 
 _Bool abort_data_reception(uint8_t cam_id){
-	if(verbose_on) printf("Abort data reception C: %d... ",cam_id);
+	if(verbose_on) { printf("Abort data reception C: %d... ",cam_id); }
 	HAL_StatusTypeDef status;
 
 	if (!camera_request_is_valid(cam_id)) {
@@ -1973,16 +1974,18 @@ _Bool abort_data_reception(uint8_t cam_id){
 	// disable the reception
 	CameraDevice* cam = get_camera_byID(cam_id);
 	if(cam->useUsart) {
-		if(cam->useDma)
+		if(cam->useDma) {
 			status = HAL_USART_Abort(cam->pUart);
-		else
+		} else {
 			status = HAL_USART_Abort_IT(cam->pUart);
+		}
 	}
 	else{
-		if(cam->useDma)
+		if(cam->useDma) {
 			status = HAL_SPI_Abort(cam->pSpi);
-		else
+		} else {
 			status = HAL_SPI_Abort_IT(cam->pSpi);
+		}
 	}
 	if (status != HAL_OK) {
 		return false;
@@ -2002,7 +2005,7 @@ _Bool abort_data_reception(uint8_t cam_id){
             return false;
         }
     }
-	if(verbose_on) printf("done\r\n");
+	if(verbose_on) { printf("done\r\n"); }
 	return true;
 }
 

--- a/Core/Src/crosslink.c
+++ b/Core/Src/crosslink.c
@@ -30,16 +30,16 @@
 
 #define CROSSLINK_I2C_TIMEOUT_MS 1000U
 
-volatile uint8_t txComplete = 0;
-volatile uint8_t rxComplete = 0;
-volatile uint8_t i2cError = 0;
+static volatile uint8_t txComplete = 0;
+static volatile uint8_t rxComplete = 0;
+static volatile uint8_t i2cError = 0;
 
-unsigned char activation_key[5] = {0xFF, 0xA4, 0xC6, 0xF4, 0x8A};
-uint8_t expected_idcode[] = {0x01, 0x2C, 0x00, 0x43};
-unsigned char write_buf[4];
-unsigned char read_buf[4];
+static unsigned char activation_key[5] = {0xFF, 0xA4, 0xC6, 0xF4, 0x8A};
+static uint8_t expected_idcode[] = {0x01, 0x2C, 0x00, 0x43};
+static unsigned char write_buf[4];
+static unsigned char read_buf[4];
 
-const uint8_t max_attempts = 3;
+static const uint8_t max_attempts = 3;
 extern uint8_t bitstream_buffer[];
 extern uint32_t bitstream_len;
 
@@ -57,25 +57,27 @@ int xi2c_write_and_read(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *w
     rxComplete = 0;
     i2cError = 0;
 
-    if (HAL_I2C_Master_Seq_Transmit_IT(hi2c, DevAddress << 1, wbuf, wlen, I2C_FIRST_FRAME) != HAL_OK)
+    if (HAL_I2C_Master_Seq_Transmit_IT(hi2c, DevAddress << 1, wbuf, wlen, I2C_FIRST_FRAME) != HAL_OK) {
         return -1;
+    }
 
     // Wait for the transmission to complete
     while (!txComplete && !i2cError) {}
 
-    if (i2cError)
+    if (i2cError != 0)
     {
         return HAL_ERROR;
     }
 
 
-    if (HAL_I2C_Master_Seq_Receive_IT(hi2c, DevAddress << 1, rbuf, rlen, I2C_LAST_FRAME) != HAL_OK)
+    if (HAL_I2C_Master_Seq_Receive_IT(hi2c, DevAddress << 1, rbuf, rlen, I2C_LAST_FRAME) != HAL_OK) {
         return -1;
+    }
 
     // Wait for the reception to complete
     while (!rxComplete && !i2cError) {}
 
-    if (i2cError)
+    if (i2cError != 0)
     {
         return HAL_ERROR;
     }
@@ -135,7 +137,7 @@ static HAL_StatusTypeDef xi2c_write_long(I2C_HandleTypeDef *hi2c, uint16_t DevAd
         // Wait for the transmission to complete
         while (!txComplete && !i2cError) {}
 
-        if (i2cError)
+        if (i2cError != 0)
         {
             return HAL_ERROR;
         }
@@ -149,9 +151,9 @@ static HAL_StatusTypeDef xi2c_write_long(I2C_HandleTypeDef *hi2c, uint16_t DevAd
 int fpga_send_activation(I2C_HandleTypeDef *hi2c, uint16_t DevAddress)
 {
 	// Step 1: Initialize
-	if(verbose_on) printf("Step 1: Send Activation Key\r\n");
+	if(verbose_on) { printf("Step 1: Send Activation Key\r\n"); }
 	if (xi2c_write_bytes(hi2c, DevAddress, activation_key, 5) != HAL_OK) {
-		if(verbose_on) printf("failed to send activation key\r\n");
+		if(verbose_on) { printf("failed to send activation key\r\n"); }
 	    return 1;  // Exit if writing activation key fails
 	}
 
@@ -161,24 +163,24 @@ int fpga_send_activation(I2C_HandleTypeDef *hi2c, uint16_t DevAddress)
 int fpga_checkid(I2C_HandleTypeDef *hi2c, uint16_t DevAddress)
 {
     // Step 2: Check IDCODE (Optional)
-    if(verbose_on) printf("Step 2: Check IDCODE (Optional)\r\n");
+    if(verbose_on) { printf("Step 2: Check IDCODE (Optional)\r\n"); }
     write_buf[0] = 0xE0; write_buf[1] = 0x00; write_buf[2] = 0x00; write_buf[3] = 0x00;
     if (xi2c_write_and_read(hi2c, DevAddress, write_buf, 4, read_buf, 4) != HAL_OK) {
-        if(verbose_on) printf("failed to send IDCODE Command\r\n");
+        if(verbose_on) { printf("failed to send IDCODE Command\r\n"); }
         return 1;  // Exit if write/read fails
     }
 
-    if(verbose_on) print_hex_buf("IDCODE", read_buf, 4);
+    if(verbose_on) { print_hex_buf("IDCODE", read_buf, 4); }
 	return 0;
 }
 
 int fpga_enter_sram_prog_mode(I2C_HandleTypeDef *hi2c, uint16_t DevAddress)
 {
     // Step 3: Enable SRAM Programming Mode
-    if(verbose_on) printf("Step 3: Enable SRAM Programming Mode\r\n");
+    if(verbose_on) { printf("Step 3: Enable SRAM Programming Mode\r\n"); }
     write_buf[0] = 0xC6; write_buf[1] = 0x00; write_buf[2] = 0x00; write_buf[3] = 0x00;
     if (xi2c_write_bytes(hi2c, DevAddress, write_buf, 4) != HAL_OK) {
-        if(verbose_on) printf("failed to send SRAM Command\r\n");
+        if(verbose_on) { printf("failed to send SRAM Command\r\n"); }
         return 1;  // Exit if writing fails
     }
     delay_ms(1);
@@ -189,10 +191,10 @@ int fpga_exit_prog_mode(I2C_HandleTypeDef *hi2c, uint16_t DevAddress)
 {
 
     // Step 11: Exit Programming Mode
-    if(verbose_on) printf("Step 10: Exit Programming Mode\r\n");
+    if(verbose_on) { printf("Step 10: Exit Programming Mode\r\n"); }
     write_buf[0] = 0x26; write_buf[1] = 0x00; write_buf[2] = 0x00; write_buf[3] = 0x00;
     if (xi2c_write_bytes(hi2c, DevAddress, write_buf, 4) != HAL_OK) {
-        if(verbose_on) printf("failed to send Exit Command\r\n");
+        if(verbose_on) { printf("failed to send Exit Command\r\n"); }
         return 1;  // Exit if writing fails
     }
 
@@ -202,14 +204,14 @@ int fpga_exit_prog_mode(I2C_HandleTypeDef *hi2c, uint16_t DevAddress)
 uint32_t fpga_read_status(I2C_HandleTypeDef *hi2c, uint16_t DevAddress)
 {
     // Step 5: Read Status Register
-    if(verbose_on) printf("Read Status Register\r\n");
+    if(verbose_on) { printf("Read Status Register\r\n"); }
     write_buf[0] = 0x3C; write_buf[1] = 0x00; write_buf[2] = 0x00; write_buf[3] = 0x00;
     if (xi2c_write_and_read(hi2c, DevAddress, write_buf, 4, read_buf, 4) != HAL_OK) {
-        if(verbose_on) printf("failed to send READ Status Command\r\n");
+        if(verbose_on) { printf("failed to send READ Status Command\r\n"); }
         return 1;  // Exit if write/read fails
     }
 
-    if(verbose_on) print_hex_buf("Erase Status", read_buf, 4);
+    if(verbose_on) { print_hex_buf("Erase Status", read_buf, 4); }
     return 0;
 
 }
@@ -217,14 +219,14 @@ uint32_t fpga_read_status(I2C_HandleTypeDef *hi2c, uint16_t DevAddress)
 uint32_t fpga_read_usercode(I2C_HandleTypeDef *hi2c, uint16_t DevAddress)
 {
     // Step 9: Read USERCODE (Optional)
-    if(verbose_on) printf("Step 9: Verify USERCODE (Optional)\r\n");
+    if(verbose_on) { printf("Step 9: Verify USERCODE (Optional)\r\n"); }
     write_buf[0] = 0xC0; write_buf[1] = 0x00; write_buf[2] = 0x00; write_buf[3] = 0x00;
     if (xi2c_write_and_read(hi2c, DevAddress, write_buf, 4, read_buf, 4) != HAL_OK) {
-        if(verbose_on) printf("failed to send USERCODE Command\r\n");
+        if(verbose_on) { printf("failed to send USERCODE Command\r\n"); }
         return 1;  // Exit if write/read fails
     }
 
-    if(verbose_on) print_hex_buf("User Register", read_buf, 4);
+    if(verbose_on) { print_hex_buf("User Register", read_buf, 4); }
     return 0;
 }
 
@@ -232,7 +234,7 @@ uint32_t fpga_read_usercode(I2C_HandleTypeDef *hi2c, uint16_t DevAddress)
 static void nvcm_log_buf(const char *label, const uint8_t *buf, int len)
 {
     printf("NVCM %s:", label);
-    for (int i = 0; i < len; i++) printf(" %02X", buf[i]);
+    for (int i = 0; i < len; i++) { printf(" %02X", buf[i]); }
     printf("\r\n");
 }
 
@@ -244,7 +246,7 @@ int fpga_nvcm_probe(I2C_HandleTypeDef *hi2c, uint16_t DevAddress,
     uint8_t wbuf[4];
 
     memset(out, 0, sizeof(*out));
-    if (num_rows > FPGA_NVCM_MAX_ROWS) num_rows = FPGA_NVCM_MAX_ROWS;
+    if (num_rows > FPGA_NVCM_MAX_ROWS) { num_rows = FPGA_NVCM_MAX_ROWS; }
 
     printf("NVCM probe: isc_operand=0x%02X num_rows=%u boot_test=%u addr=0x%02X\r\n",
            isc_operand, (unsigned)num_rows, (unsigned)do_boot_test, (unsigned)DevAddress);
@@ -357,7 +359,7 @@ int fpga_nvcm_probe(I2C_HandleTypeDef *hi2c, uint16_t DevAddress,
      *         0x40 gone  -> programmed
      *     Ends by re-asserting CRESETB low to halt any booted user design and
      *     free the shared I2C bus (TCA-safe). */
-    if (do_boot_test) {
+    if (do_boot_test != 0) {
         HAL_GPIO_WritePin(GPIOx, GPIO_Pin, GPIO_PIN_RESET);  /* assert reset */
         delay_ms(5);
         HAL_GPIO_WritePin(GPIOx, GPIO_Pin, GPIO_PIN_SET);    /* release, NO activation key */
@@ -381,22 +383,22 @@ int fpga_nvcm_probe(I2C_HandleTypeDef *hi2c, uint16_t DevAddress,
 int fpga_erase_sram(I2C_HandleTypeDef *hi2c, uint16_t DevAddress)
 {
     // Step 4: Erase SRAM
-    if(verbose_on) printf("Step 4: Erase SRAM...");
+    if(verbose_on) { printf("Step 4: Erase SRAM..."); }
     write_buf[0] = 0x0E; write_buf[1] = 0x00; write_buf[2] = 0x00; write_buf[3] = 0x00;
     if (xi2c_write_bytes(hi2c, DevAddress, write_buf, 4) != HAL_OK) {
-        if(verbose_on) printf("\r\nFAILED to send SRAM Erase Command\r\n");
+        if(verbose_on) { printf("\r\nFAILED to send SRAM Erase Command\r\n"); }
         return 1;  // Exit if writing fails
     }
-    if(verbose_on) printf("COMPLETED\r\n");
+    if(verbose_on) { printf("COMPLETED\r\n"); }
     return 0;
 }
 
 int fpga_program_sram(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, bool rom_bitstream, uint8_t* pData, uint32_t Data_Len)
 {
-    if(verbose_on) printf("Program SRAM\r\n");
+    if(verbose_on) { printf("Program SRAM\r\n"); }
     write_buf[0] = 0x46; write_buf[1] = 0x00; write_buf[2] = 0x00; write_buf[3] = 0x00;
     if (xi2c_write_bytes(hi2c, DevAddress, write_buf, 4)!= HAL_OK) {
-        if(verbose_on) printf("failed to send Exit Command\r\n");
+        if(verbose_on) { printf("failed to send Exit Command\r\n"); }
         return 1;  // Exit if writing fails
     }
 
@@ -422,7 +424,7 @@ int fpga_configure(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, GPIO_TypeDef *G
 	uint8_t attempt = 0;
 	_Bool idcode_match = false;
 
-	if(verbose_on) printf("Starting FPGA configuration...\r\n");
+	if(verbose_on) { printf("Starting FPGA configuration...\r\n"); }
 
     // Set GPIO HIGH
     HAL_GPIO_WritePin(GPIOx, GPIO_Pin, GPIO_PIN_SET);
@@ -451,7 +453,7 @@ int fpga_configure(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, GPIO_TypeDef *G
 		memset(read_buf, 0, 4);
 		memcpy(write_buf, (uint8_t[]){0xE0,0x00,0x00,0x00}, 4);
 		xi2c_write_and_read(hi2c, DevAddress, write_buf, 4, read_buf, 4);
-		if(verbose_on) print_hex_buf("IDCODE", read_buf, 4);
+		if(verbose_on) { print_hex_buf("IDCODE", read_buf, 4); }
 
 	    // Check if IDCODE matches expected
 	    if (memcmp(read_buf, expected_idcode, 4) == 0) {
@@ -465,7 +467,7 @@ int fpga_configure(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, GPIO_TypeDef *G
         // Optionally return or handle error
         return HAL_ERROR;
     } else {
-        if(verbose_on) printf("IDCODE matched successfully.\r\n");
+        if(verbose_on) { printf("IDCODE matched successfully.\r\n"); }
         // Proceed with the next steps
     }
 
@@ -483,7 +485,7 @@ int fpga_configure(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, GPIO_TypeDef *G
     memset(read_buf, 0, 4);
     memcpy(write_buf, (uint8_t[]){0x3C,0x00,0x00,0x00}, 4);
     xi2c_write_and_read(hi2c, DevAddress, write_buf, 4, read_buf, 4);
-    if(verbose_on) print_hex_buf("Erase Status", read_buf, 4);
+    if(verbose_on) { print_hex_buf("Erase Status", read_buf, 4); }
 
     // Program Command
     memcpy(write_buf, (uint8_t[]){0x46,0x00,0x00,0x00}, 4);
@@ -499,21 +501,21 @@ int fpga_configure(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, GPIO_TypeDef *G
     memset(read_buf, 0, 4);
     memcpy(write_buf, (uint8_t[]){0xC0,0x00,0x00,0x00}, 4);
     xi2c_write_and_read(hi2c, DevAddress, write_buf, 4, read_buf, 4);
-    if(verbose_on) print_hex_buf("User Register", read_buf, 4);
+    if(verbose_on) { print_hex_buf("User Register", read_buf, 4); }
 
     // Final Status
     memset(read_buf, 0, 4);
     memcpy(write_buf, (uint8_t[]){0x3C,0x00,0x00,0x00}, 4);
     xi2c_write_and_read(hi2c, DevAddress, write_buf, 4, read_buf, 4);
-    if(verbose_on) print_hex_buf("Program Status", read_buf, 4);
+    if(verbose_on) { print_hex_buf("Program Status", read_buf, 4); }
 
-    if(read_buf[2] != 0x0F) ret_status = 1;
+    if(read_buf[2] != 0x0F) { ret_status = 1; }
 
     // Exit Program Mode
     memcpy(write_buf, (uint8_t[]){0x26,0x00,0x00,0x00}, 4);
     xi2c_write_bytes(hi2c, DevAddress, write_buf, 4);
 
-    if(verbose_on) printf("FPGA configuration complete.\r\n");
+    if(verbose_on) { printf("FPGA configuration complete.\r\n"); }
     return ret_status;
 }
 

--- a/Core/Src/flash_eeprom.c
+++ b/Core/Src/flash_eeprom.c
@@ -27,7 +27,9 @@ static uint32_t GetSector(uint32_t Address)
     }
 
     if (sector > FLASH_SECTOR_7)
+    {
         sector = FLASH_SECTOR_7;
+    }
 
     return sector;
 }
@@ -70,7 +72,9 @@ HAL_StatusTypeDef Flash_Write(uint32_t address, const uint32_t *data, uint32_t s
         );
 
         if (status != HAL_OK)
+        {
             break;
+        }
     }
 
     HAL_FLASH_Lock();
@@ -135,7 +139,9 @@ HAL_StatusTypeDef Flash_Write_Bytes(uint32_t address,
         );
 
         if (status != HAL_OK)
+        {
             break;
+        }
     }
 
     HAL_FLASH_Lock();
@@ -170,9 +176,13 @@ HAL_StatusTypeDef Flash_Erase(uint32_t start_address, uint32_t end_address)
     uint32_t bank;
 
     if (start_address < FLASH_BANK2_BASE)
+    {
         bank = FLASH_BANK_1;
+    }
     else
+    {
         bank = FLASH_BANK_2;
+    }
 
     HAL_FLASH_Unlock();
     SCB_DisableICache();

--- a/Core/Src/histo_fake.c
+++ b/Core/Src/histo_fake.c
@@ -15,7 +15,9 @@ static HistoFakeContext histo_ctx;
 void HistoFake_Init(uint32_t camera_count)
 {
     if (camera_count > HISTO_CAMERA_MAX_COUNT)
+    {
         camera_count = HISTO_CAMERA_MAX_COUNT;
+    }
 
     histo_ctx.camera_count = camera_count;
     histo_ctx.frame_id = 0;

--- a/Core/Src/i2c_master.c
+++ b/Core/Src/i2c_master.c
@@ -15,7 +15,7 @@
 // I2C Expander specific
 #define TCA9548_ADDR 0x70
 
-uint8_t I2C_current_target = 0x00; // Default target address
+static uint8_t I2C_current_target = 0x00; // Default target address
 
 static void TCA9548A_ResetHardware(void)
 {
@@ -90,7 +90,7 @@ uint8_t I2C_scan(I2C_HandleTypeDef * pI2c, uint8_t* addr_list, size_t list_size,
         		printf("-- ");
         	}
         }
-        if (display && (address + 1) % 16 == 0)  printf("\r\n");
+        if (display && (address + 1) % 16 == 0) { printf("\r\n"); }
     }
 
 	if(display)
@@ -253,8 +253,9 @@ void I2C_BusRecovery(I2C_HandleTypeDef *hi2c)
         delay_us(5);
         HAL_GPIO_WritePin(GPIOB, GPIO_PIN_8, GPIO_PIN_SET);
         delay_us(5);
-        if (HAL_GPIO_ReadPin(GPIOB, GPIO_PIN_7) == GPIO_PIN_SET)
+        if (HAL_GPIO_ReadPin(GPIOB, GPIO_PIN_7) == GPIO_PIN_SET) {
             break;
+        }
     }
 
     /* Generate STOP: SDA low → SCL high → SDA high. */

--- a/Core/Src/i2c_protocol.c
+++ b/Core/Src/i2c_protocol.c
@@ -99,7 +99,7 @@ size_t i2c_packet_toBuffer(I2C_TX_Packet* pTX, uint8_t* buffer) {
     buffer++;
 
     // Write Data
-    if (pTX->pData) {
+    if (pTX->pData != NULL) {
         for (i = 0; i < pTX->data_len; i++) {
             *buffer = pTX->pData[i];
             buffer++;

--- a/Core/Src/if_commands.c
+++ b/Core/Src/if_commands.c
@@ -36,7 +36,7 @@ static uint32_t id_words[3] = {0};
 static uint8_t camera_status[8] = {0};
 static uint8_t camera_power_status = 0;
 static float cam_temp;
-volatile float imu_temp = 0;
+static volatile float imu_temp = 0;
 static ICM_Axis3D accel;
 static ICM_Axis3D gyro;
 volatile uint32_t imu_frame_counter = 0;
@@ -104,7 +104,7 @@ static void process_basic_command(UartPacket *uartResp, UartPacket cmd)
 		VERBOSE_CMD("[CMD] OW_CMD_DEBUG_FLAGS reserved=0x%02X len=%u\r\n", cmd.reserved, (unsigned)cmd.data_len);
 		uartResp->command = OW_CMD_DEBUG_FLAGS;
 		// reserved bit0: 0 = get, 1 = set
-		if (cmd.reserved & 0x01) {
+		if ((cmd.reserved & 0x01) != 0) {
 			if (cmd.data_len != sizeof(uint32_t)) {
 				uartResp->packet_type = OW_ERROR;
 				uartResp->data_len = 0;
@@ -274,8 +274,8 @@ static void process_sensor_command(UartPacket *uartResp, UartPacket cmd)
 		uartResp->packet_type = OW_RESP;
 		// reserved bit0: 0 = get, 1 = set
 		// reserved bit1 (only for set): 0 = OFF, 1 = ON
-		if (cmd.reserved & 0x01) {
-			if (cmd.reserved & 0x02) {
+		if ((cmd.reserved & 0x01) != 0) {
+			if ((cmd.reserved & 0x02) != 0) {
 				HAL_GPIO_WritePin(FAN_CTL_GPIO_Port, FAN_CTL_Pin, GPIO_PIN_SET);
 			} else {
 				HAL_GPIO_WritePin(FAN_CTL_GPIO_Port, FAN_CTL_Pin, GPIO_PIN_RESET);
@@ -297,9 +297,9 @@ static void process_sensor_command(UartPacket *uartResp, UartPacket cmd)
 extern uint8_t bitstream_buffer[];
 extern uint32_t bitstream_len;
 
-uint8_t* ptrBitstream;
+static uint8_t* ptrBitstream;
 
-void I2C_DisableEnableReset(I2C_HandleTypeDef *hi2c)
+static void I2C_DisableEnableReset(I2C_HandleTypeDef *hi2c)
 {
     // Step 1: Disable the I2C peripheral
     __HAL_RCC_I2C1_CLK_DISABLE(); // Replace I2C1 with your I2C instance
@@ -339,7 +339,7 @@ static void process_fpga_commands(UartPacket *uartResp, UartPacket cmd)
 		uartResp->command = OW_FPGA_ON;
 		uartResp->packet_type = OW_RESP;
 	    for (uint8_t i = 0; i < 8; i++) {
-	        if ((cmd.addr >> i) & 0x01) {
+	        if (((cmd.addr >> i) & 0x01) != 0) {
 	    		if(!enable_fpga(i))
 	    		{
 	    			uartResp->packet_type = OW_ERROR;
@@ -353,7 +353,7 @@ static void process_fpga_commands(UartPacket *uartResp, UartPacket cmd)
 		uartResp->command = OW_FPGA_OFF;
 		uartResp->packet_type = OW_RESP;
 	    for (uint8_t i = 0; i < 8; i++) {
-	        if ((cmd.addr >> i) & 0x01) {
+	        if (((cmd.addr >> i) & 0x01) != 0) {
 	    		if(!disable_fpga(i))
 	    		{
 	    			uartResp->packet_type = OW_ERROR;
@@ -367,7 +367,7 @@ static void process_fpga_commands(UartPacket *uartResp, UartPacket cmd)
 		uartResp->command = OW_FPGA_ACTIVATE;
 		uartResp->packet_type = OW_RESP;
 	    for (uint8_t i = 0; i < 8; i++) {
-	        if ((cmd.addr >> i) & 0x01) {
+	        if (((cmd.addr >> i) & 0x01) != 0) {
 	    		if(!activate_fpga(i))
 	    		{
 	    			uartResp->packet_type = OW_ERROR;
@@ -381,7 +381,7 @@ static void process_fpga_commands(UartPacket *uartResp, UartPacket cmd)
 		uartResp->command = OW_FPGA_ID;
 		uartResp->packet_type = OW_RESP;
 	    for (uint8_t i = 0; i < 8; i++) {
-	        if ((cmd.addr >> i) & 0x01) {
+	        if (((cmd.addr >> i) & 0x01) != 0) {
 	    		if(!verify_fpga(i))
 	    		{
 	    			uartResp->packet_type = OW_ERROR;
@@ -395,7 +395,7 @@ static void process_fpga_commands(UartPacket *uartResp, UartPacket cmd)
 		uartResp->command = OW_FPGA_ENTER_SRAM_PROG;
 		uartResp->packet_type = OW_RESP;
 	    for (uint8_t i = 0; i < 8; i++) {
-	        if ((cmd.addr >> i) & 0x01) {
+	        if (((cmd.addr >> i) & 0x01) != 0) {
 	    		if(!enter_sram_prog_fpga(i))
 	    		{
 	    			uartResp->packet_type = OW_ERROR;
@@ -409,7 +409,7 @@ static void process_fpga_commands(UartPacket *uartResp, UartPacket cmd)
 		uartResp->command = OW_FPGA_EXIT_SRAM_PROG;
 		uartResp->packet_type = OW_RESP;
 	    for (uint8_t i = 0; i < 8; i++) {
-	        if ((cmd.addr >> i) & 0x01) {
+	        if (((cmd.addr >> i) & 0x01) != 0) {
 	    		if(!exit_sram_prog_fpga(i))
 	    		{
 	    			uartResp->packet_type = OW_ERROR;
@@ -423,7 +423,7 @@ static void process_fpga_commands(UartPacket *uartResp, UartPacket cmd)
 		uartResp->command = OW_FPGA_ERASE_SRAM;
 		uartResp->packet_type = OW_RESP;
 	    for (uint8_t i = 0; i < 8; i++) {
-	        if ((cmd.addr >> i) & 0x01) {
+	        if (((cmd.addr >> i) & 0x01) != 0) {
 	    		if(!erase_sram_fpga(i))
 	    		{
 	    			uartResp->packet_type = OW_ERROR;
@@ -438,7 +438,7 @@ static void process_fpga_commands(UartPacket *uartResp, UartPacket cmd)
 		uartResp->packet_type = OW_RESP;
 		// TODO: Add parameter to force update currently defaults to false
 	    for (uint8_t i = 0; i < 8; i++) {
-	        if ((cmd.addr >> i) & 0x01) {
+	        if (((cmd.addr >> i) & 0x01) != 0) {
 	        	_Bool func_ret = false;
 
 	        	if(cmd.reserved == 1) {
@@ -459,7 +459,7 @@ static void process_fpga_commands(UartPacket *uartResp, UartPacket cmd)
 		uartResp->command = OW_FPGA_USERCODE;
 		uartResp->packet_type = OW_RESP;
 	    for (uint8_t i = 0; i < 8; i++) {
-	        if ((cmd.addr >> i) & 0x01) {
+	        if (((cmd.addr >> i) & 0x01) != 0) {
 	        	read_usercode_fpga(i);
 	        }
 	    }
@@ -493,7 +493,7 @@ static void process_fpga_commands(UartPacket *uartResp, UartPacket cmd)
 		uartResp->command = OW_FPGA_STATUS;
 		uartResp->packet_type = OW_RESP;
 	    for (uint8_t i = 0; i < 8; i++) {
-	        if ((cmd.addr >> i) & 0x01) {
+	        if (((cmd.addr >> i) & 0x01) != 0) {
 	    		read_status_fpga(i);
 	        }
 	    }
@@ -503,7 +503,7 @@ static void process_fpga_commands(UartPacket *uartResp, UartPacket cmd)
 		uartResp->command = OW_FPGA_RESET;
 		uartResp->packet_type = OW_RESP;
 	    for (uint8_t i = 0; i < 8; i++) {
-	        if ((cmd.addr >> i) & 0x01) {
+	        if (((cmd.addr >> i) & 0x01) != 0) {
 	        	if(!reset_camera(i))
 	        	{
 	    			uartResp->packet_type = OW_ERROR;
@@ -637,7 +637,7 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 		VERBOSE_CMD("[CMD] OW_CAMERA_SCAN\r\n");
 		uartResp->command = OW_CAMERA_SCAN;
 		uartResp->packet_type = OW_RESP;
-		if(X02C1B_detect(pCam)){
+		if(X02C1B_detect(pCam) != 0){
 			// error
 			VERBOSE_CMD("Failed Reading Camera %d ID\r\n",pCam->id+1);
 			uartResp->packet_type = OW_ERROR;
@@ -648,7 +648,7 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 		uartResp->command = OW_CAMERA_ON;
 		uartResp->packet_type = OW_RESP;
 		if ((logging_get_debug_flags() & DEBUG_FLAG_FAKE_DATA) == 0u) {
-			if(X02C1B_stream_on(pCam)){
+			if(X02C1B_stream_on(pCam) != 0){
 				VERBOSE_CMD("Failed Setting Camera %d Stream on\r\n",pCam->id+1);
 				uartResp->packet_type = OW_ERROR;
 			}
@@ -663,7 +663,7 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 			break;
 		}
 	    for (uint8_t i = 0; i < 8; i++) {
-	        if ((cmd.addr >> i) & 0x01) {
+	        if (((cmd.addr >> i) & 0x01) != 0) {
 	        	if(!configure_camera_sensor(i))
 	        	{
 	    			uartResp->packet_type = OW_ERROR;
@@ -689,9 +689,10 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 		}
 		uint8_t status = 0;
 		for (uint8_t i = 0; i < 8; i++) {
-	        if ((cmd.addr >> i) & 0x01) {
-				if(cmd.reserved == 1)
+	        if (((cmd.addr >> i) & 0x01) != 0) {
+				if(cmd.reserved == 1) {
 					status |= (enable_camera_stream(i)<<i);
+				}
 				else {
 					status |= (disable_camera_stream(i)<<i);
 				}
@@ -703,7 +704,7 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 			VERBOSE_CMD("Failed to %d on mask %02X\r\n", cmd.reserved, status);
 
 		}
-		else uartResp->packet_type = OW_ACK;
+		else { uartResp->packet_type = OW_ACK; }
 		break;
 	case OW_CAMERA_SINGLE_HISTOGRAM:
 		VERBOSE_CMD("[CMD] OW_CAMERA_SINGLE_HISTOGRAM addr=0x%02X\r\n", cmd.addr);
@@ -714,7 +715,7 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 			break;
 		}
 	    for (uint8_t i = 0; i < 8; i++) {
-	        if ((cmd.addr >> i) & 0x01) {
+	        if (((cmd.addr >> i) & 0x01) != 0) {
 	        	if(!capture_single_histogram(i))
 	        	{
 	    			uartResp->packet_type = OW_ERROR;
@@ -735,7 +736,7 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 			break;
 		}
 	    for (uint8_t i = 0; i < 8; i++) {
-	        if ((cmd.addr >> i) & 0x01) {
+	        if (((cmd.addr >> i) & 0x01) != 0) {
 	        	if(!get_single_histogram(i, uartResp->data, &uartResp->data_len))
 	        	{
 	        		uartResp->reserved &= ~(1 << i);
@@ -764,7 +765,7 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 			break;
 		}
 	    for (uint8_t i = 0; i < 8; i++) {
-	        if ((cmd.addr >> i) & 0x01) {
+	        if (((cmd.addr >> i) & 0x01) != 0) {
 	        	if(!configure_camera_testpattern(i,test_pattern))
 	        	{
 	    			uartResp->packet_type = OW_ERROR;
@@ -792,7 +793,7 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 
 
 	    for (uint8_t i = 0; i < 8; i++) {
-	        if ((cmd.addr >> i) & 0x01) {
+	        if (((cmd.addr >> i) & 0x01) != 0) {
 	        	// update camera status requested
 	        	camera_status[i] = get_camera_status(i);
 	        }
@@ -903,7 +904,7 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 		/* In fake data mode, cameras remain powered off; treat as no-op success */
 		if ((logging_get_debug_flags() & DEBUG_FLAG_FAKE_DATA) != 0u) {
 			for (uint8_t i = 0; i < 8; i++) {
-				if ((cmd.addr >> i) & 0x01) {
+				if (((cmd.addr >> i) & 0x01) != 0) {
 					camera_status[i] = 0x00;
 				}
 			}
@@ -928,7 +929,7 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 
 		/* 1) Enable power for all cameras in the mask */
 		for (uint8_t i = 0; i < 8; i++) {
-			if ((cmd.addr >> i) & 0x01) {
+			if (((cmd.addr >> i) & 0x01) != 0) {
 				if (!enable_camera_power(i)) {
 					uartResp->packet_type = OW_ERROR;
 					VERBOSE_CMD("Failed to power on camera %d\r\n", i);
@@ -964,7 +965,7 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 		/* In fake data mode, cameras are already powered off; treat as no-op success */
 		if ((logging_get_debug_flags() & DEBUG_FLAG_FAKE_DATA) != 0u) {
 			for (uint8_t i = 0; i < 8; i++) {
-				if ((cmd.addr >> i) & 0x01) {
+				if (((cmd.addr >> i) & 0x01) != 0) {
 					camera_status[i] = 0x00;
 				}
 			}
@@ -987,7 +988,7 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 		}
 		delay_ms(10); // Short delay to ensure FSIN_ext is fully disabled before power state changes
 	    for (uint8_t i = 0; i < 8; i++) {
-	        if ((cmd.addr >> i) & 0x01) {
+	        if (((cmd.addr >> i) & 0x01) != 0) {
 	        	if(!disable_camera_power(i))
 	        	{
 	    			uartResp->packet_type = OW_ERROR;
@@ -1190,7 +1191,7 @@ UartPacket process_if_command(UartPacket cmd)
 		for (int i = 0; i < cmd.data_len && i < 16; i++) {
 			VERBOSE_CMD("0x%02X ", cmd.data[i]);
 		}
-		if (cmd.data_len > 16) VERBOSE_CMD("... ");
+		if (cmd.data_len > 16) { VERBOSE_CMD("... "); }
 		VERBOSE_CMD("Len: %d\r\n", cmd.data_len);
 
 		uartReturn.command = OW_I2C_PASSTHRU;

--- a/Core/Src/if_factory_prog.c
+++ b/Core/Src/if_factory_prog.c
@@ -15,8 +15,8 @@ extern I2C_HandleTypeDef hi2c1;
 
 static uint8_t i2c_list[128] = {0};
 
-uint8_t i2c_write_buf[256] = {0};
-uint8_t i2c_read_buf[256] = {0};
+static uint8_t i2c_write_buf[256] = {0};
+static uint8_t i2c_read_buf[256] = {0};
 
 static int iRet;
 static uint32_t _creset_state = 0;

--- a/Core/Src/logging.c
+++ b/Core/Src/logging.c
@@ -12,16 +12,16 @@
 #include <stdint.h>
 
 static bool bInit_dma = false;
-volatile bool bPrintfTransferComplete = false;
+static volatile bool bPrintfTransferComplete = false;
 static volatile uint32_t debug_flags = 0x00000000;
 
 static uint8_t usart_start_tx_dma_transfer(void);
 static bool logging_uart_dma_write(const uint8_t *src, size_t count);
 
 /* Ring buffer for TX data */
-lwrb_t usart_tx_buff;
-uint8_t usart_tx_buff_data[1512];
-volatile size_t usart_tx_dma_current_len;
+static lwrb_t usart_tx_buff;
+static uint8_t usart_tx_buff_data[1512];
+static volatile size_t usart_tx_dma_current_len;
 static bool usart_drop_marker_pending = false;
 
 /* Ring buffer for accumulating printf messages to send over command and control endpoint */

--- a/Core/Src/motion_config.c
+++ b/Core/Src/motion_config.c
@@ -19,7 +19,7 @@ static uint16_t crc16_ccitt(const uint8_t *data, size_t len)
     for (size_t i = 0; i < len; i++) {
         crc ^= ((uint16_t)data[i] << 8);
         for (int b = 0; b < 8; b++) {
-            if (crc & 0x8000u) {
+            if ((crc & 0x8000u) != 0u) {
                 crc = (uint16_t)((crc << 1) ^ 0x1021u);
             } else {
                 crc <<= 1;

--- a/Core/Src/sensor_serial.c
+++ b/Core/Src/sensor_serial.c
@@ -36,9 +36,9 @@ static bool char_is_serial_ok(char c)
 
 static bool record_valid(const serial_record_t *rec)
 {
-    if (rec->magic != SERIAL_RECORD_MAGIC)         return false;
-    if (rec->version != SERIAL_RECORD_VERSION)     return false;
-    if (rec->len < 1 || rec->len > SERIAL_MAX_LEN)  return false;
+    if (rec->magic != SERIAL_RECORD_MAGIC)         { return false; }
+    if (rec->version != SERIAL_RECORD_VERSION)     { return false; }
+    if (rec->len < 1 || rec->len > SERIAL_MAX_LEN)  { return false; }
     uint16_t want = serial_crc16(rec, offsetof(serial_record_t, crc16));
     return rec->crc16 == want;
 }

--- a/Core/Src/system_monitor.c
+++ b/Core/Src/system_monitor.c
@@ -96,18 +96,18 @@ void system_monitor_capture_reset_cause(void)
     s_persist.boot_count++;
     s_persist.last_rcc_csr = rsr;
 
-    if (rsr & RCC_RSR_BORRSTF)   s_persist.bor_count++;
-    if (rsr & RCC_RSR_PORRSTF)   s_persist.por_count++;
-    if (rsr & RCC_RSR_PINRSTF)   s_persist.pin_count++;
-    if (rsr & RCC_RSR_SFTRSTF)   s_persist.sft_count++;
+    if (rsr & RCC_RSR_BORRSTF)   { s_persist.bor_count++; }
+    if (rsr & RCC_RSR_PORRSTF)   { s_persist.por_count++; }
+    if (rsr & RCC_RSR_PINRSTF)   { s_persist.pin_count++; }
+    if (rsr & RCC_RSR_SFTRSTF)   { s_persist.sft_count++; }
 #ifdef RCC_RSR_IWDG1RSTF
-    if (rsr & RCC_RSR_IWDG1RSTF) s_persist.iwdg_count++;
+    if (rsr & RCC_RSR_IWDG1RSTF) { s_persist.iwdg_count++; }
 #endif
 #ifdef RCC_RSR_WWDG1RSTF
-    if (rsr & RCC_RSR_WWDG1RSTF) s_persist.wwdg_count++;
+    if (rsr & RCC_RSR_WWDG1RSTF) { s_persist.wwdg_count++; }
 #endif
 #ifdef RCC_RSR_LPWRRSTF
-    if (rsr & RCC_RSR_LPWRRSTF)  s_persist.lpwr_count++;
+    if (rsr & RCC_RSR_LPWRRSTF)  { s_persist.lpwr_count++; }
 #endif
 }
 
@@ -129,7 +129,7 @@ void system_monitor_print_history(void)
                (unsigned long)s_persist.ecc_last_addr,
                (unsigned long)s_persist.ecc_last_monitor);
     }
-    if (s_persist.dma_err_count) {
+    if (s_persist.dma_err_count != 0u) {
         printf("DMA stats:  transfer-errors=%lu\r\n",
                (unsigned long)s_persist.dma_err_count);
     }
@@ -148,7 +148,7 @@ void system_monitor_ecc_enable(void)
     for (uint32_t i = 0; i < ECC_MON_COUNT; i++) {
         /* Drop any flags that latched during cold-boot reads of uninit RAM. */
         __HAL_RAMECC_CLEAR_FLAG(ecc_handles[i], RAMECC_FLAGS_ALL);
-        if (!ecc_enabled[i]) continue;
+        if (!ecc_enabled[i]) { continue; }
         (void)HAL_RAMECC_StartMonitor(ecc_handles[i]);
     }
 }
@@ -163,10 +163,10 @@ static uint32_t s_ecc_dbe_session;
 static void ecc_poll(void)
 {
     for (uint32_t i = 0; i < ECC_MON_COUNT; i++) {
-        if (!ecc_enabled[i]) continue;
+        if (!ecc_enabled[i]) { continue; }
         RAMECC_HandleTypeDef *h = ecc_handles[i];
         uint32_t sr = h->Instance->SR;
-        if (sr == 0u) continue;
+        if (sr == 0u) { continue; }
 
         uint32_t addr = HAL_RAMECC_GetFailingAddress(h);
         if (sr & RAMECC_SR_SEDCF) {
@@ -217,18 +217,18 @@ static void scan_dma_stream_bank(DMA_TypeDef *dma, bool high, uint8_t stream_bas
     volatile uint32_t * const isr = high ? &dma->HISR  : &dma->LISR;
     volatile uint32_t * const ifc = high ? &dma->HIFCR : &dma->LIFCR;
     uint32_t v = *isr;
-    if (v == 0u) return;
+    if (v == 0u) { return; }
 
     for (uint32_t s = 0; s < 4; s++) {
         uint32_t te = 1u << s_te_bit_lo[s];
         uint32_t fe = 1u << s_fe_bit_lo[s];
-        if (v & te) {
+        if ((v & te) != 0u) {
             s_persist.dma_err_count++;
             printf("[DMA] %s stream%lu transfer-error\r\n",
                    name, (unsigned long)(stream_base + s));
             *ifc = te;
         }
-        if (v & fe) {
+        if ((v & fe) != 0u) {
             /* FIFO errors are common during legitimate operation; only count,
              * don't spam. */
             *ifc = fe;
@@ -239,10 +239,10 @@ static void scan_dma_stream_bank(DMA_TypeDef *dma, bool high, uint8_t stream_bas
 static void scan_bdma(void)
 {
     uint32_t v = BDMA->ISR;
-    if (v == 0u) return;
+    if (v == 0u) { return; }
     for (uint32_t ch = 0; ch < 8; ch++) {
         uint32_t te = 1u << (3u + 4u * ch); /* TEIFx */
-        if (v & te) {
+        if ((v & te) != 0u) {
             s_persist.dma_err_count++;
             printf("[DMA] BDMA ch%lu transfer-error\r\n", (unsigned long)ch);
             BDMA->IFCR = te;
@@ -257,7 +257,7 @@ void system_monitor_poll(void)
     /* Periodic ECC and DMA error-flag scan */
     static uint32_t last_ms = 0;
     uint32_t now = HAL_GetTick();
-    if ((now - last_ms) < DMA_POLL_MS) return;
+    if ((now - last_ms) < DMA_POLL_MS) { return; }
     last_ms = now;
 
     ecc_poll();

--- a/Core/Src/uart_comms.c
+++ b/Core/Src/uart_comms.c
@@ -26,10 +26,10 @@ extern uint8_t rxBuffer[COMMAND_MAX_SIZE];
 extern uint8_t txBuffer[COMMAND_MAX_SIZE];
 extern DMA_HandleTypeDef hdma_memtomem_dma2_stream1;
 
-volatile uint32_t ptrReceive;
-volatile uint8_t rx_flag = 0; // start in idle state (0)
+static volatile uint32_t ptrReceive;
+static volatile uint8_t rx_flag = 0; // start in idle state (0)
 volatile uint8_t tx_flag = 1; // Start in idle state (1)
-const uint32_t zero_val = 0;
+static const uint32_t zero_val = 0;
 static uint8_t cmd_data_buf[COMMAND_MAX_SIZE];
 
 extern USBD_HandleTypeDef hUsbDeviceHS;
@@ -81,7 +81,7 @@ static void print_uart_packet(const UartPacket *pkt)
     printf("}\r\n");
 }
 
-void ClearBuffer_DMA(void)
+static void ClearBuffer_DMA(void)
 {
     // Clear using 32-bit writes (COMMAND_MAX_SIZE must be divisible by 4)
     HAL_DMA_Start(&hdma_memtomem_dma2_stream1,

--- a/Core/Src/utils.c
+++ b/Core/Src/utils.c
@@ -10,10 +10,10 @@
 #include "utils.h"
 #include <stdio.h>
 // testing crc calculations
-uint32_t startTime = 0, endTime = 0, duration = 0;
+static uint32_t startTime = 0, endTime = 0, duration = 0;
 
 // CRC16-ccitt lookup table
-const uint16_t crc16_tab[256] = {
+static const uint16_t crc16_tab[256] = {
 	0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50a5, 0x60c6, 0x70e7,
 	0x8108, 0x9129, 0xa14a, 0xb16b, 0xc18c, 0xd1ad, 0xe1ce, 0xf1ef,
 	0x1231, 0x0210, 0x3273, 0x2252, 0x52b5, 0x4294, 0x72f7, 0x62d6,
@@ -75,7 +75,7 @@ uint16_t util_hw_crc16(uint8_t* buf, uint32_t size)
 }
 
 void print_hex_buf(const char *label, uint8_t *buf, size_t len) {
-    if (label) printf("%s: ", label);
+    if (label != NULL) { printf("%s: ", label); }
     for (size_t i = 0; i < len; i++) {
         printf("%02X ", buf[i]);
     }
@@ -100,7 +100,7 @@ void delay_us(uint32_t us)
     uint32_t start = DWT->CYCCNT;
     uint32_t delay_cycles = us * cycles_per_us;
 
-    while ((DWT->CYCCNT - start) < delay_cycles);
+    while ((DWT->CYCCNT - start) < delay_cycles) { }
 }
 
 // get timestamp ms will grab the current timestamp in milliseconds as counted by tim5

--- a/USB/Class/COMMS/Inc/usbd_comms.h
+++ b/USB/Class/COMMS/Inc/usbd_comms.h
@@ -35,7 +35,7 @@ extern USBD_ClassTypeDef USBD_COMMS;
 uint8_t  USBD_COMMS_SetTxBuffer(USBD_HandleTypeDef *pdev, uint8_t  *pbuff, uint16_t length);
 uint8_t USBD_COMMS_SendData(USBD_HandleTypeDef *pdev, uint8_t *data, uint16_t len, uint8_t ep_idx);
 uint8_t USBD_COMMS_Transmit(USBD_HandleTypeDef *pdev, uint8_t* Buf, uint16_t Len);
-void USBD_COMMS_FlushRxBuffer();
+void USBD_COMMS_FlushRxBuffer(void);
 uint8_t USBD_COMMS_RegisterInterface(USBD_HandleTypeDef *pdev, uint8_t *buffer);
 uint8_t USBD_COMMS_RegisterRxCallback(void (*cb)(uint8_t *buf, uint16_t len));
 void USBD_COMMS_RxCpltCallback(uint8_t *Buf, uint32_t Len, uint8_t epnum);

--- a/USB/Class/COMMS/Src/usbd_comms.c
+++ b/USB/Class/COMMS/Src/usbd_comms.c
@@ -90,7 +90,7 @@ __ALIGN_BEGIN static uint8_t USBD_Comms_GetDeviceQualifierDescriptor[USB_LEN_DEV
 #endif /* USE_USBD_COMPOSITE  */
 
 extern uint8_t COMMS_InstID;
-uint8_t* pTxCommsBuff = 0;
+static uint8_t* pTxCommsBuff = 0;
 static uint16_t tx_comms_total_len = 0;
 static uint16_t tx_comms_ptr = 0;
 static __IO uint8_t comms_ep_enabled = 0;
@@ -190,7 +190,7 @@ static uint8_t USBD_Comms_DeInit(USBD_HandleTypeDef *pdev, uint8_t cfgidx)
   pdev->ep_in[COMMSInEpAdd & 0xFU].total_length = 0U;
   comms_ep_enabled = 0;
 
-  if(pTxCommsBuff){
+  if(pTxCommsBuff != NULL){
     pTxCommsBuff = 0;
   }
 
@@ -235,7 +235,7 @@ static uint8_t comms_queue_is_full(void)
 
 static uint8_t comms_queue_enqueue(uint8_t *data, uint16_t length)
 {
-  if (comms_queue_is_full()) {
+  if (comms_queue_is_full() != 0) {
     printf("COMMS enqueue fail: queue full (count=%u size=%u enq=%lu deq=%lu datain=%lu txfail=%lu)\r\n",
            comms_queue_count, (uint8_t)COMMS_QUEUE_SIZE,
            (unsigned long)comms_enq_count,
@@ -263,7 +263,7 @@ static uint8_t comms_queue_enqueue(uint8_t *data, uint16_t length)
 
 static uint8_t comms_queue_dequeue(uint8_t **data, uint16_t *length)
 {
-  if (comms_queue_is_empty()) {
+  if (comms_queue_is_empty() != 0) {
     return USBD_FAIL;
   }
 
@@ -286,7 +286,7 @@ static uint8_t comms_process_queue(void)
     return USBD_FAIL;
   }
 
-  if (comms_queue_is_empty()) {
+  if (comms_queue_is_empty() != 0) {
     return USBD_OK;
   }
 

--- a/USB/Class/HISTO/Src/usbd_histo.c
+++ b/USB/Class/HISTO/Src/usbd_histo.c
@@ -91,7 +91,7 @@ __ALIGN_BEGIN static uint8_t USBD_Histo_GetDeviceQualifierDescriptor[USB_LEN_DEV
 #endif /* USE_USBD_COMPOSITE  */
 
 extern uint8_t HISTO_InstID;
-uint8_t* pTxHistoBuff = 0;
+static uint8_t* pTxHistoBuff = 0;
 static uint16_t tx_histo_total_len = 0;
 static uint16_t tx_histo_ptr = 0;
 static __IO uint8_t histo_ep_enabled = 0;
@@ -172,7 +172,7 @@ static uint8_t USBD_Histo_DeInit(USBD_HandleTypeDef *pdev, uint8_t cfgidx)
   pdev->ep_in[HISTOInEpAdd & 0xFU].total_length = 0U;
   histo_ep_enabled = 0;
 
-  if(pTxHistoBuff){
+  if(pTxHistoBuff != NULL){
     pTxHistoBuff = 0;
   }
 
@@ -218,7 +218,7 @@ static uint8_t histo_queue_is_full(void)
 
 static uint8_t histo_queue_enqueue(uint8_t *data, uint16_t length)
 {
-  if (histo_queue_is_full()) {
+  if (histo_queue_is_full() != 0) {
     printf("HISTO enqueue fail: queue full (count=%u size=%u enq=%lu deq=%lu datain=%lu txfail=%lu)\r\n",
            histo_queue_count, (uint8_t)HISTO_QUEUE_SIZE,
            (unsigned long)histo_enq_count,
@@ -248,7 +248,7 @@ static uint8_t histo_queue_enqueue(uint8_t *data, uint16_t length)
 
 static uint8_t histo_queue_dequeue(uint8_t **data, uint16_t *length)
 {
-  if (histo_queue_is_empty()) {
+  if (histo_queue_is_empty() != 0) {
     return USBD_FAIL;
   }
 
@@ -272,7 +272,7 @@ static uint8_t histo_process_queue(void)
     return USBD_FAIL;
   }
 
-  if (histo_queue_is_empty()) {
+  if (histo_queue_is_empty() != 0) {
     return USBD_OK;
   }
 
@@ -436,7 +436,7 @@ uint8_t  USBD_HISTO_SetTxBuffer(USBD_HandleTypeDef *pdev, uint8_t  *pbuff, uint1
   return ret;
 }
 
-uint8_t USBD_HISTO_RegisterInterface(USBD_HandleTypeDef *pdev, uint8_t *buffer)
+static uint8_t USBD_HISTO_RegisterInterface(USBD_HandleTypeDef *pdev, uint8_t *buffer)
 {
   UNUSED(pdev);
   UNUSED(buffer);

--- a/docs/misra-deviations.md
+++ b/docs/misra-deviations.md
@@ -1,0 +1,53 @@
+# MISRA C:2012 — Audit Scope & Deviations
+
+Partial MISRA C:2012 conformance effort for the sensor firmware. Detection: cppcheck 2.17
+MISRA addon. This document records what was audited, what was fixed, and what is intentionally
+deviated.
+
+## Scope — project-authored code only
+
+ST-provided and third-party code is **out of scope** (we do not modify code we don't own):
+
+- **ST / CubeMX / vendor:** `main.c`, `main.h`, `stm32h7xx_*`, `system_stm32h7xx.c`, `syscalls.c`,
+  `sysmem.c`, the STM32 HAL/CMSIS drivers (`Drivers/`), and the ST USB Device Library
+  (`USB/Core/`, `USB/Class/CompositeBuilder/`, `usbd_imu.c` — retains the ST template header).
+- **Third-party libraries:** `jsmn.c` (JSON parser), `lwrb.c` (ring buffer).
+
+## Fixes applied (safe, behavior-preserving)
+
+Branch `chore/misra-safe-fixes`. Result: project-owned in-scope findings **225 → 21**; the whole
+firmware **compiles and links at `-Os`** (`cmake --build --preset Release`).
+
+| Rule | Fix | Notes |
+|---|---|---|
+| 15.6 | braces on every single-statement control body | 105 → 0 |
+| 8.2  | parameterless prototypes `()` → `(void)`; unnamed params named | |
+| 8.4  | file-local objects/functions made `static` | grep-verified single-TU usage only |
+| 14.4 | non-boolean controlling expressions made explicit | `!= NULL` for pointers, `!= 0` for ints |
+| 7.2  | `U` suffix on unsigned literals | |
+
+## Deviations (intentionally NOT fixed)
+
+- **Rule 21.6 (`<stdio.h>`)** — `printf` is the firmware's logging transport over UART/USB;
+  pervasive and intentional. Not removed.
+- **Rule 17.7 (unused return value)** — 534 instances, predominantly `(void)`-less
+  `printf` / `memcpy` / `snprintf` / HAL calls. Deviated by decision; not mass-cast in this pass.
+- **Rule 21.1 (reserved identifiers)** — flagged on identifier/macro forms in project headers; deviated.
+- **Advisory / structural rules** — 15.5 (single point of exit), 12.1 (parenthesisation),
+  10.x (essential-type conversions), 11.x (pointer casts): out of scope for this safe-mechanical
+  pass; they require per-site behavioral review and were excluded given no hardware test access.
+
+## Remaining in-scope findings (21) — why not fixed
+
+- **8.4 ×10** — cross-TU symbols referenced from other translation units (HAL weak-callback
+  overrides `HAL_I2C_MasterTxCpltCallback` / `…RxCpltCallback` / `…ErrorCallback`; globals
+  `tx_flag`, `imu_frame_counter`, `frame_id`, etc.). Cannot be made `static` without adding
+  shared-header declarations — out of scope to avoid churn/conflicts.
+- **8.2 ×8** — header prototypes were fixed to `(void)`, but the matching function *definitions*
+  in the corresponding `.c` still use `()`. Compatible and harmless (the firmware links); the
+  definitions were not in the fed finding set and were left untouched.
+- **14.4 ×1, 7.2 ×2** — individually skipped (false positive / not safe-confirmed).
+
+## Status
+
+Verified by full build+link at `-Os`. **NOT yet tested on hardware.**


### PR DESCRIPTION
Behavior-preserving MISRA C:2012 cleanup of **project-authored code only** (ST/CubeMX/HAL/CMSIS, the ST USB library, and third-party `jsmn`/`lwrb` are out of scope). Detection: cppcheck 2.17 MISRA addon.

**Result:** project-owned in-scope findings **225 → 21**; the whole firmware **compiles and links at `-Os`** (`cmake --build --preset Release`).

**Rules fixed**
- `15.6` braces on all single-statement control bodies (105 → 0)
- `8.2` parameterless prototypes `()` → `(void)`; unnamed params named
- `8.4` file-local objects/functions made `static` (grep-verified single-TU usage)
- `14.4` non-boolean controlling expressions made explicit (`!= NULL` / `!= 0`)
- `7.2` `U` suffix on unsigned literals

**Deviations** (see `docs/misra-deviations.md`): `21.6`/printf (logging transport), `17.7` unused-return (534, mostly `(void)printf`), and advisory/structural rules (`15.5`, `12.1`, `10.x`, `11.x`). The 21 remaining are cross-TU `8.4` symbols (can't `static` without shared-header decls) and partial header-only `8.2`.

Not yet hardware-tested; the `static` linkage changes are specifically de-risked by the clean full link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)