### PR TITLE
fix: flush camera receive buffer at scan start (#172)

### DIFF
--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -2062,6 +2062,20 @@ _Bool enable_camera_stream(uint8_t cam_id){
 	event_bits &= ~(1u << cam_id);
 	__enable_irq();
 
+	/* Flush this camera's receive buffer before arming DMA. The FPGA is
+	 * re-programmed at every scan start (its frame counter resets to 1), but
+	 * the MCU's frame_buffer/spi6_buffer still holds the PREVIOUS scan's last
+	 * DMA'd frame — old FPGA frame_id and timestamp. If a send fires before
+	 * the first fresh DMA completes, that stale frame ships ahead of frame 1,
+	 * desyncing the host's frame-id unwrap and dark schedule (issue #172:
+	 * left-sensor "stale 255/173 with negative timestamps at scan start").
+	 * Zeroing it makes any premature send an obvious empty frame, not stale
+	 * data. capture_single_histogram() clears the buffer the same way. */
+	if (cam->pRecieveHistoBuffer != NULL) {
+		memset((uint8_t *)cam->pRecieveHistoBuffer, 0,
+			cam->useUsart ? USART_PACKET_LENGTH : SPI_PACKET_LENGTH);
+	}
+
 	/* Arm DMA BEFORE stream_on so the receiver is ready when the sensor
 	 * starts clocking data.  Arming after stream_on causes an immediate SPI
 	 * overrun on fast cameras (e.g. SPI4 / cam 8). */


### PR DESCRIPTION
## Problem
On the left sensor of the unit in OpenwaterHealth/openmotion-bloodflow-app#172 / OpenwaterHealth/openmotion-bloodflow-app#183, raw captures show **stale frames at scan start** — frame_ids `255`, `173` with *negative* timestamps appearing ahead of frame 1 — and a mid-scan counter blip. These desync the host's frame-id unwrap and the positional dark-frame schedule, so the "dark" reference lands on a laser-on frame and dark correction is poisoned (garbage BFI/BVI, contaminated dark, calibration aborts).

## Root cause
The FPGA is re-programmed at every scan start (its frame counter resets to 1), but the MCU's `frame_buffer`/`spi6_buffer` still holds the **previous scan's last DMA'd frame** — old frame_id + timestamp. `enable_camera_stream()` cleared the event bit but never flushed the buffer, so if a send fired before the first fresh DMA completed, that stale frame shipped ahead of frame 1.

## Fix
Zero the camera's receive buffer in `enable_camera_stream()` before arming DMA. Any premature send then ships an obvious empty frame instead of stale data. (`capture_single_histogram()` already clears the buffer the same way.) 14 lines, guarded on `pRecieveHistoBuffer != NULL`.

## Verification status (please read)
- ✅ Builds Debug; flashed both sensors; back-to-back scans on a **non-repro bench** stream clean (frame_ids monotonic from 1, no negative timestamps, warmup=9). No regression.
- ⚠️ **Efficacy on the bug itself is NOT yet confirmed** — the available bench does not reproduce the stale-frame condition even on stock `next` (10 scans clean), so this couldn't be shown as a true before/after. It needs the unit that reproduces OpenwaterHealth/openmotion-bloodflow-app#172. A repro/verify kit is being handed off for that unit.
- The companion SDK change (OpenwaterHealth/openmotion-sdk, frame-unwrap robustness) is the verified, fleet-wide safety net and neutralizes the host-side symptom regardless of firmware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
