### PR TITLE
fix: pulse-matched camera exposure (122 to 72 rows / 648 us) + clear test-pattern reg in config table

### DIFF
--- a/Core/Inc/X02C1B_Sensor_Config.h
+++ b/Core/Inc/X02C1B_Sensor_Config.h
@@ -726,18 +726,18 @@ static struct regval_list X02C1B_SENSOR_CONFIG[] = {
 		{0x380f, 0xD0},
 		{0x386d, 0x09},
 		{0x386e, 0x04},
-		/* Exposure 70 rows = 630 us. The measured optical laser pulse is
-		 * 494 us regardless of the console gate width (fully captured at
-		 * >= 528 us of exposure; knee measured per-camera on both modules,
-		 * plus delay sweeps at 500 us and 600 us gates, 2026-07-02 drift
-		 * campaign). The previous 122 rows (1098 us) integrated ~570 us of
-		 * pure dark current past the pulse, doubling the gain-scaled
-		 * black-level drift for zero extra signal. 70 rows keeps ~136 us of
-		 * total timing slack (vs 64 us at the 62-row alternative) while
-		 * still cutting the dark-current integral 1.74x. LaserPulseDelayUsec
-		 * stays 100 (measured plateau center). */
+		/* Exposure 72 rows = 648 us (bench decision: ~650 us). The measured
+		 * optical laser pulse is 494 us regardless of the console gate width
+		 * (per-camera exposure staircase + delay sweeps at 500 us and 600 us
+		 * gates, 2026-07-02 drift campaign; capture knee at 528 us,
+		 * LaserPulseDelayUsec=100 = measured plateau center). The previous
+		 * 122 rows (1098 us) integrated ~570 us of pure dark current past
+		 * the pulse, doubling the gain-scaled black-level drift that shows
+		 * up as camera-to-camera image-mean divergence, for zero extra
+		 * signal. 72 rows keeps ~154 us of timing slack and cuts the
+		 * dark-current integral 1.7x. */
 		{0x3501, 0x00},
-		{0x3502, 0x46},
+		{0x3502, 0x48},
 		{0x3823, 0x20},
 		{0x382e, 0x03},
 		{0x3861, 0x00},

--- a/Core/Inc/X02C1B_Sensor_Config.h
+++ b/Core/Inc/X02C1B_Sensor_Config.h
@@ -726,15 +726,18 @@ static struct regval_list X02C1B_SENSOR_CONFIG[] = {
 		{0x380f, 0xD0},
 		{0x386d, 0x09},
 		{0x386e, 0x04},
-		/* Exposure 62 rows = 558 us. The measured optical laser pulse is
-		 * 494 us (fully captured at >= 528 us of exposure; knee measured
-		 * per-camera on both modules, 2026-07-02 drift campaign). The
-		 * previous 122 rows (1098 us) integrated ~570 us of pure dark
-		 * current past the pulse, doubling the gain-scaled black-level
-		 * drift for zero extra signal. 62 rows keeps ~30 us of margin at
-		 * both pulse edges with no laser timing change. */
+		/* Exposure 70 rows = 630 us. The measured optical laser pulse is
+		 * 494 us regardless of the console gate width (fully captured at
+		 * >= 528 us of exposure; knee measured per-camera on both modules,
+		 * plus delay sweeps at 500 us and 600 us gates, 2026-07-02 drift
+		 * campaign). The previous 122 rows (1098 us) integrated ~570 us of
+		 * pure dark current past the pulse, doubling the gain-scaled
+		 * black-level drift for zero extra signal. 70 rows keeps ~136 us of
+		 * total timing slack (vs 64 us at the 62-row alternative) while
+		 * still cutting the dark-current integral 1.74x. LaserPulseDelayUsec
+		 * stays 100 (measured plateau center). */
 		{0x3501, 0x00},
-		{0x3502, 0x3e},
+		{0x3502, 0x46},
 		{0x3823, 0x20},
 		{0x382e, 0x03},
 		{0x3861, 0x00},

--- a/Core/Inc/X02C1B_Sensor_Config.h
+++ b/Core/Inc/X02C1B_Sensor_Config.h
@@ -726,8 +726,15 @@ static struct regval_list X02C1B_SENSOR_CONFIG[] = {
 		{0x380f, 0xD0},
 		{0x386d, 0x09},
 		{0x386e, 0x04},
+		/* Exposure 62 rows = 558 us. The measured optical laser pulse is
+		 * 494 us (fully captured at >= 528 us of exposure; knee measured
+		 * per-camera on both modules, 2026-07-02 drift campaign). The
+		 * previous 122 rows (1098 us) integrated ~570 us of pure dark
+		 * current past the pulse, doubling the gain-scaled black-level
+		 * drift for zero extra signal. 62 rows keeps ~30 us of margin at
+		 * both pulse edges with no laser timing change. */
 		{0x3501, 0x00},
-		{0x3502, 0x7a},
+		{0x3502, 0x3e},
 		{0x3823, 0x20},
 		{0x382e, 0x03},
 		{0x3861, 0x00},
@@ -738,6 +745,12 @@ static struct regval_list X02C1B_SENSOR_CONFIG[] = {
 		{0x3883, 0xd0},
 		{0x3880, 0x05},
 		{0x4800, 0x14},
+		/* Always leave test-pattern mode: 0x5100 was previously absent
+		 * from this table, and OW_CAMERA_SET_CONFIG skips cameras it
+		 * considers already configured — so a camera left in test-pattern
+		 * mode by tooling kept streaming synthetic data through later
+		 * scans while looking healthy. */
+		{0x5100, 0x00},
 };
 
 #endif /* INC_X02C1B_SENSOR_CONFIG_H_ */


### PR DESCRIPTION
## What

Two changes to `X02C1B_SENSOR_CONFIG` (from the overnight camera-drift campaign, 2026-07-01/02, run on the production bench system):

1. **Exposure 122 rows (1098 us) -> 70 rows (630 us)** (`0x3502: 0x7a -> 0x46`) — updated from the 62-row draft after the bench decision + a second sweep at a 600 us console gate
2. **Append `{0x5100, 0x00}`** — always leave test-pattern mode on (re)configure

## Why

**Exposure:** the optical laser pulse was measured at **494 us** (per-camera exposure staircase, both modules agree within 0.5%; full capture at >=528 us). A second delay sweep at a 600 us console gate confirmed the pulse is driver-shaped at ~494 us independent of gate width (PDC-equal pulse energy at both gates), so wider gates buy nothing. The deployed 1098 us exposure integrated ~570 us of pure dark current after the pulse ended — doubling the gain-scaled black-level drift that appears as camera-to-camera image-mean divergence on static phantoms, for zero extra signal. 70 rows keeps ~136 us of total timing slack (double the 62-row draft's margin at nearly the same dark-current cut, 1.74x vs 1.97x) and needs **no laser timing change** — LaserPulseDelayUsec stays 100, the measured plateau center at both gate widths.

Validated on hardware:

- Signal parity: 0.98-1.02x vs 122 rows measured at the 62-row window, all 16 cameras, live phantom; the 70-row window strictly contains it (staircase point at 70 rows read 0.995-0.999)
- Paired A/B (treated vs control cameras, same scan): pedestal drift on treated cameras drops to 0.51-0.62x — matching the predicted 62/122 exposure ratio
- Full-map validation, 20-min scans @40 Hz: camera-to-camera residual drift <1% (dark: 0.99%/0.83% worst per module; light: 0.88%/0.80%)

Ruled out by paired hardware A/Bs (all null within the +/-0.3% noise floor): DC-BLC on/off, DC-BLC kcoef, OB median filter. Digital path is bit-exact (test-pattern scan: 0.000% drift over 20 min). The remaining equilibrium drift is optical (light redistributes across the module under thermal settling, module total conserved) — not addressable in camera registers.

**Test-pattern clear:** `OW_CAMERA_SET_CONFIG` skips cameras it considers already configured, so a camera left in test-pattern mode by tooling keeps streaming synthetic data through subsequent scans while looking healthy (bit us twice tonight). Clearing `0x5100` in the table closes the hole whenever a camera IS re-initialized. The skip behavior itself (sentinel register values survive a full reconfigure until camera power-cycle) is worth a follow-up discussion — as is a related find: after a thermal latch + revive, a camera streams frames with its TPM readout frozen at a stale value (this explains historical reports of cameras "dying below 110C"; clean-telemetry deaths cluster at 113-117C die temp, n=10).

Full evidence: `C:\Users\ethan\Projects\camera-drift-campaign\` (journal.md chronology, docs/report.md summary, experiments/ data+plots, data/thermal_deaths.csv).

## Testing

- 20 hardware experiments overnight on the production bench (both sensor modules on static phantoms)
- Not yet flashed as firmware — all validation was done via runtime register writes of the identical values; a Debug-config build + HIL pass on this branch is the remaining step

🤖 Generated with [Claude Code](https://claude.com/claude-code)
