### PR TITLE
ci: build Release for rc/release tags, Debug for dev/branches

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -25,6 +25,31 @@ jobs:
           fetch-depth: 0        # full history so git-describe works
           fetch-tags: true       # ensure all tags are present
       # ---------------------------
+      # Determine build config from the ref:
+      #   *-dev.* tag            -> Debug   (development pre-release)
+      #   *-rc.* / X.Y.Z tag     -> Release (release candidate / final release)
+      #   branch push / dispatch -> Debug
+      # ---------------------------
+      - name: Determine build config
+        id: cfg
+        run: |
+          if [ "$GITHUB_EVENT_NAME" = "release" ]; then
+            TAG_NAME=$(python3 -c "import json;print(json.load(open('$GITHUB_EVENT_PATH'))['release']['tag_name'])")
+            IS_TAG=1
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            TAG_NAME="$GITHUB_REF_NAME"; IS_TAG=1
+          else
+            TAG_NAME="$GITHUB_REF_NAME"; IS_TAG=0
+          fi
+          if [ "$IS_TAG" = "1" ] && [[ "$TAG_NAME" != *-dev.* ]]; then
+            CONFIG=Release
+          else
+            CONFIG=Debug
+          fi
+          echo "config=$CONFIG" >> "$GITHUB_OUTPUT"
+          echo "ref='$GITHUB_REF' event='$GITHUB_EVENT_NAME' tag='$TAG_NAME' -> build config: $CONFIG"
+
+      # ---------------------------
       # Build Firmware
       # ---------------------------
       - name: Pull build image
@@ -37,7 +62,7 @@ jobs:
             -w /workspace \
             --workdir /workspace \
             ghcr.io/openwaterhealth/stm32-build-env:latest \
-            bash -lc "git config --global --add safe.directory /workspace || true; cmake --preset Debug && cmake --build build/Debug --config Debug --target all -j 10"
+            bash -lc "git config --global --add safe.directory /workspace || true; cmake --preset ${{ steps.cfg.outputs.config }} && cmake --build build/${{ steps.cfg.outputs.config }} --config ${{ steps.cfg.outputs.config }} --target all -j 10"
 
       # ---------------------------
       # Upload Firmware
@@ -47,8 +72,8 @@ jobs:
         with:
           name: motion-sensor-fw
           path: |
-            build/Debug/*.hex
-            build/Debug/*.bin
+            build/${{ steps.cfg.outputs.config }}/*.hex
+            build/${{ steps.cfg.outputs.config }}/*.bin
 
 
       # ---------------------------
@@ -114,6 +139,7 @@ jobs:
           echo "---" >> notes.md
           echo "**Build SHA:** \`${{ steps.buildmeta.outputs.sha }}\`" >> notes.md
           echo "**Build Time:** ${{ steps.buildmeta.outputs.datetime }}" >> notes.md
+          echo "**Build Config:** ${{ steps.cfg.outputs.config }}" >> notes.md
 
       - name: Create GitHub Release
         if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'release'
@@ -126,6 +152,6 @@ jobs:
           name: ${{ github.ref_name }}
           body_path: notes.md
           files: |
-            build/Debug/*.hex
-            build/Debug/*.bin
+            build/${{ steps.cfg.outputs.config }}/*.hex
+            build/${{ steps.cfg.outputs.config }}/*.bin
 


### PR DESCRIPTION
Makes the firmware CI pick the compiler build config from the ref, now that the `-Os` boot HardFault is fixed (`ram_scrub` asm seed, #61) so Release is safe to ship:

| Ref | Config |
|---|---|
| `*-rc.*` tag | **Release** |
| final `X.Y.Z` tag | **Release** |
| `*-dev.*` tag | **Debug** |
| push to `next`/`main`, manual run | **Debug** |

A new **Determine build config** step derives the config from the ref (`Release` only for a tag that isn't `-dev.`, else `Debug`); the build command, artifact paths, release files, and release notes all reference it. YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)