### PR TITLE
fix: DFU enter broken on next — SRAM ECC seed wiped the boot marker

### DIFF
--- a/startup_stm32h743xx.s
+++ b/startup_stm32h743xx.s
@@ -115,17 +115,29 @@ Reset_Handler:
   strd  r2, r3, [r0], #8
   cmp   r0, r1
   blo   5b
+/* NOTE: SRAM4 (D3) is deliberately NOT seeded here. CheckBootloaderFlag()
+   (the first thing SystemInit does) reads the "enter DFU" magic 0xDEADBEEF at
+   0x38000000, which is written before NVIC_SystemReset() and survives the
+   reset. Zeroing SRAM4 before that check silently swallows the DFU request.
+   SRAM4 is seeded just after SystemInit instead (see below). */
+
+/* Call the ExitRun0Mode function to configure the power supply */
+  bl  ExitRun0Mode
+/* Call the clock system initialization function.*/
+  bl  SystemInit
+
+/* Seed SRAM4 (D3) now that CheckBootloaderFlag() has consumed the DFU marker.
+   r2/r3 were clobbered by the C calls above, so re-zero them. Register-only,
+   touches only SRAM4 (not the stack). On a DFU boot CheckBootloaderFlag() jumps
+   to the ROM bootloader and never returns, so this is simply skipped. */
+  movs  r2, #0
+  movs  r3, #0
   ldr   r0, =0x38000000          /* SRAM4   64 KB @ 0x38000000 (D3) */
   ldr   r1, =0x38010000
 6:
   strd  r2, r3, [r0], #8
   cmp   r0, r1
   blo   6b
-
-/* Call the ExitRun0Mode function to configure the power supply */
-  bl  ExitRun0Mode
-/* Call the clock system initialization function.*/
-  bl  SystemInit
 
 /* Copy the data segment initializers from flash to SRAM */
   ldr r0, =_sdata


### PR DESCRIPTION
**Regression from #61.** On `next`/`1.8.0-rc.1`, telling the device to enter DFU does nothing — it just resets back into the app.

## Root cause
DFU-entry is reset-based: `OW_CMD_DFU` writes `0xDEADBEEF` to **`0x38000000` (SRAM4)** and resets; on the next boot `CheckBootloaderFlag()` (first thing in `SystemInit`) reads that marker and jumps to the ROM bootloader.

PR #61 moved the SRAM ECC seed to the **top of `Reset_Handler`** (before any C stack use, per the ram_scrub fix). That seed zeroes **SRAM4** — so it **wiped the `0xDEADBEEF` marker before `SystemInit` could read it**. Old code seeded SRAM4 *after* `SystemInit`, so the marker survived. Deterministic; confirmed on hardware.

## Fix
Move **only the SRAM4 seed** to just after `bl SystemInit` (after `CheckBootloaderFlag` consumes the marker). RAM_D1 (the stack) and the other banks stay seeded early, so George's "seed before C stack use" invariant is preserved — SRAM4 holds no stack. On a real DFU boot `CheckBootloaderFlag` jumps away and never returns, so the SRAM4 seed is simply skipped.

## Verification (hardware, right sensor, SWD)
| | `enter_dfu()` |
|---|---|
| before fix (`1.8.0-rc.1`) | 0 DFU devices — reset to app |
| after fix | sensor enumerates as `0483:DF11` (DFU in FS Mode) ✅ |

## Note (separate, pre-existing — not this PR)
`system_monitor`'s `.noinit` persistent counters live in **RAM_D1**, which *both* the old and new ram_scrub zero before `main`. So those "survive-reset" counters have never actually survived a reset — a latent bug unrelated to #61. Worth a follow-up if you rely on them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)