### PR TITLE
fix: wrap-exact TIM5 tick deltas for remaining interval timeouts (#73)

### DIFF
--- a/Core/Inc/utils.h
+++ b/Core/Inc/utils.h
@@ -18,6 +18,8 @@ void DWT_Init(void);
 void delay_ms(uint32_t ms);
 void delay_us(uint32_t us);
 uint32_t get_timestamp_ms(void);
+uint32_t timestamp_ticks(void);
+uint32_t timestamp_elapsed_ms(uint32_t start_ticks);
 void GPIO_SetHiZ(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin);
 void GPIO_SetOutput(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin, GPIO_PinState PinState);
 void print_hex_buf(const char *label, uint8_t *buf, size_t len);

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -77,8 +77,14 @@ static volatile uint32_t cmp_timeout_count = 0;
 static volatile uint32_t cmp_fallback_count = 0;
 
 #define STREAMING_TIMEOUT_MS 150
-static volatile uint32_t most_recent_frame_time = 0;
-static volatile uint32_t streaming_start_time = 0;
+/* Raw TIM5 ticks (100 kHz, via timestamp_ticks()), NOT get_timestamp_ms():
+ * ms deltas of the /100 clock are wrong at its non-power-of-two wrap
+ * (~11.93 h). A scan ending within STREAMING_TIMEOUT_MS of the wrap would
+ * park check_streaming()'s stall detection (current < most_recent) for
+ * hours, leaving streaming_active stuck with no terminal flush (#73).
+ * Raw tick deltas wrap at exactly 2^32 and stay exact. */
+static volatile uint32_t most_recent_frame_ticks = 0;
+static volatile uint32_t streaming_start_ticks = 0;
 static bool streaming_active = false;
 static bool streaming_first_frame = false;
 
@@ -1455,7 +1461,7 @@ _Bool send_data(void) {
 	// Take care of statistics
 	if(!streaming_active && event_bits_enabled != 0x00){
 		printf("Scan started\r\n");
-		streaming_start_time = get_timestamp_ms();
+		streaming_start_ticks = timestamp_ticks();
 		streaming_active = true;
 		streaming_first_frame = true;
 		/* #68 instrumentation: zero per-camera overrun counts at scan start. */
@@ -1472,7 +1478,7 @@ _Bool send_data(void) {
 	}
 
 	// Sometimes the frame sync fires 4ms after the previous frame due to electrical noise. Ignore these.
-	if(get_timestamp_ms() - most_recent_frame_time < 15 ){
+	if(timestamp_elapsed_ms(most_recent_frame_ticks) < 15 ){
 		/* Rate-limit this warning: on boards with FSIN ringing it fires on
 		 * EVERY frame (40 Hz), and the printf flood over UART/USB has been
 		 * an amplifier in several USB-death cascades. Keep the signal,
@@ -1486,8 +1492,8 @@ _Bool send_data(void) {
 		return true;
 	}
 
-	most_recent_frame_time = get_timestamp_ms();
-	// printf("%lu\r\n", most_recent_frame_time);
+	most_recent_frame_ticks = timestamp_ticks();
+	// printf("%lu\r\n", most_recent_frame_ticks);
 	
 	// Check for camera failures before clearing event_bits
 	check_camera_failures();
@@ -1515,16 +1521,19 @@ _Bool send_data(void) {
 
 _Bool check_streaming(void){
 	if(streaming_active){
-		uint32_t current_time = get_timestamp_ms();
-		uint32_t most_recent_frame_time_local = most_recent_frame_time;
+		uint32_t current_ticks = timestamp_ticks();
+		uint32_t most_recent_frame_ticks_local = most_recent_frame_ticks;
 
-		if(current_time<most_recent_frame_time_local){
+		/* Signed tick delta: wrap-exact across TIM5's 2^32 rollover (real frame
+		 * ages here are ≤ seconds, far below the 2^31-tick ≈ 5.96 h limit). */
+		int32_t frame_age_ticks = (int32_t)(current_ticks - most_recent_frame_ticks_local);
+		if(frame_age_ticks < 0){
 			if(verbose_on) { printf("Current time is less than most recent frame time, passing.\r\n"); }
-			// This is an edge case that seems to happen due to this function being interrupted by the interrupt that sets most_recent_frame_time.
+			// This is an edge case that seems to happen due to this function being interrupted by the interrupt that sets most_recent_frame_ticks.
 			return streaming_active;
 		}
-		if((current_time - most_recent_frame_time_local) > STREAMING_TIMEOUT_MS){
-			uint32_t elapsed = current_time - streaming_start_time;
+		if(((uint32_t)frame_age_ticks / 100u) > STREAMING_TIMEOUT_MS){
+			uint32_t elapsed = timestamp_elapsed_ms(streaming_start_ticks);
 			/* #68: this terminal flush is NOT driven by a fresh FSIN, so the
 			 * ISR-captured fsin_timestamp_ms would be stale (the previous frame's
 			 * time) here. Stamp it now so the terminal frame carries a current

--- a/Core/Src/logging.c
+++ b/Core/Src/logging.c
@@ -129,14 +129,18 @@ static bool logging_uart_dma_write(const uint8_t *src, size_t count) {
 	}
 
 	size_t remaining = count;
-	uint32_t start_time = get_timestamp_ms();
+	/* Raw TIM5 ticks, not get_timestamp_ms(): the /100 ms value's ms-delta is
+	 * wrong at its non-power-of-two wrap (~11.93 h) — spurious instant timeout
+	 * and a bogus drop marker (#73). Tick deltas are wrap-exact, and TIM5 keeps
+	 * counting even when this runs from ISR context with the tick masked. */
+	uint32_t start_ticks = timestamp_ticks();
 	const uint32_t timeout_ms = 10u;
 
 	while (remaining > 0) {
 		size_t free_bytes = lwrb_get_free(&usart_tx_buff);
 		if (free_bytes == 0) {
 			usart_start_tx_dma_transfer();
-			if ((get_timestamp_ms() - start_time) >= timeout_ms) {
+			if (timestamp_elapsed_ms(start_ticks) >= timeout_ms) {
 				usart_drop_marker_pending = true;
 				break;
 			}

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -2051,7 +2051,10 @@ void ExitRun0Mode(void) {
 static void wait_for_usb_queues_to_finish(void)
 {
   const uint32_t timeout_ms = 1000;  // Maximum wait time: 1 second
-  uint32_t start_time = get_timestamp_ms();
+  /* timestamp_ticks(), not get_timestamp_ms(): ms deltas of the /100 clock
+   * jump to ~4.25e9 at its non-power-of-two wrap (~11.93 h), firing this
+   * timeout spuriously (#73). Raw TIM5 tick deltas are wrap-exact. */
+  uint32_t start_ticks = timestamp_ticks();
   uint32_t elapsed = 0;
   
   printf("Waiting for USB queues to finish...\r\n");
@@ -2089,7 +2092,7 @@ static void wait_for_usb_queues_to_finish(void)
     
     // Small delay to avoid busy-waiting
     delay_ms(1);
-    elapsed = get_timestamp_ms() - start_time;
+    elapsed = timestamp_elapsed_ms(start_ticks);
   }
   
   printf("USB queue wait timeout after %lu ms (some data may not have been sent).\r\n", elapsed);

--- a/Core/Src/uart_comms.c
+++ b/Core/Src/uart_comms.c
@@ -181,10 +181,14 @@ _Bool comms_interface_send(UartPacket *pResp) {
 	}
 
 	// Wait for the transmit complete flag with a timeout to avoid infinite loop.
-	uint32_t start_time = get_timestamp_ms();
+	/* Raw TIM5 ticks, not get_timestamp_ms(): the /100 ms-delta jumps to
+	 * ~4.25e9 at its non-power-of-two wrap (~11.93 h), spuriously "timing out"
+	 * an in-flight transmit — forcing tx_flag idle and flagging a TX failure
+	 * on a healthy endpoint (#73). Tick deltas are wrap-exact. */
+	uint32_t start_ticks = timestamp_ticks();
 
 	while (!tx_flag) {
-		if ((get_timestamp_ms() - start_time) >= TX_TIMEOUT) {
+		if (timestamp_elapsed_ms(start_ticks) >= TX_TIMEOUT) {
 			// Timeout handling: Log error and break out or reset the flag.
 			// printf before releasing send_in_progress so the message only
 			// buffers instead of re-entering this function.

--- a/Core/Src/utils.c
+++ b/Core/Src/utils.c
@@ -116,6 +116,26 @@ uint32_t get_timestamp_ms(void)
     // printf("Timestamp: %d\r\n", timestamp);
     return timestamp;
 }
+
+/* Raw TIM5 counter (100 kHz, 10 us/tick). Wraps at exactly 2^32 ticks, so
+ * unsigned tick deltas (now - start) are wrap-exact — unlike ms deltas of
+ * get_timestamp_ms(), whose 2^32/100 wrap point is NOT a power of two,
+ * making (now_ms - start_ms) jump to ~4.25e9 once per ~11.93 h (#73).
+ * TIM5 is a free-running hardware counter: unlike HAL_GetTick()'s uwTick it
+ * keeps advancing in ISR context / with the tick interrupt masked, so these
+ * are the right primitives for busy-wait timeouts that may run there. */
+uint32_t timestamp_ticks(void)
+{
+    return TIM5->CNT;
+}
+
+/* Wrap-exact milliseconds elapsed since a timestamp_ticks() reading.
+ * Valid for intervals < 2^32 ticks (~11.93 h). */
+uint32_t timestamp_elapsed_ms(uint32_t start_ticks)
+{
+    return (uint32_t)(TIM5->CNT - start_ticks) / 100u;
+}
+
 void GPIO_SetHiZ(GPIO_TypeDef *GPIOx, uint16_t GPIO_Pin)
 {
     GPIO_InitTypeDef GPIO_InitStruct = {0};

--- a/USB/Class/HISTO/Src/usbd_histo.c
+++ b/USB/Class/HISTO/Src/usbd_histo.c
@@ -362,8 +362,10 @@ static uint8_t USBD_Histo_DataIn(USBD_HandleTypeDef *pdev, uint8_t epnum)
   return ret;
 }
 
-/* Last timestamp when a histogram packet was actually sent (for DEBUG_FLAG_HISTO_THROTTLE) */
-static uint32_t histo_last_send_ms = 0;
+/* Raw TIM5 ticks (timestamp_ticks()) of the last histogram packet actually
+ * sent (for DEBUG_FLAG_HISTO_THROTTLE). Tick deltas are wrap-exact; ms deltas
+ * of get_timestamp_ms() misbehave at its non-power-of-two wrap (#73). */
+static uint32_t histo_last_send_ticks = 0;
 
 uint8_t USBD_HISTO_SendData(USBD_HandleTypeDef *pdev, uint8_t *data, uint16_t len, uint8_t ep_idx)
 {
@@ -392,12 +394,12 @@ uint8_t USBD_HISTO_SendData(USBD_HandleTypeDef *pdev, uint8_t *data, uint16_t le
 
   /* Debug flag: only send histogram packet every 5 seconds; others pretend success */
   if ((logging_get_debug_flags() & DEBUG_FLAG_HISTO_THROTTLE) != 0u) {
-    uint32_t now_ms = get_timestamp_ms();
-    uint32_t elapsed = (histo_last_send_ms != 0u) ? (now_ms - histo_last_send_ms) : HISTO_THROTTLE_INTERVAL_MS;
+    uint32_t now_ticks = timestamp_ticks();
+    uint32_t elapsed = (histo_last_send_ticks != 0u) ? ((now_ticks - histo_last_send_ticks) / 100u) : HISTO_THROTTLE_INTERVAL_MS;
     if (elapsed < HISTO_THROTTLE_INTERVAL_MS) {
       return USBD_OK;  /* Pretend sent, do not enqueue or transmit */
     }
-    histo_last_send_ms = now_ms;
+    histo_last_send_ticks = now_ticks;
   }
 
   /* Ensure pdev is stored (in case called before Init, though this shouldn't happen) */


### PR DESCRIPTION
@-