### PR TITLE
feat: DEBUG_FLAG_HISTO_STALL — suppress histogram sends mid-scan (deterministic camera-stall repro)

### DIFF
--- a/Core/Inc/common.h
+++ b/Core/Inc/common.h
@@ -32,6 +32,8 @@
 #define DEBUG_FLAG_CMD_VERBOSE (1u << 5)  /* Enable printf in command handlers (if_commands.c) */
 #define DEBUG_FLAG_HISTO_CMP  (1u << 6)  /* Send compressed histogram packets (TYPE_HISTO_CMP) */
 #define DEBUG_FLAG_SEND_DEFER (1u << 7)  /* #68: FSIN ISR only flips send_data_flag; main loop runs send_data() */
+#define DEBUG_FLAG_HISTO_STALL (1u << 8) /* #75: stop sending histogram frames after HISTO_STALL_TRIGGER_FRAMES;
+                                          * cameras/SPI/USB stay alive — deterministic host-visible stall repro */
 
 
 #define I2C_IRQ_PRIORITY 0

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -82,6 +82,19 @@ static volatile uint32_t streaming_start_time = 0;
 static bool streaming_active = false;
 static bool streaming_first_frame = false;
 
+/* #75: DEBUG_FLAG_HISTO_STALL — deterministic host-visible stall repro for the
+ * bloodflow app's E-303 all-cameras-stalled watchdog (app#248/app#174/PR #294).
+ * When the flag is set, streaming runs normally for HISTO_STALL_TRIGGER_FRAMES
+ * frames, then send_data() silently stops emitting histogram USB frames while
+ * everything else stays healthy: cameras keep streaming, event bits keep being
+ * consumed, SPI receptions keep re-arming (so check_camera_failures() never
+ * trips and no rail-off recovery fires), temp polling and command handling
+ * continue, USB stays enumerated. This simulates the HOST-visible signature of
+ * the #68 FSIN-ISR starvation fault on demand. State resets at scan start. */
+#define HISTO_STALL_TRIGGER_FRAMES 1800u  /* ~45 s at 40 fps */
+static uint32_t histo_stall_frame_count = 0;
+static bool histo_stall_tripped = false;
+
 // Camera failure detection
 #define CAMERA_FAILURE_THRESHOLD_CYCLES 3  // Number of consecutive cycles before reporting failure
 static uint8_t camera_failure_counters[CAMERA_COUNT] = {0};  // Track consecutive cycles without event bits
@@ -1450,6 +1463,26 @@ static void check_camera_failures(void) {
 	}
 }
 
+/* #75: consume this frame's camera data WITHOUT sending it to the host.
+ * Mirrors the event-bit consume + per-camera re-arm that send_histogram_data()
+ * would have done (same masking rationale — see the comment there), so the
+ * cameras/SPI pipeline keeps flowing and check_camera_failures() stays happy;
+ * only the USB HISTO frame is withheld. Short-circuits BEFORE compression, so
+ * the #70 cmp budget guard never runs on a suppressed frame. */
+static _Bool histo_stall_suppress_frame(void) {
+	uint8_t ready_bits;
+	__disable_irq();
+	ready_bits = event_bits & event_bits_enabled;
+	event_bits = 0x00;
+	__enable_irq();
+	for (uint8_t cam_id = 0; cam_id < CAMERA_COUNT; ++cam_id) {
+		if ((ready_bits & (1u << cam_id)) != 0) {
+			start_data_reception(cam_id);
+		}
+	}
+	return true;  /* pretend success, like DEBUG_FLAG_HISTO_THROTTLE does */
+}
+
 _Bool send_data(void) {
 
 	// Take care of statistics
@@ -1469,6 +1502,14 @@ _Bool send_data(void) {
 		cmp_timeout_count = 0;
 		cmp_fallback_count = 0;
 		cmp_max_time_us = 0;
+		/* #75: re-arm the histo-stall repro each scan (stall persists until scan
+		 * stop; the next scan streams normally again until the trigger point). */
+		histo_stall_frame_count = 0;
+		histo_stall_tripped = false;
+		if ((logging_get_debug_flags() & DEBUG_FLAG_HISTO_STALL) != 0u) {
+			printf("DEBUG: histo stall armed, trips at frame %lu\r\n",
+			       (unsigned long)HISTO_STALL_TRIGGER_FRAMES);
+		}
 	}
 
 	// Sometimes the frame sync fires 4ms after the previous frame due to electrical noise. Ignore these.
@@ -1494,7 +1535,25 @@ _Bool send_data(void) {
 	
 	bool success = false;
 	uint32_t dflags = logging_get_debug_flags();
-	if ((dflags & DEBUG_FLAG_FAKE_DATA) != 0u) {
+	/* #75: DEBUG_FLAG_HISTO_STALL — count frames; past the trigger point,
+	 * suppress the send entirely (all modes: fake, compressed, plain). This
+	 * runs at the common send entry, so it behaves identically whether
+	 * send_data() was called from the FSIN ISR or deferred to the main loop
+	 * by DEBUG_FLAG_SEND_DEFER (#68). Unreachable with the flag clear. */
+	bool histo_stall_this_frame = false;
+	if ((dflags & DEBUG_FLAG_HISTO_STALL) != 0u) {
+		histo_stall_frame_count++;
+		histo_stall_this_frame =
+			(histo_stall_frame_count > HISTO_STALL_TRIGGER_FRAMES);
+		if (histo_stall_this_frame && !histo_stall_tripped) {
+			histo_stall_tripped = true;
+			printf("DEBUG: histo stall tripped at frame %lu\r\n",
+			       (unsigned long)histo_stall_frame_count);
+		}
+	}
+	if (histo_stall_this_frame) {
+		success = histo_stall_suppress_frame();
+	} else if ((dflags & DEBUG_FLAG_FAKE_DATA) != 0u) {
 		success = send_fake_data();
 	} else if ((dflags & DEBUG_FLAG_HISTO_CMP) != 0u) {
 		success = send_histogram_data_cmp();


### PR DESCRIPTION
Refs #75

## Why

bloodflow-app PR OpenwaterHealth/openmotion-bloodflow-app#294 adds an app-side E-303 watchdog (scan aborts when ALL cameras stop delivering frames) and per-camera CONNECTION LOST badges (app#248/app#174). That fault signature — frames stop, USB stays connected — only occurs naturally via the intermittent #68 FSIN-ISR starvation fault, so the app work can't be verified on a healthy bench: a USB pull takes the SDK's disconnect-abort path instead. This flag gives a deterministic repro for bench + future HIL tests.

## Design

**Chosen bit: `DEBUG_FLAG_HISTO_STALL = (1u << 8)` (0x100).** Both repos checked: sensor-fw `Core/Inc/common.h` and SDK `omotion/config.py` (on `next`) each define bits 0–7 with identical values (USB_PRINTF 0x01 … SEND_DEFER 0x80) — no drift found, and the u8 range is full. The mask is a **uint32 on the wire** (`OW_CMD_DEBUG_FLAGS` takes a 4-byte payload, `logging_set_debug_flags(uint32_t)`; SDK packs `struct.pack('<I', flags)`), so bit 8 is free in both repos and needs no protocol change. Companion SDK constant: OpenwaterHealth/openmotion-sdk PR from branch `feature/histo-stall-debug-flag`.

**Trigger:** compile-time `HISTO_STALL_TRIGGER_FRAMES = 1800` frames ≈ 45 s at 40 fps. Counter + tripped-latch reset in `send_data()`'s scan-start block, so the stall persists until scan stop and every new scan re-arms fresh.

**What keeps running while tripped** — this simulates the HOST-visible stall, not an internal fault:
- `histo_stall_suppress_frame()` consumes `event_bits` (masked by `event_bits_enabled`, same rationale as `send_histogram_data()`) and **re-arms `start_data_reception()` per camera**, so cameras keep streaming and `check_camera_failures()` never increments — no false camera-dead, no rail-off recovery.
- Returns success (precedent: `DEBUG_FLAG_HISTO_THROTTLE` 'others pretend success'), so frame stats stay sane.
- `cam_temp_poll_due` still set every frame; command handling and USB enumeration untouched.

**Interaction with #68 / #70** (both already merged to `next`):
- The check sits at the **common send entry** in `send_data()`, which is the single path for both ISR-direct FSIN and `DEBUG_FLAG_SEND_DEFER` deferred mode (`main.c` only chooses *where* `send_data()` runs) — identical behavior in both modes.
- It short-circuits **before** the fake/cmp/plain dispatch, so `rle_compress` and the #70 budget guard never run on a suppressed frame (also removes ~all ISR send cost past the trigger, conservative for the starvation-sensitive path).

**Logging:** one-shot printfs `DEBUG: histo stall armed, trips at frame 1800` (scan start, flag set) and `DEBUG: histo stall tripped at frame N` (first suppressed frame).

**Flag clear = zero behavior change:** the suppression branch is only reachable when bit 8 is set; the dispatch chain is byte-for-byte the same logic otherwise. Diff is purely additive (+62/−1... the −1 is the dispatch line rewrap).

## Build

`cmake --preset Debug && cmake --build build/Debug` — clean, no new warnings. FLASH 37.24%, link + hex merge OK.

## Bench-test plan (post-review; rig currently in use)

1. Flash this image (`deploy.py --device left --fw-only --power-cycle-cmd ...`).
2. Set the flag via the existing app debug-flag mechanism (same path as `histoCmp` at `_run_sensor_init`) or directly: `sensor.set_debug_flags(current | 0x100)`.
3. Start a scan ≥ 60 s. Expect: normal streaming for ~45 s, then `DEBUG: histo stall tripped at frame 1801` on the printf log, host histogram stream goes silent, **USB stays enumerated**, sensor still answers commands (ping/temp).
4. App side (PR app#294 build): E-303 watchdog fires within ~15 s of the stall; per-camera CONNECTION LOST badges show; scan aborts via the watchdog path, NOT the USB-disconnect path.
5. Stop scan, start another: streaming is normal again for 45 s (re-arm verified), then trips again.
6. Clear the flag: full-length scan streams end-to-end (no-regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)