### PR TITLE
fix: schedule camera temp polls + thermal-latch recovery off HAL_GetTick (#73)

### DIFF
--- a/Core/Inc/camera_manager.h
+++ b/Core/Inc/camera_manager.h
@@ -46,7 +46,7 @@ typedef struct {
 	 * thermal shutdown etc.); cleared when program_fpga() completes a real
 	 * bring-up or the host explicitly powers the camera off. */
 	bool		needs_recovery;
-	uint32_t	recovery_repower_at;	/* get_timestamp_ms() deadline to re-power the rail */
+	uint32_t	recovery_repower_at;	/* HAL_GetTick() deadline to re-power the rail */
 } CameraDevice;
 
 #define CAMERA_COUNT	8

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -1100,9 +1100,13 @@ _Bool configure_camera_testpattern(uint8_t cam_id, uint8_t test_pattern)
 
 static void poll_camera_temperatures(void)
 {
-    uint32_t now = get_timestamp_ms();
+    /* HAL_GetTick(), NOT get_timestamp_ms(): the TIM5-derived clock wraps at
+     * 2^32/100 ms (~11.93 h of uptime), so deadlines scheduled on it freeze
+     * this gate for hours — or forever, if scheduled within the last poll
+     * interval before the wrap (#73). */
+    uint32_t now = HAL_GetTick();
 
-    if ((next_temp_ms == 0u) || (now >= next_temp_ms))
+    if ((int32_t)(now - next_temp_ms) >= 0)
     {
         /* Schedule from current time to keep a constant cadence without catch-up bursts. */
         next_temp_ms = now + CAM_TEMP_POLL_INTERVAL_MS;
@@ -1197,7 +1201,9 @@ static void camera_death_isolate(uint8_t cam_id)
     cam->isProgrammed = false;
     cam->isConfigured = false;
     cam->streaming_enabled = false;
-    cam->recovery_repower_at = get_timestamp_ms() + CAMERA_RECOVERY_OFF_MS;
+    /* HAL_GetTick(), NOT get_timestamp_ms(): the TIM5-derived clock wraps at
+     * ~11.93 h, which stretched this 10 s cool-off into hours (#73). */
+    cam->recovery_repower_at = HAL_GetTick() + CAMERA_RECOVERY_OFF_MS;
 
     printf("Camera %d: rail off for %u ms (regulator cool-off)\r\n",
            cam_id + 1, (unsigned)CAMERA_RECOVERY_OFF_MS);
@@ -1210,7 +1216,7 @@ static void camera_death_isolate(uint8_t cam_id)
  * bring-up at the next scan. Main-loop only. */
 static void camera_recovery_tick(void)
 {
-    uint32_t now = get_timestamp_ms();
+    uint32_t now = HAL_GetTick();  /* must match camera_death_isolate's timebase */
 
     for (uint8_t cam_id = 0; cam_id < CAMERA_COUNT; cam_id++) {
         CameraDevice *cam = &cam_array[cam_id];
@@ -1361,10 +1367,12 @@ _Bool capture_single_histogram(uint8_t cam_id)
 	HAL_GPIO_WritePin(FSIN_GPIO_Port, FSIN_Pin, GPIO_PIN_RESET);
 	delay_ms(2);
 
-	uint32_t timeout = get_timestamp_ms() + 5000; // 100ms timeout example
+	/* HAL_GetTick() + wrap-safe compare: a get_timestamp_ms() deadline set
+	 * within 5 s of its ~11.93 h wrap is unreachable → infinite loop (#73). */
+	uint32_t timeout = HAL_GetTick() + 5000;
 
 	while(!event_bits) {
-	    if (get_timestamp_ms() > timeout) {
+	    if ((int32_t)(HAL_GetTick() - timeout) >= 0) {
 	        printf("HISTO receive timeout!\r\n");
 	        if(cam->useUsart) {
 	            HAL_DMA_Abort(cam->pUart->hdmarx); // safely abort DMA

--- a/Core/Src/utils.c
+++ b/Core/Src/utils.c
@@ -103,7 +103,13 @@ void delay_us(uint32_t us)
     while ((DWT->CYCCNT - start) < delay_cycles) { }
 }
 
-// get timestamp ms will grab the current timestamp in milliseconds as counted by tim5
+/* Frame/scan timestamp in ms, counted by free-running TIM5 (100 kHz).
+ * WARNING: wraps at 2^32/100 ms ≈ 11.93 h of uptime — NOT at 2^32 ms — so:
+ * (a) never schedule deadlines on this clock; use HAL_GetTick() instead (#73);
+ * (b) the host SDK unwraps histogram-frame timestamps assuming exactly this
+ *     period (MotionProcessing._TIMESTAMP_ROLLOVER_S = 2^32/100/1000 s) —
+ *     changing this timebase breaks host-side unwrapping unless the SDK
+ *     constant changes in lockstep. */
 uint32_t get_timestamp_ms(void)
 {
     uint32_t timestamp = TIM5->CNT/100;


### PR DESCRIPTION
Fixes #73.

## Root cause (corrects the issue text)

`get_timestamp_ms()` returns `TIM5->CNT / 100`. TIM5 free-runs from boot and is **never reset** by firmware — the issue's "resets at scan start" framing was wrong. The actual hazard: the derived ms value wraps at `2^32 / 100` = **42,949,672 ms ≈ 11.93 h of uptime**, not at 2^32. That breaks every deadline scheduled on it:

1. **Temp-poll gate** (`poll_camera_temperatures`): `now >= next_temp_ms` is not wrap-safe. After the wrap, polls freeze for up to another ~11.9 h — and a deadline scheduled within the last poll interval *before* the wrap exceeds any value the clock can ever produce → **frozen until reboot**. This is the whole-scan `cam_temp[]` freeze from the 2026-07-01/02 drift campaign (the bench crossed 11.93 h uptime right around when freezes appeared; direct TPM register reads stayed live).
2. **Thermal-latch recovery** (`camera_death_isolate` / `camera_recovery_tick`): the `(int32_t)(now - deadline)` idiom is only wrap-safe for a full 2^32 wrap, so the 10 s cool-off (`CAMERA_RECOVERY_OFF_MS`) stretched to hours near the wrap.
3. **Same class, same file** (`capture_single_histogram`): `if (now > timeout)` with a timeout set <5 s before the wrap is unreachable → the `while(!event_bits)` wait can spin forever.

## Change

All three schedulers now use `HAL_GetTick()` (TIM17-driven `uwTick`: monotonic uint32 ms, wraps at the full 2^32 where the int32 idiom is sound; precedent in `main.c` / `system_monitor.c`) with wrap-safe compares. The temp-poll gate's `next_temp_ms == 0` bootstrap case is dropped — the int32 compare self-starts from the zero-initialized static.

**Untouched:** `fsin_timestamp_ms` / frame timestamps stay on TIM5 — that's the host-facing frame timebase. `check_streaming`'s existing `current_time < most_recent` guard already happens to protect its wrap case.

## SDK compatibility (verified)

The SDK's timestamp unwrapper (`omotion/MotionProcessing.py`, `_TIMESTAMP_ROLLOVER_S = 2**32/100/1000`) hard-codes exactly the TIM5-derived wrap period and unwraps the histogram-frame timestamp in both streaming consumers (backward jump > half period → add one period). This PR is compatible by construction:

- Frame timestamps stay on `get_timestamp_ms()`, so the wire wrap period is unchanged and the SDK constant still matches. (Moving frame timestamps to `HAL_GetTick()` would change the wire wrap to 2^32 ms while the SDK adds 42,949.67 s per detected wrap — silently corrupting unwrapped timestamps. `get_timestamp_ms()` now carries a warning comment documenting this coupling.)
- Nothing this PR touches is host-visible: `next_temp_ms`, `recovery_repower_at`, and the `capture_single_histogram` timeout are internal scheduling state, never serialized. `cam_temp[]` wire semantics are unchanged — it just updates when it's supposed to now.

**Deferred (follow-up per issue discussion):** aging/staleness flag for `cam_temp[]` keep-last-good values — changes host-visible telemetry semantics, needs SDK/app coordination.

## Verification

- `cmake --preset Debug` + full build: clean link, FLASH 37.21%.
- SDK unwrap cross-check above (code review of `MotionProcessing.py` unwrap paths; no host-visible field changed).
- Not yet flashed/HIL-tested — draft for hand-testing. Relevant bench check: `test_camera_death_recovery_hil.py`, plus a >12 h powered soak (or a shortened-wrap debug build) to confirm temp telemetry no longer freezes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)