### PR TITLE
Release 1.8.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,9 @@ Firmware for the sensor-module MCU (STM32H743VIH6). Drives 8 OV2312 cameras thro
 
 Cross-repo context + shared protocol: [../CLAUDE.md](../CLAUDE.md). Authoritative protocol spec lives in [../openmotion-console-fw/CommandHandling.md](../openmotion-console-fw/CommandHandling.md).
 
-## Build / flash
+> **Code references in this guide are by function/symbol name, not line number.** An earlier version pinned line numbers; the core files grew and every citation rotted. Grep for the symbol.
+
+## Build
 
 ```powershell
 cmake --preset Debug
@@ -14,21 +16,69 @@ cmake --preset Release
 cmake --build build/Release
 ```
 
-- Build is gated by an **FPGA bitstream download from GitHub** at CMake configure time:
-  ```cmake
-  # CMakeLists.txt:143-161
-  file(DOWNLOAD
-       https://github.com/OpenwaterHealth/openmotion-camera-fpga/releases/latest/download/openmotion-camera-fpga.bin
-       fpga/openmotion-camera-fpga.bin
-       ...)
+Two firmware images come out of a build:
+- `motion-sensor-fw.bin` / `.hex` — the **merged** image (firmware + FPGA bitstream), ~1.78 MB.
+- `motion-sensor-fw-raw.bin` — the **firmware-only** pre-merge image, ~374 KB. Flash this when the FPGA bitstream hasn't changed (see `--fw-only` below).
+
+- Build is gated by an **FPGA bitstream download from GitHub** at CMake configure time (`FPGA_BITSTREAM_URL` in `CMakeLists.txt`):
+  ```
+  https://github.com/OpenwaterHealth/openmotion-camera-fpga/releases/latest/download/openmotion-camera-fpga.bin
   ```
   - **No auth needed** (releases are public).
-  - **No cached fallback** — if GitHub is unreachable, configure step exits with `FATAL_ERROR`. To work offline, pre-place the file at `fpga/openmotion-camera-fpga.bin` and CMake will skip the download.
-  - **To pin or override:** edit the URL in `CMakeLists.txt:145` to a specific release tag, or drop a local `.bin` into `fpga/` before configuring.
-- Post-build: `objcopy` converts the FPGA `.bin` to Intel HEX at flash address `0x081A0000`, then `merge_hex.py` concatenates firmware + FPGA into the final `motion-sensor-fw.hex`.
+  - **No cached fallback** — if GitHub is unreachable, configure exits with `FATAL_ERROR`. To work offline, pre-place the file at `fpga/openmotion-camera-fpga.bin` and CMake skips the download.
+  - **To pin or override:** edit `FPGA_BITSTREAM_URL` in `CMakeLists.txt` to a specific release tag, or drop a local `.bin` into `fpga/` before configuring.
+- Post-build: `objcopy` converts the FPGA `.bin` to Intel HEX at `FPGA_BITSTREAM_ADDR` (`0x081A0000`), then `merge_hex.py` concatenates firmware + FPGA into `motion-sensor-fw.hex`.
 - Toolchain file: `cmake/gcc-arm-none-eabi.cmake`. CI uses `ghcr.io/openwaterhealth/stm32-build-env:latest`.
 
-## Flash layout (`Core/Inc/memory_map.h:15-40`)
+## Deployment (DFU flash over USB)
+
+`scripts/deploy.py` is the canonical way to flash a sensor — DFU over USB, no ST-LINK. It builds (unless `--no-build`), triggers DFU through the `omotion` SDK, flashes, and waits for the sensor to re-enumerate.
+
+```powershell
+python scripts/deploy.py --device left      # or right
+```
+
+CMake convenience targets wrap the same script (they pass `--no-build` and depend on the build):
+
+```powershell
+cmake --build build/Debug --target flash-left      # = deploy.py --device left --config Debug --no-build
+cmake --build build/Debug --target flash-right
+```
+
+**Prerequisites**
+- `omotion` installed in the active Python env: `pip install -e ../openmotion-sdk` (path may differ).
+- A flasher: **STM32_Programmer_CLI** (STM32CubeProgrammer) is preferred — ~10× faster against the ROM bootloader; the script auto-discovers it on `PATH` and standard install dirs. Falls back to **dfu-util** otherwise.
+- On Windows, bind **WinUSB to the STM32 DFU interface (PID `0xDF11`) via Zadig**, or the DFU device won't enumerate.
+
+**Key options** (`--help` for the full list)
+
+| Flag | Effect |
+|---|---|
+| `--device left\|right` | **Required.** Which sensor side. Mandatory to prevent wrong-side flashes. |
+| `--config Debug\|Release` | Image to flash. Default `Debug`. |
+| `--fw-only` | Flash the firmware-only `-raw.bin` (~374 KB, ~5 s) instead of the merged image (~1.78 MB, ~23 s). Use whenever the FPGA bitstream hasn't changed. |
+| `--no-build` | Skip the build; flash whatever's already in `build/<config>/`. |
+| `--power-cycle-cmd CMD` | Shell command that power-cycles the sensor. See gotcha below. |
+| `--no-confirm` | Skip the interactive "Deploy left sensor? (y/N)" prompt. |
+| `--use-dfu-util` | Force dfu-util even when CubeProgrammer is present. |
+
+### ⚠️ The jump-to-app hang — always pass `--power-cycle-cmd`
+
+After a DFU flash, the STM32H743 ROM bootloader's **jump-to-app is unreliable on the sensor modules — it hangs before any app code runs** (pre-`SystemInit`, likely a pending bootloader interrupt vectoring through the bootloader's VTOR). No firmware-side fix can make the jump reliable, so a deploy must end with a real power cycle.
+
+Pass `--power-cycle-cmd` so the deploy is hands-free. The script also power-cycles *up front* if the sensor is already hung from an earlier failed flash, then retries DFU entry. On the bench this is a smart-plug (Shelly) script:
+
+```powershell
+# Generic form: --power-cycle-cmd is any shell command that cuts and restores DUT power.
+python scripts/deploy.py --device left --fw-only --no-confirm `
+  --power-cycle-cmd "python C:\Users\ethan\Projects\openmotion-bloodflow-app\tests\shelly.py cycle"
+```
+
+Other notes:
+- **dfu-util exit 74** ("Error during download get_status") *after a successful download* is a known STM32 ROM quirk — the device jumps to app on `:leave` before dfu-util reads final status. The script trusts the sensor's comeback as truth, not the exit code.
+- There is **no software path to power-cycle a single sensor** independently; absent `--power-cycle-cmd`, the script tells you to toggle console power (which cycles both sensors).
+
+## Flash layout (`Core/Inc/memory_map.h`)
 
 | Range | Size | Contents |
 |---|---:|---|
@@ -41,31 +91,33 @@ Note: the parent CLAUDE.md historically claimed 384 KB for the FPGA region — t
 
 ## Layout
 
-| Path | Lines | Purpose |
-|---|---:|---|
-| `Core/Src/main.c` | 1959 | Init, event loop, USB setup, GPIO / IRQ handlers. |
-| `Core/Src/if_commands.c` | 1105 | Command dispatcher — ~25 handlers in `app_handle_uartframe()`. |
-| `Core/Src/camera_manager.c` | 1598 | 8-camera orchestration, histogram streaming. SPI6 read from FPGA → buffer → USB HISTO. |
-| `Core/Src/0X02C1B.c` | 375 | OV2312 image-sensor register config (the file is literally named after the part). |
-| `Core/Src/crosslink.c` | 378 | Lattice CrossLink FPGA — I2C activation, IDCODE check, SRAM erase/program, status verify. Bitstream size hardcoded at line 339 (`163489`). |
-| `Core/Src/ICM20948.c` | 337 | 6-DOF IMU + magnetometer driver. |
-| `Core/Src/uart_comms.c` | 350 | UART packet framing with CRC-16. |
-| `Core/Src/flash_eeprom.c` | — | Persistent config storage at `0x081FE000`. |
-| `Core/Src/motion_config.c` | — | JSON config parsing / persistence. |
-| `Core/Src/histo_fake.c` | — | Synthetic histogram generator, gated by `DEBUG_FLAG_FAKE_DATA`. |
-| `Core/Src/i2c_protocol.c`, `i2c_master.c` | — | Multi-camera I2C bus management. |
-| `USB/Class/COMMS/Src/usbd_comms.c` | 554 | **IF 0** — bulk command/response. Endpoints `0x81` IN / `0x01` OUT, 512 B HS packets. |
-| `USB/Class/HISTO/Src/usbd_histo.c` | 451 | **IF 1** — histogram streaming, IN only, 32 KB packets. |
-| `USB/Class/IMU/Src/usbd_imu.c` | 497 | **IF 2** — IMU streaming, IN only, 200 B packets. |
-| `USB/Class/CompositeBuilder/` | — | Composite USB descriptor builder. |
-| `CMakeLists.txt` | — | FPGA download + merge_hex orchestration (lines 143–188). |
-| `merge_hex.py` | — | Combines firmware HEX + FPGA HEX. |
+| Path | Purpose |
+|---|---|
+| `Core/Src/main.c` | Init, event loop, USB setup, GPIO / IRQ handlers. |
+| `Core/Src/if_commands.c` | Command dispatcher — handlers in `app_handle_uartframe()`. |
+| `Core/Src/camera_manager.c` | 8-camera orchestration, histogram streaming. SPI6 read from FPGA → `frame_buffer` → USB HISTO. |
+| `Core/Src/0X02C1B.c` | OV2312 image-sensor register config (the file is literally named after the part). |
+| `Core/Src/crosslink.c` | Lattice CrossLink FPGA — I2C activation, IDCODE check, SRAM erase/program, status verify. Bitstream size hardcoded as `163489`. |
+| `Core/Src/ICM20948.c` | 6-DOF IMU + magnetometer driver. |
+| `Core/Src/uart_comms.c` | UART packet framing with CRC-16. |
+| `Core/Src/flash_eeprom.c` | Persistent config storage at `0x081FE000`. |
+| `Core/Src/motion_config.c` | JSON config parsing / persistence. |
+| `Core/Src/histo_fake.c` | Synthetic histogram generator, gated by `DEBUG_FLAG_FAKE_DATA`. |
+| `Core/Src/i2c_protocol.c`, `i2c_master.c` | Multi-camera I2C bus management. |
+| `USB/Class/COMMS/Src/usbd_comms.c` | **IF 0** — bulk command/response. Endpoints `0x81` IN / `0x01` OUT, 512 B HS packets. |
+| `USB/Class/HISTO/Src/usbd_histo.c` | **IF 1** — histogram streaming, IN only, 32 KB packets. |
+| `USB/Class/IMU/Src/usbd_imu.c` | **IF 2** — IMU streaming, IN only, 200 B packets. |
+| `USB/Class/CompositeBuilder/` | Composite USB descriptor builder. |
+| `CMakeLists.txt` | FPGA download + merge_hex + `flash-left`/`flash-right` target orchestration. |
+| `merge_hex.py` | Combines firmware HEX + FPGA HEX. |
+| `scripts/deploy.py`, `scripts/_deploy_helpers.py` | DFU flash + recovery (see Deployment). |
+| `tests/` | pytest suite — unit + hardware-in-the-loop (see Tests). |
 
-## FPGA + camera flow (`crosslink.c:264-362`)
+## FPGA + camera flow (`crosslink.c`)
 
-FPGA is at I2C address `0x40`. Bring-up:
+FPGA is at I2C address `0x40`. Bring-up sequence (in `crosslink.c`):
 
-1. Write 5-byte activation key (line 290).
+1. Write 5-byte activation key.
 2. Read IDCODE via `0xE0`, expect `{0x01, 0x2C, 0x00, 0x43}`. Retry up to 3 times.
 3. Enable SRAM mode (`0xC6`, 1 ms delay).
 4. Erase SRAM (`0x0E`, **5 second delay**).
@@ -73,18 +125,17 @@ FPGA is at I2C address `0x40`. Bring-up:
 6. Verify status (`0x3C`, check bit 2).
 7. Exit program mode (`0x26`).
 
-Histogram path: FPGA computes 1024-bin histograms from MIPI CSI-2 cameras → SPI6 → `spi6_buffer` in SRAM4 → `frame_buffer` (`camera_manager.c:40`) → USB HISTO endpoint.
+Histogram path: FPGA computes 1024-bin histograms from MIPI CSI-2 cameras → SPI6 → `spi6_buffer` in SRAM4 → `frame_buffer` (`camera_manager.c`) → USB HISTO endpoint.
 
 ## Gotchas
 
-- **`crosslink.c:339` hardcodes the bitstream size** (`163489` bytes). If `openmotion-camera-fpga` ships a larger bitstream, programming will misalign and corrupt adjacent flash. Update both `crosslink.c:339` and verify against `memory_map.h` boundaries.
+- **`crosslink.c` hardcodes the bitstream size** (`163489` bytes). If `openmotion-camera-fpga` ships a larger bitstream, programming will misalign and corrupt adjacent flash. Update the `163489` constant in `crosslink.c` and verify against `memory_map.h` boundaries.
 - **Build fails hard when offline.** No cached bitstream fallback — pre-place `fpga/openmotion-camera-fpga.bin` before configuring if you're flying.
 - **I2C bus is single-threaded.** 8 cameras + FPGA all share one bus through the FPGA mux. No mutex / semaphore in `camera_manager.c`. Concurrent commands → deadlock.
-- **USB packet send is fire-and-forget.** `camera_manager.c:1306` has a TODO "handle the case where the packet fails to send better." Currently a failed USB TX silently drops the frame, no retry.
-- **UART reset at frame end** (`if_commands.c:714`, TODO): "fix this garbage, this resets the usart at the finish of a frame." Abrupt restart can drop late telemetry.
-- **Camera enumeration is not a real probe** (`if_commands.c:837`, TODO): "due to a bug in the scan camera sensors, we will just set `isPresent` for each of these to TRUE if it is powered." Don't trust `isPresent` for camera health.
+- **USB packet send is fire-and-forget.** `camera_manager.c` has a TODO "handle the case where the packet fails to send better." Currently a failed USB TX silently drops the frame, no retry.
+- **Camera enumeration is not a real probe.** `if_commands.c` sets `isPresent = true` for any powered slot (TODO: "due to a bug in the scan camera sensors…"). Don't trust `isPresent` for camera health.
 - **Debug flags can mask real sensor issues.** `DEBUG_FLAG_FAKE_DATA` injects synthetic histograms; `DEBUG_FLAG_HISTO_SPARSE` throttles to 15 s; `DEBUG_FLAG_HISTO_THROTTLE` throttles to 5 s. Check the active flags before diagnosing "no data."
-- **DFU entry path is unclear.** `OW_CMD_DFU` exists (`if_commands.c:174`) but it's not confirmed that bootloader DFU is fully wired here.
+- **DFU works, but the jump-to-app hangs.** `OW_CMD_DFU` (`if_commands.c`) enters the bootloader fine; the ROM's jump back to the app is what's unreliable — always finish a deploy with a power cycle. See Deployment.
 
 ## USB classes
 
@@ -100,20 +151,64 @@ To add a new endpoint: modify the class header (`usbd_<class>.h`) for endpoint d
 
 To change a packet size: edit the `*_HS_MAX_PACKET_SIZE` macro in the class header; descriptors regenerate on build.
 
-## CI / releases
+## Tests (`tests/`)
 
-- `.github/workflows/build-firmware.yml` — push to `main` / `next`, tag push (`v*.*.*` or `*-rc.*`), release event. Builds in Docker, uploads `.hex` and `.bin` as release artifacts, generates release notes from commit log.
-- Tags use **semantic versioning** (e.g. `1.2.3`, `1.2.3-rc.1`, `v0.1.0`).
-- Branching: feature branches off `next`, PR to `next`, `next` → `main` for tagging.
-- `tests/` directory exists but is empty (no unit tests).
+pytest. There's no `pytest.ini`/`pyproject` config — `conftest.py` just adds `scripts/` to `sys.path`. Two kinds of test live here:
+
+**Unit tests** — no hardware, run anywhere:
+- `test_deploy_helpers.py` — `scripts/_deploy_helpers.py` logic (path resolution, etc.).
+- `test_serial_record.py` — serial-number record validation.
+
+```powershell
+pytest tests/        # off-bench: unit tests run, all HIL tests skip
+```
+
+**Hardware-in-the-loop (HIL) tests** — `*_hil.py`, gated behind an env var. Each is decorated with `requires_bench`, which **skips unless `OPENMOTION_HIL=1`**. They connect to a real sensor through `omotion`, so the SDK must be installed and a sensor must be on the bench.
+
+```powershell
+$env:OPENMOTION_HIL = "1"
+$env:OW_SENSOR_SIDE = "left"   # or "right"; defaults to left
+pytest tests/                  # runs HIL tests against the selected sensor
+```
+
+| HIL test | Covers |
+|---|---|
+| `test_serial_hil.py` | Serial-number read/write over the wire. |
+| `test_imu_stream_hil.py` | IMU streaming at the expected ~40 Hz rate. |
+| `test_imu_wedge_hil.py` | IMU endpoint recovery after a wedge. |
+| `test_histo_wedge_recovery_hil.py` | Histogram endpoint recovery after a wedge. |
+| `test_i2c_health_hil.py` | I2C bus / camera health. |
+| `test_i2c_serialization_hil.py` | I2C single-bus serialization behavior. |
+| `test_camera_gain_hil.py` | Camera gain set/readback. |
+| `test_camera_death_recovery_hil.py` | Camera death + recovery. |
+
+- **Side selection:** HIL fixtures read `OW_SENSOR_SIDE` (default `left`).
+- **Wedge tests can leave an endpoint stuck.** The HISTO/IMU streaming endpoints can wedge if the host stops reading mid-stream; **power-cycle the sensor between streaming HIL runs** rather than chaining them.
+
+## CI / releases (`.github/workflows/build-firmware.yml`)
+
+Triggers: `workflow_dispatch`, push to `main`/`next`, tag push (`*.*.*`, `*.*.*-rc.*`, `*.*.*-dev.*`), and `release` events. Builds in the `stm32-build-env` Docker image; uploads `.hex` and `.bin` as artifacts and (on tags) creates a GitHub Release with notes from the commit log.
+
+Build config is chosen from the trigger:
+- `*-dev.*` tag → **Debug** (development pre-release).
+- `*-rc.*` or final `X.Y.Z` tag → **Release** (`-Os`).
+- branch push / `workflow_dispatch` → **Debug**.
+
+## Git workflow
+
+- **Branching:** feature branches off `next`, PR to `next`, `next` → `main` for release. Releases are tagged on `main`.
+- **Feature branch naming:** `feature/<issue>-short-desc`.
+- **Commit prefixes:** `feat:` / `fix:` / `refactor:` / `docs:` / `test:` / `chore:`.
+- **Tags:** semantic versioning — `MAJOR.MINOR.PATCH`, optionally with a pre-release suffix (`1.5.8`, `1.5.8-rc.2`, `1.5.8-dev.1`). Tags drive the build version (`generated/version.h` at CMake configure time) and the CI build config (see above).
 
 ## "Start here" by task
 
 | Task | First files |
 |---|---|
-| Add a new command | `Core/Inc/common.h` (enum) → `Core/Src/if_commands.c` (case in `app_handle_uartframe()`) → return via `uartResp`. SDK side: `openmotion-sdk/omotion/MotionSensor.py` + `CommInterface.py`. |
-| Change histogram packet format | `USB_HISTO_MAX_SIZE` in `USB/Class/HISTO/Inc/usbd_histo.h` → `frame_buffer` in `camera_manager.c:40` → match parser in `openmotion-sdk/omotion/MotionProcessing.py`. |
-| Update FPGA bitstream pin / version | Edit URL at `CMakeLists.txt:145`, **and** confirm the new bitstream size matches `crosslink.c:339`. Reconfigure to redownload. |
-| Debug a camera that won't enumerate | Don't trust `isPresent` (`if_commands.c:837`). Set `DEBUG_FLAG_USB_PRINTF` via `OW_CMD_DEBUG_FLAGS`, watch UART for the init sequence, check I2C/SPI health via `OW_IMU_*` / `OW_CAMERA_*`. |
-| Investigate dropped histograms | `camera_manager.c:1306` (USB TX failures are silent), plus any active `DEBUG_FLAG_HISTO_*` throttles. |
+| Add a new command | `Core/Inc/common.h` (enum) → `app_handle_uartframe()` in `Core/Src/if_commands.c` → return via `uartResp`. SDK side: `openmotion-sdk/omotion/MotionSensor.py` + `CommInterface.py`. |
+| Change histogram packet format | `USB_HISTO_MAX_SIZE` in `USB/Class/HISTO/Inc/usbd_histo.h` → `frame_buffer` in `camera_manager.c` → match parser in `openmotion-sdk/omotion/MotionProcessing.py`. |
+| Update FPGA bitstream pin / version | Edit `FPGA_BITSTREAM_URL` in `CMakeLists.txt`, **and** confirm the new bitstream size matches the `163489` constant in `crosslink.c`. Reconfigure to redownload. |
+| Flash a sensor | `python scripts/deploy.py --device left` (always with `--power-cycle-cmd`). See Deployment. |
+| Debug a camera that won't enumerate | Don't trust `isPresent` (`if_commands.c`). Set `DEBUG_FLAG_USB_PRINTF` via `OW_CMD_DEBUG_FLAGS`, watch UART for the init sequence, check I2C/SPI health via `OW_IMU_*` / `OW_CAMERA_*`. |
+| Investigate dropped histograms | USB-TX failures are silent (`camera_manager.c`), plus any active `DEBUG_FLAG_HISTO_*` throttles. |
 | Touch persistent config | `Core/Src/flash_eeprom.c` + `motion_config.c`. Respect sector 7 bank 2 boundary at `0x081FE000`. |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,18 @@ Cross-repo context + shared protocol: [../CLAUDE.md](../CLAUDE.md). Authoritativ
 
 > **Code references in this guide are by function/symbol name, not line number.** An earlier version pinned line numbers; the core files grew and every citation rotted. Grep for the symbol.
 
+## Reporting firmware issues (for agents)
+
+If you find a firmware bug or issue while working in this repo, **open a GitHub issue — do not file a background-task chip.** Use the `gh` CLI:
+
+```bash
+gh issue create --repo OpenwaterHealth/openmotion-sensor-fw \
+  --title "<concise summary>" \
+  --body "<what's wrong, where (file/function), how to reproduce or observe it, and impact>"
+```
+
+Write a self-contained description: the affected file/function, what's wrong, how it reproduces or how you observed it, and the impact. This keeps firmware issues tracked on the repo where the maintainers see them, rather than as ephemeral session chips.
+
 ## Build
 
 ```powershell

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,119 @@
+# openmotion-sensor-fw — Claude guide
+
+Firmware for the sensor-module MCU (STM32H743VIH6). Drives 8 OV2312 cameras through a Lattice CrossLink FPGA, exposes a composite USB device (three bulk interfaces: COMMS, HISTO, IMU) to the host, and ships a `.hex` that merges the firmware + the FPGA bitstream into one programmable image.
+
+Cross-repo context + shared protocol: [../CLAUDE.md](../CLAUDE.md). Authoritative protocol spec lives in [../openmotion-console-fw/CommandHandling.md](../openmotion-console-fw/CommandHandling.md).
+
+## Build / flash
+
+```powershell
+cmake --preset Debug
+cmake --build build/Debug          # → build/Debug/motion-sensor-fw.{elf,hex,bin,map}
+
+cmake --preset Release
+cmake --build build/Release
+```
+
+- Build is gated by an **FPGA bitstream download from GitHub** at CMake configure time:
+  ```cmake
+  # CMakeLists.txt:143-161
+  file(DOWNLOAD
+       https://github.com/OpenwaterHealth/openmotion-camera-fpga/releases/latest/download/openmotion-camera-fpga.bin
+       fpga/openmotion-camera-fpga.bin
+       ...)
+  ```
+  - **No auth needed** (releases are public).
+  - **No cached fallback** — if GitHub is unreachable, configure step exits with `FATAL_ERROR`. To work offline, pre-place the file at `fpga/openmotion-camera-fpga.bin` and CMake will skip the download.
+  - **To pin or override:** edit the URL in `CMakeLists.txt:145` to a specific release tag, or drop a local `.bin` into `fpga/` before configuring.
+- Post-build: `objcopy` converts the FPGA `.bin` to Intel HEX at flash address `0x081A0000`, then `merge_hex.py` concatenates firmware + FPGA into the final `motion-sensor-fw.hex`.
+- Toolchain file: `cmake/gcc-arm-none-eabi.cmake`. CI uses `ghcr.io/openwaterhealth/stm32-build-env:latest`.
+
+## Flash layout (`Core/Inc/memory_map.h:15-40`)
+
+| Range | Size | Contents |
+|---|---:|---|
+| `0x08000000 – 0x081A0000` | 1.625 MB | Firmware (sectors 0–4 of both banks) |
+| `0x081A0000 – 0x081C0000` | 128 KB | FPGA bitstream (sector 5 bank 2). Bitstream is currently 163,489 B. |
+| `0x081C0000 – 0x081E0000` | 128 KB | Unused (sector 6 bank 2). |
+| `0x081FE000 – 0x08200000` | 8 KB | Persistent config JSON (sector 7 bank 2). |
+
+Note: the parent CLAUDE.md historically claimed 384 KB for the FPGA region — the actual erasable sector is 128 KB. There's no room to grow the bitstream past that without consuming sector 6.
+
+## Layout
+
+| Path | Lines | Purpose |
+|---|---:|---|
+| `Core/Src/main.c` | 1959 | Init, event loop, USB setup, GPIO / IRQ handlers. |
+| `Core/Src/if_commands.c` | 1105 | Command dispatcher — ~25 handlers in `app_handle_uartframe()`. |
+| `Core/Src/camera_manager.c` | 1598 | 8-camera orchestration, histogram streaming. SPI6 read from FPGA → buffer → USB HISTO. |
+| `Core/Src/0X02C1B.c` | 375 | OV2312 image-sensor register config (the file is literally named after the part). |
+| `Core/Src/crosslink.c` | 378 | Lattice CrossLink FPGA — I2C activation, IDCODE check, SRAM erase/program, status verify. Bitstream size hardcoded at line 339 (`163489`). |
+| `Core/Src/ICM20948.c` | 337 | 6-DOF IMU + magnetometer driver. |
+| `Core/Src/uart_comms.c` | 350 | UART packet framing with CRC-16. |
+| `Core/Src/flash_eeprom.c` | — | Persistent config storage at `0x081FE000`. |
+| `Core/Src/motion_config.c` | — | JSON config parsing / persistence. |
+| `Core/Src/histo_fake.c` | — | Synthetic histogram generator, gated by `DEBUG_FLAG_FAKE_DATA`. |
+| `Core/Src/i2c_protocol.c`, `i2c_master.c` | — | Multi-camera I2C bus management. |
+| `USB/Class/COMMS/Src/usbd_comms.c` | 554 | **IF 0** — bulk command/response. Endpoints `0x81` IN / `0x01` OUT, 512 B HS packets. |
+| `USB/Class/HISTO/Src/usbd_histo.c` | 451 | **IF 1** — histogram streaming, IN only, 32 KB packets. |
+| `USB/Class/IMU/Src/usbd_imu.c` | 497 | **IF 2** — IMU streaming, IN only, 200 B packets. |
+| `USB/Class/CompositeBuilder/` | — | Composite USB descriptor builder. |
+| `CMakeLists.txt` | — | FPGA download + merge_hex orchestration (lines 143–188). |
+| `merge_hex.py` | — | Combines firmware HEX + FPGA HEX. |
+
+## FPGA + camera flow (`crosslink.c:264-362`)
+
+FPGA is at I2C address `0x40`. Bring-up:
+
+1. Write 5-byte activation key (line 290).
+2. Read IDCODE via `0xE0`, expect `{0x01, 0x2C, 0x00, 0x43}`. Retry up to 3 times.
+3. Enable SRAM mode (`0xC6`, 1 ms delay).
+4. Erase SRAM (`0x0E`, **5 second delay**).
+5. Program SRAM (`0x46`, then stream the bitstream over I2C with 0x7A framing).
+6. Verify status (`0x3C`, check bit 2).
+7. Exit program mode (`0x26`).
+
+Histogram path: FPGA computes 1024-bin histograms from MIPI CSI-2 cameras → SPI6 → `spi6_buffer` in SRAM4 → `frame_buffer` (`camera_manager.c:40`) → USB HISTO endpoint.
+
+## Gotchas
+
+- **`crosslink.c:339` hardcodes the bitstream size** (`163489` bytes). If `openmotion-camera-fpga` ships a larger bitstream, programming will misalign and corrupt adjacent flash. Update both `crosslink.c:339` and verify against `memory_map.h` boundaries.
+- **Build fails hard when offline.** No cached bitstream fallback — pre-place `fpga/openmotion-camera-fpga.bin` before configuring if you're flying.
+- **I2C bus is single-threaded.** 8 cameras + FPGA all share one bus through the FPGA mux. No mutex / semaphore in `camera_manager.c`. Concurrent commands → deadlock.
+- **USB packet send is fire-and-forget.** `camera_manager.c:1306` has a TODO "handle the case where the packet fails to send better." Currently a failed USB TX silently drops the frame, no retry.
+- **UART reset at frame end** (`if_commands.c:714`, TODO): "fix this garbage, this resets the usart at the finish of a frame." Abrupt restart can drop late telemetry.
+- **Camera enumeration is not a real probe** (`if_commands.c:837`, TODO): "due to a bug in the scan camera sensors, we will just set `isPresent` for each of these to TRUE if it is powered." Don't trust `isPresent` for camera health.
+- **Debug flags can mask real sensor issues.** `DEBUG_FLAG_FAKE_DATA` injects synthetic histograms; `DEBUG_FLAG_HISTO_SPARSE` throttles to 15 s; `DEBUG_FLAG_HISTO_THROTTLE` throttles to 5 s. Check the active flags before diagnosing "no data."
+- **DFU entry path is unclear.** `OW_CMD_DFU` exists (`if_commands.c:174`) but it's not confirmed that bootloader DFU is fully wired here.
+
+## USB classes
+
+All three classes are independent bulk endpoints, each on its own interface:
+
+| IF | Class | Direction | Packet size | Endpoint |
+|---:|---|---|---:|---|
+| 0 | COMMS | bidirectional | 512 B HS | `0x81` IN, `0x01` OUT |
+| 1 | HISTO | IN only | 32,837 B | `0x81` IN |
+| 2 | IMU   | IN only | 200 B | `0x81` IN |
+
+To add a new endpoint: modify the class header (`usbd_<class>.h`) for endpoint defines, the class `.c` for callbacks, and `usbd_composite_builder.c` to add the class to the composite descriptor.
+
+To change a packet size: edit the `*_HS_MAX_PACKET_SIZE` macro in the class header; descriptors regenerate on build.
+
+## CI / releases
+
+- `.github/workflows/build-firmware.yml` — push to `main` / `next`, tag push (`v*.*.*` or `*-rc.*`), release event. Builds in Docker, uploads `.hex` and `.bin` as release artifacts, generates release notes from commit log.
+- Tags use **semantic versioning** (e.g. `1.2.3`, `1.2.3-rc.1`, `v0.1.0`).
+- Branching: feature branches off `next`, PR to `next`, `next` → `main` for tagging.
+- `tests/` directory exists but is empty (no unit tests).
+
+## "Start here" by task
+
+| Task | First files |
+|---|---|
+| Add a new command | `Core/Inc/common.h` (enum) → `Core/Src/if_commands.c` (case in `app_handle_uartframe()`) → return via `uartResp`. SDK side: `openmotion-sdk/omotion/MotionSensor.py` + `CommInterface.py`. |
+| Change histogram packet format | `USB_HISTO_MAX_SIZE` in `USB/Class/HISTO/Inc/usbd_histo.h` → `frame_buffer` in `camera_manager.c:40` → match parser in `openmotion-sdk/omotion/MotionProcessing.py`. |
+| Update FPGA bitstream pin / version | Edit URL at `CMakeLists.txt:145`, **and** confirm the new bitstream size matches `crosslink.c:339`. Reconfigure to redownload. |
+| Debug a camera that won't enumerate | Don't trust `isPresent` (`if_commands.c:837`). Set `DEBUG_FLAG_USB_PRINTF` via `OW_CMD_DEBUG_FLAGS`, watch UART for the init sequence, check I2C/SPI health via `OW_IMU_*` / `OW_CAMERA_*`. |
+| Investigate dropped histograms | `camera_manager.c:1306` (USB TX failures are silent), plus any active `DEBUG_FLAG_HISTO_*` throttles. |
+| Touch persistent config | `Core/Src/flash_eeprom.c` + `motion_config.c`. Respect sector 7 bank 2 boundary at `0x081FE000`. |

--- a/Core/Inc/X02C1B_Sensor_Config.h
+++ b/Core/Inc/X02C1B_Sensor_Config.h
@@ -726,18 +726,18 @@ static struct regval_list X02C1B_SENSOR_CONFIG[] = {
 		{0x380f, 0xD0},
 		{0x386d, 0x09},
 		{0x386e, 0x04},
-		/* Exposure 70 rows = 630 us. The measured optical laser pulse is
-		 * 494 us regardless of the console gate width (fully captured at
-		 * >= 528 us of exposure; knee measured per-camera on both modules,
-		 * plus delay sweeps at 500 us and 600 us gates, 2026-07-02 drift
-		 * campaign). The previous 122 rows (1098 us) integrated ~570 us of
-		 * pure dark current past the pulse, doubling the gain-scaled
-		 * black-level drift for zero extra signal. 70 rows keeps ~136 us of
-		 * total timing slack (vs 64 us at the 62-row alternative) while
-		 * still cutting the dark-current integral 1.74x. LaserPulseDelayUsec
-		 * stays 100 (measured plateau center). */
+		/* Exposure 72 rows = 648 us (bench decision: ~650 us). The measured
+		 * optical laser pulse is 494 us regardless of the console gate width
+		 * (per-camera exposure staircase + delay sweeps at 500 us and 600 us
+		 * gates, 2026-07-02 drift campaign; capture knee at 528 us,
+		 * LaserPulseDelayUsec=100 = measured plateau center). The previous
+		 * 122 rows (1098 us) integrated ~570 us of pure dark current past
+		 * the pulse, doubling the gain-scaled black-level drift that shows
+		 * up as camera-to-camera image-mean divergence, for zero extra
+		 * signal. 72 rows keeps ~154 us of timing slack and cuts the
+		 * dark-current integral 1.7x. */
 		{0x3501, 0x00},
-		{0x3502, 0x46},
+		{0x3502, 0x48},
 		{0x3823, 0x20},
 		{0x382e, 0x03},
 		{0x3861, 0x00},

--- a/Core/Inc/X02C1B_Sensor_Config.h
+++ b/Core/Inc/X02C1B_Sensor_Config.h
@@ -726,15 +726,18 @@ static struct regval_list X02C1B_SENSOR_CONFIG[] = {
 		{0x380f, 0xD0},
 		{0x386d, 0x09},
 		{0x386e, 0x04},
-		/* Exposure 62 rows = 558 us. The measured optical laser pulse is
-		 * 494 us (fully captured at >= 528 us of exposure; knee measured
-		 * per-camera on both modules, 2026-07-02 drift campaign). The
-		 * previous 122 rows (1098 us) integrated ~570 us of pure dark
-		 * current past the pulse, doubling the gain-scaled black-level
-		 * drift for zero extra signal. 62 rows keeps ~30 us of margin at
-		 * both pulse edges with no laser timing change. */
+		/* Exposure 70 rows = 630 us. The measured optical laser pulse is
+		 * 494 us regardless of the console gate width (fully captured at
+		 * >= 528 us of exposure; knee measured per-camera on both modules,
+		 * plus delay sweeps at 500 us and 600 us gates, 2026-07-02 drift
+		 * campaign). The previous 122 rows (1098 us) integrated ~570 us of
+		 * pure dark current past the pulse, doubling the gain-scaled
+		 * black-level drift for zero extra signal. 70 rows keeps ~136 us of
+		 * total timing slack (vs 64 us at the 62-row alternative) while
+		 * still cutting the dark-current integral 1.74x. LaserPulseDelayUsec
+		 * stays 100 (measured plateau center). */
 		{0x3501, 0x00},
-		{0x3502, 0x3e},
+		{0x3502, 0x46},
 		{0x3823, 0x20},
 		{0x382e, 0x03},
 		{0x3861, 0x00},

--- a/Core/Inc/X02C1B_Sensor_Config.h
+++ b/Core/Inc/X02C1B_Sensor_Config.h
@@ -726,8 +726,15 @@ static struct regval_list X02C1B_SENSOR_CONFIG[] = {
 		{0x380f, 0xD0},
 		{0x386d, 0x09},
 		{0x386e, 0x04},
+		/* Exposure 62 rows = 558 us. The measured optical laser pulse is
+		 * 494 us (fully captured at >= 528 us of exposure; knee measured
+		 * per-camera on both modules, 2026-07-02 drift campaign). The
+		 * previous 122 rows (1098 us) integrated ~570 us of pure dark
+		 * current past the pulse, doubling the gain-scaled black-level
+		 * drift for zero extra signal. 62 rows keeps ~30 us of margin at
+		 * both pulse edges with no laser timing change. */
 		{0x3501, 0x00},
-		{0x3502, 0x7a},
+		{0x3502, 0x3e},
 		{0x3823, 0x20},
 		{0x382e, 0x03},
 		{0x3861, 0x00},
@@ -738,6 +745,12 @@ static struct regval_list X02C1B_SENSOR_CONFIG[] = {
 		{0x3883, 0xd0},
 		{0x3880, 0x05},
 		{0x4800, 0x14},
+		/* Always leave test-pattern mode: 0x5100 was previously absent
+		 * from this table, and OW_CAMERA_SET_CONFIG skips cameras it
+		 * considers already configured — so a camera left in test-pattern
+		 * mode by tooling kept streaming synthetic data through later
+		 * scans while looking healthy. */
+		{0x5100, 0x00},
 };
 
 #endif /* INC_X02C1B_SENSOR_CONFIG_H_ */

--- a/Core/Inc/camera_manager.h
+++ b/Core/Inc/camera_manager.h
@@ -100,6 +100,9 @@ _Bool abort_data_reception(uint8_t cam_id);
  * Incremented in the HAL error callbacks (main.c); reset at scan start, dumped at
  * scan end (camera_manager.c). */
 extern volatile uint32_t cam_overrun_count[CAMERA_COUNT];
+/* #68: frame-sync timestamp captured in the FSIN ISR (main.c); used as the
+ * histogram packet timestamp so it is correct regardless of deferred-send timing. */
+extern volatile uint32_t fsin_timestamp_ms;
 _Bool send_data(void);
 _Bool send_fake_data(void);
 _Bool send_histogram_data(void);

--- a/Core/Inc/camera_manager.h
+++ b/Core/Inc/camera_manager.h
@@ -46,7 +46,7 @@ typedef struct {
 	 * thermal shutdown etc.); cleared when program_fpga() completes a real
 	 * bring-up or the host explicitly powers the camera off. */
 	bool		needs_recovery;
-	uint32_t	recovery_repower_at;	/* get_timestamp_ms() deadline to re-power the rail */
+	uint32_t	recovery_repower_at;	/* HAL_GetTick() deadline to re-power the rail */
 } CameraDevice;
 
 #define CAMERA_COUNT	8

--- a/Core/Inc/camera_manager.h
+++ b/Core/Inc/camera_manager.h
@@ -96,6 +96,10 @@ _Bool capture_single_histogram(uint8_t cam_id);
 _Bool get_single_histogram(uint8_t cam_id, uint8_t* data, uint16_t* data_len);
 _Bool start_data_reception(uint8_t cam_id);
 _Bool abort_data_reception(uint8_t cam_id);
+/* #68 instrumentation: per-camera SPI/USART RX overrun counts for the current scan.
+ * Incremented in the HAL error callbacks (main.c); reset at scan start, dumped at
+ * scan end (camera_manager.c). */
+extern volatile uint32_t cam_overrun_count[CAMERA_COUNT];
 _Bool send_data(void);
 _Bool send_fake_data(void);
 _Bool send_histogram_data(void);

--- a/Core/Inc/camera_manager.h
+++ b/Core/Inc/camera_manager.h
@@ -100,6 +100,25 @@ _Bool abort_data_reception(uint8_t cam_id);
  * Incremented in the HAL error callbacks (main.c); reset at scan start, dumped at
  * scan end (camera_manager.c). */
 extern volatile uint32_t cam_overrun_count[CAMERA_COUNT];
+
+/* #70: printf-independent diagnostics snapshot, queryable over OW_CMD_DIAG_STATS
+ * regardless of DEBUG_FLAG_USB_PRINTF. Fixed 8-byte-aligned wire layout returned
+ * verbatim — do not reorder fields without bumping CAM_DIAG_STATS_VERSION and the
+ * SDK parser (omotion/MotionSensor.py get_diag_stats()). */
+#define CAM_DIAG_STATS_VERSION 1u
+typedef struct __attribute__((packed)) {
+	uint8_t  version;                       /* = CAM_DIAG_STATS_VERSION */
+	uint8_t  reserved[3];                   /* pad to 4-byte alignment for the u32s below */
+	uint32_t cam_overrun_count[CAMERA_COUNT]; /* per-camera SPI/USART RX overruns, this scan */
+	uint32_t cmp_fail_count;                /* rle_compress dst_max overflow, this scan */
+	uint32_t cmp_timeout_count;              /* rle_compress hit its time budget, this scan */
+	uint32_t cmp_fallback_count;             /* frames sent uncompressed due to either above */
+	uint32_t cmp_max_time_us;                /* worst-case compression time this scan */
+} cam_diag_stats_t;
+
+/* Snapshot the live counters above into *out. Safe to call any time (main loop
+ * or command-handler context); does not reset anything. */
+void camera_manager_get_diag_stats(cam_diag_stats_t *out);
 /* #68: frame-sync timestamp captured in the FSIN ISR (main.c); used as the
  * histogram packet timestamp so it is correct regardless of deferred-send timing. */
 extern volatile uint32_t fsin_timestamp_ms;

--- a/Core/Inc/common.h
+++ b/Core/Inc/common.h
@@ -32,6 +32,8 @@
 #define DEBUG_FLAG_CMD_VERBOSE (1u << 5)  /* Enable printf in command handlers (if_commands.c) */
 #define DEBUG_FLAG_HISTO_CMP  (1u << 6)  /* Send compressed histogram packets (TYPE_HISTO_CMP) */
 #define DEBUG_FLAG_SEND_DEFER (1u << 7)  /* #68: FSIN ISR only flips send_data_flag; main loop runs send_data() */
+#define DEBUG_FLAG_HISTO_STALL (1u << 8) /* #75: stop sending histogram frames after HISTO_STALL_TRIGGER_FRAMES;
+                                          * cameras/SPI/USB stay alive — deterministic host-visible stall repro */
 
 
 #define I2C_IRQ_PRIORITY 0

--- a/Core/Inc/common.h
+++ b/Core/Inc/common.h
@@ -90,6 +90,7 @@ typedef enum {
 
 typedef enum {
 	OW_CMD_PING = 0x00,
+	OW_CMD_DIAG_STATS = 0x01,  /* #70: cam_diag_stats_t snapshot, printf-independent */
 	OW_CMD_VERSION = 0x02,
 	OW_CMD_ECHO = 0x03,
 	OW_CMD_TOGGLE_LED = 0x04,

--- a/Core/Inc/common.h
+++ b/Core/Inc/common.h
@@ -31,6 +31,7 @@
 #define DEBUG_FLAG_COMM_VERBOSE (1u << 4)  /* Enable cmd id and "." response prints in uart_comms */
 #define DEBUG_FLAG_CMD_VERBOSE (1u << 5)  /* Enable printf in command handlers (if_commands.c) */
 #define DEBUG_FLAG_HISTO_CMP  (1u << 6)  /* Send compressed histogram packets (TYPE_HISTO_CMP) */
+#define DEBUG_FLAG_SEND_DEFER (1u << 7)  /* #68: FSIN ISR only flips send_data_flag; main loop runs send_data() */
 
 
 #define I2C_IRQ_PRIORITY 0

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -78,6 +78,8 @@ static bool streaming_first_frame = false;
 // Camera failure detection
 #define CAMERA_FAILURE_THRESHOLD_CYCLES 3  // Number of consecutive cycles before reporting failure
 static uint8_t camera_failure_counters[CAMERA_COUNT] = {0};  // Track consecutive cycles without event bits
+/* #68 instrumentation: per-camera RX overrun counts (set in main.c error callbacks). */
+volatile uint32_t cam_overrun_count[CAMERA_COUNT] = {0};
 
  __ALIGN_BEGIN __attribute__((section(".sram4"))) volatile uint8_t spi6_buffer[SPI_PACKET_LENGTH] __ALIGN_END;
 
@@ -1425,6 +1427,8 @@ _Bool send_data(void) {
 		streaming_start_time = get_timestamp_ms();
 		streaming_active = true;
 		streaming_first_frame = true;
+		/* #68 instrumentation: zero per-camera overrun counts at scan start. */
+		for (uint8_t ci = 0; ci < CAMERA_COUNT; ci++) { cam_overrun_count[ci] = 0; }
 	}
 
 	// Sometimes the frame sync fires 4ms after the previous frame due to electrical noise. Ignore these.
@@ -1489,6 +1493,12 @@ _Bool check_streaming(void){
 			if(total_frames_failed > 0){
 				printf("%lu frames failed\r\n", total_frames_failed);
 			}
+			/* #68 instrumentation: per-camera RX overrun counts this scan. */
+			printf("[DIAG] overruns c1-c8: %lu %lu %lu %lu %lu %lu %lu %lu\r\n",
+			       (unsigned long)cam_overrun_count[0], (unsigned long)cam_overrun_count[1],
+			       (unsigned long)cam_overrun_count[2], (unsigned long)cam_overrun_count[3],
+			       (unsigned long)cam_overrun_count[4], (unsigned long)cam_overrun_count[5],
+			       (unsigned long)cam_overrun_count[6], (unsigned long)cam_overrun_count[7]);
 			/* Print compression stats if compression was used */
 			if (cmp_frame_count > 0) {
 				uint32_t avg_ratio = (cmp_total_compressed * 100) / cmp_total_uncompressed;

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -65,9 +65,16 @@ static volatile uint32_t total_frames_failed = 0;
 static uint32_t cmp_total_uncompressed = 0;  // Sum of all uncompressed payload sizes
 static uint32_t cmp_total_compressed = 0;    // Sum of all compressed payload sizes
 static uint32_t cmp_frame_count = 0;         // Number of compressed frames sent
-static uint32_t cmp_fail_count = 0;          // Number of compression failures
+static uint32_t cmp_fail_count = 0;          // Number of compression failures (dst_max overflow)
 static uint32_t cmp_usb_fail_count = 0;      // Number of USB send failures (compressed)
 static uint32_t cmp_max_time_us = 0;         // Worst-case compression time in µs
+/* #70: rle_compress hit its hard time budget (still falls back to uncompressed,
+ * same as a dst_max overflow) — see CMP_BUDGET_HARD_US below. */
+static volatile uint32_t cmp_timeout_count = 0;
+/* #70: frames actually sent uncompressed because compression didn't finish in
+ * budget/space (cmp_timeout_count + cmp_fail_count, kept as its own counter so
+ * a query doesn't need to add two fields to know "how many frames fell back"). */
+static volatile uint32_t cmp_fallback_count = 0;
 
 #define STREAMING_TIMEOUT_MS 150
 static volatile uint32_t most_recent_frame_time = 0;
@@ -80,6 +87,22 @@ static bool streaming_first_frame = false;
 static uint8_t camera_failure_counters[CAMERA_COUNT] = {0};  // Track consecutive cycles without event bits
 /* #68 instrumentation: per-camera RX overrun counts (set in main.c error callbacks). */
 volatile uint32_t cam_overrun_count[CAMERA_COUNT] = {0};
+
+/* #70: printf-independent snapshot for OW_CMD_DIAG_STATS (if_commands.c) — see
+ * cam_diag_stats_t in camera_manager.h. Plain field copy, no critical section:
+ * these are diagnostic counters (worst case a torn read mixes adjacent scans'
+ * values briefly), same tolerance as the existing [DIAG] printf dump. */
+void camera_manager_get_diag_stats(cam_diag_stats_t *out) {
+	out->version = CAM_DIAG_STATS_VERSION;
+	out->reserved[0] = 0; out->reserved[1] = 0; out->reserved[2] = 0;
+	for (uint8_t i = 0; i < CAMERA_COUNT; i++) {
+		out->cam_overrun_count[i] = cam_overrun_count[i];
+	}
+	out->cmp_fail_count = cmp_fail_count;
+	out->cmp_timeout_count = cmp_timeout_count;
+	out->cmp_fallback_count = cmp_fallback_count;
+	out->cmp_max_time_us = cmp_max_time_us;
+}
 
  __ALIGN_BEGIN __attribute__((section(".sram4"))) volatile uint8_t spi6_buffer[SPI_PACKET_LENGTH] __ALIGN_END;
 
@@ -1429,6 +1452,15 @@ _Bool send_data(void) {
 		streaming_first_frame = true;
 		/* #68 instrumentation: zero per-camera overrun counts at scan start. */
 		for (uint8_t ci = 0; ci < CAMERA_COUNT; ci++) { cam_overrun_count[ci] = 0; }
+		/* #70: zero the compression-guard counters at scan START (not stop, like
+		 * cmp_total_uncompressed/cmp_frame_count etc below) — these are part of
+		 * cam_diag_stats_t (OW_CMD_DIAG_STATS), and a host naturally queries
+		 * diagnostics AFTER a scan finishes. Resetting at stop would zero them
+		 * before that query ever has a chance to read the scan's actual tally. */
+		cmp_fail_count = 0;
+		cmp_timeout_count = 0;
+		cmp_fallback_count = 0;
+		cmp_max_time_us = 0;
 	}
 
 	// Sometimes the frame sync fires 4ms after the previous frame due to electrical noise. Ignore these.
@@ -1506,6 +1538,12 @@ _Bool check_streaming(void){
 			       (unsigned long)cam_overrun_count[2], (unsigned long)cam_overrun_count[3],
 			       (unsigned long)cam_overrun_count[4], (unsigned long)cam_overrun_count[5],
 			       (unsigned long)cam_overrun_count[6], (unsigned long)cam_overrun_count[7]);
+			/* #70 instrumentation: compression budget-guard fallback counts this scan. */
+			if (cmp_timeout_count > 0 || cmp_fail_count > 0) {
+				printf("[DIAG] cmp fallback: timeout=%lu overflow=%lu total=%lu\r\n",
+				       (unsigned long)cmp_timeout_count, (unsigned long)cmp_fail_count,
+				       (unsigned long)cmp_fallback_count);
+			}
 			/* Print compression stats if compression was used */
 			if (cmp_frame_count > 0) {
 				uint32_t avg_ratio = (cmp_total_compressed * 100) / cmp_total_uncompressed;
@@ -1527,9 +1565,11 @@ _Bool check_streaming(void){
 			cmp_total_uncompressed = 0;
 			cmp_total_compressed = 0;
 			cmp_frame_count = 0;
-			cmp_fail_count = 0;
 			cmp_usb_fail_count = 0;
-			cmp_max_time_us = 0;
+			/* cmp_fail_count / cmp_timeout_count / cmp_fallback_count / cmp_max_time_us
+			 * are NOT reset here — see the #70 comment at their scan-START reset
+			 * in send_data(), above. They still get printed just above, before
+			 * this block runs, same as always. */
 			streaming_active = false;
 		}
 	}
@@ -1638,11 +1678,23 @@ _Bool send_histogram_data(void) {
 	return status;
 }
 
+/* #70: hard deadline for rle_compress, in microseconds. The frame period is
+ * ~25 ms (40 fps); 15 ms leaves headroom for the payload copy + USB send +
+ * per-camera re-arm that share the same budget. Above CMP_BUDGET_WARNING_US
+ * (10 ms) is just a yellow-flag printf; at CMP_BUDGET_HARD_US the compressor
+ * aborts and the caller falls back to an uncompressed frame instead of
+ * risking the next frame's SPI/USART overrun (sensor-fw#70). */
+#define CMP_BUDGET_HARD_US 15000UL  /* 15 ms */
+
 /*
  * PackBits-style byte-level RLE compressor.
  * Control byte < 0x80: literal run of (ctrl + 1) bytes follow (1–128).
  * Control byte >= 0x80: repeat run – next byte repeated (ctrl - 0x80 + 3) times (3–130).
- * Returns compressed size, or -1 if dst_max would be exceeded.
+ * Returns compressed size, -1 if dst_max would be exceeded, or -2 if
+ * deadline_cyccnt (a DWT->CYCCNT value) is reached before finishing — checked
+ * once per encoded run/literal chunk (at most ~130 bytes of overshoot, i.e.
+ * negligible next to the µs-scale budget). Both negative returns mean the
+ * caller should fall back to sending the frame uncompressed.
  *
  * NOTE: __attribute__((optimize("O3"))) forces GCC to compile this single
  * function at -O3 even when the rest of the file is built at -O0 or -Og.
@@ -1651,11 +1703,20 @@ _Bool send_histogram_data(void) {
  *   -O0 / compressible data:    ~9 ms   (barely OK for zeros/fake data)
  *   -O0 / incompressible data: ~37 ms   (EXCEEDS budget → SPI overrun!)
  *   -O3 / incompressible data: ~3–5 ms  (safe margin)
+ *   -O3 / pathological (camera brownout garbage): observed ~25 ms on hardware
+ *   (sensor-fw#70) — i.e. even -O3 doesn't bound the worst case; the deadline
+ *   check below does.
  */
 __attribute__((optimize("O3")))
-static int rle_compress(const uint8_t *src, int src_len, uint8_t *dst, int dst_max) {
+static int rle_compress(const uint8_t *src, int src_len, uint8_t *dst, int dst_max,
+                         uint32_t deadline_cyccnt) {
 	int si = 0, di = 0;
 	while (si < src_len) {
+		/* Wrap-safe "now >= deadline" check (same pattern as
+		 * camera_recovery_tick's cool-off timer elsewhere in this file). */
+		if ((int32_t)(DWT->CYCCNT - deadline_cyccnt) >= 0) {
+			return -2;
+		}
 		/* Try to find a run of identical bytes (min 3) */
 		uint8_t val = src[si];
 		int run_start = si;
@@ -1688,6 +1749,42 @@ static int rle_compress(const uint8_t *src, int src_len, uint8_t *dst, int dst_m
 		}
 	}
 	return di;
+}
+
+/* #70: ship the already-staged uncompressed payload (built in
+ * send_histogram_data_cmp before compression) as a plain TYPE_HISTO frame.
+ * Used when rle_compress can't finish in time/space, so a slow or
+ * incompressible frame is sent rather than silently dropped. Wire format is
+ * byte-identical to a normal TYPE_HISTO frame from send_histogram_data(), so
+ * the host needs no special handling — it just sees an uncompressed frame
+ * for that one interval. */
+static _Bool send_uncompressed_histo(const uint8_t *payload, int payload_len) {
+	uint32_t total_size = HISTO_HEADER_SIZE + (uint32_t)payload_len + HISTO_TRAILER_SIZE;
+	if (HISTO_JSON_BUFFER_SIZE < total_size) {
+		printf("[CMP] fallback packet too large (%lu), dropping frame\r\n",
+		       (unsigned long)total_size);
+		return false;
+	}
+
+	int offset = 0;
+	packet_buffer[offset++] = HISTO_SOF;
+	packet_buffer[offset++] = TYPE_HISTO;
+	packet_buffer[offset++] = (uint8_t)(total_size & 0xFF);
+	packet_buffer[offset++] = (uint8_t)((total_size >> 8) & 0xFF);
+	packet_buffer[offset++] = (uint8_t)((total_size >> 16) & 0xFF);
+	packet_buffer[offset++] = (uint8_t)((total_size >> 24) & 0xFF);
+
+	memcpy(packet_buffer + offset, payload, (size_t)payload_len);
+	offset += payload_len;
+
+	uint16_t crc = util_crc16(packet_buffer, offset - 1);
+	packet_buffer[offset++] = crc & 0xFF;
+	packet_buffer[offset++] = (crc >> 8) & 0xFF;
+	packet_buffer[offset++] = HISTO_EOF;
+
+	uint8_t tx_status = USBD_HISTO_SendData(&hUsbDeviceHS, packet_buffer, offset, 0);
+	frame_id++;
+	return tx_status == USBD_OK;
 }
 
 _Bool send_histogram_data_cmp(void) {
@@ -1757,8 +1854,9 @@ _Bool send_histogram_data_cmp(void) {
 	int dst_max = HISTO_JSON_BUFFER_SIZE - HISTO_HEADER_SIZE - HISTO_CMP_UNCMP_CRC_SIZE - HISTO_TRAILER_SIZE;
 
 	uint32_t cyc_start = DWT->CYCCNT;
+	uint32_t deadline_cyccnt = cyc_start + (SystemCoreClock / 1000000u) * CMP_BUDGET_HARD_US;
 	int cmp_len = rle_compress(uncmp_payload, p_off,
-	                           packet_buffer + HISTO_HEADER_SIZE, dst_max);
+	                           packet_buffer + HISTO_HEADER_SIZE, dst_max, deadline_cyccnt);
 	uint32_t cyc_elapsed = DWT->CYCCNT - cyc_start;
 	uint32_t elapsed_us = cyc_elapsed / (SystemCoreClock / 1000000u);
 
@@ -1767,10 +1865,23 @@ _Bool send_histogram_data_cmp(void) {
 	}
 
 	if (cmp_len < 0) {
-		cmp_fail_count++;
-		printf("[CMP] FAIL: compression overflow, %d cams, uncmp=%d, dst_max=%d, time=%luus (fail #%lu)\r\n",
-		       count, p_off, dst_max, (unsigned long)elapsed_us, (unsigned long)cmp_fail_count);
-		return false;
+		/* #70: compression couldn't finish in time (-2) or space (-1) — ship
+		 * the frame uncompressed instead of dropping it, so neither failure
+		 * mode costs data or leaves the next frame's SPI/USART re-arm late. */
+		if (cmp_len == -2) {
+			cmp_timeout_count++;
+			printf("[CMP] TIMEOUT: compression exceeded %lu us budget (ran %lu us), "
+			       "%d cams, falling back to uncompressed (#%lu)\r\n",
+			       (unsigned long)CMP_BUDGET_HARD_US, (unsigned long)elapsed_us, count,
+			       (unsigned long)cmp_timeout_count);
+		} else {
+			cmp_fail_count++;
+			printf("[CMP] OVERFLOW: compression overflow, %d cams, uncmp=%d, dst_max=%d, "
+			       "time=%luus, falling back to uncompressed (#%lu)\r\n",
+			       count, p_off, dst_max, (unsigned long)elapsed_us, (unsigned long)cmp_fail_count);
+		}
+		cmp_fallback_count++;
+		return send_uncompressed_histo(uncmp_payload, p_off);
 	}
 
 	/* Warn if compression time is eating into the frame budget.

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -1485,6 +1485,13 @@ _Bool check_streaming(void){
 		}
 		if((current_time - most_recent_frame_time_local) > STREAMING_TIMEOUT_MS){
 			uint32_t elapsed = current_time - streaming_start_time;
+			/* #68: this terminal flush is NOT driven by a fresh FSIN, so the
+			 * ISR-captured fsin_timestamp_ms would be stale (the previous frame's
+			 * time) here. Stamp it now so the terminal frame carries a current
+			 * timestamp — i.e. the ~150 ms off-grid laser-off frame the host already
+			 * expects and re-times. Harmless if the dark frame was already sent by
+			 * its own off-grid FSIN (then there is no data left to flush). */
+			fsin_timestamp_ms = get_timestamp_ms();
 			send_data(); // send data one last frame to finish the buffers
 			if (total_frames_failed > 0) {
 				total_frames_failed--;  // first frame skip / last frame extra
@@ -1578,7 +1585,7 @@ _Bool send_histogram_data(void) {
     packet_buffer[offset++] = (uint8_t)((total_size >> 24) & 0xFF);
 	
 	// --- Timestamp ---
-	uint32_t timestamp = get_timestamp_ms();
+	uint32_t timestamp = fsin_timestamp_ms;  /* #68: stamped at FSIN, not at (possibly deferred) send time */
 	packet_buffer[offset++] = (uint8_t)(timestamp & 0xFF);
 	packet_buffer[offset++] = (uint8_t)((timestamp >> 8) & 0xFF);
 	packet_buffer[offset++] = (uint8_t)((timestamp >> 16) & 0xFF);
@@ -1717,7 +1724,7 @@ _Bool send_histogram_data_cmp(void) {
 	/* --- Build uncompressed payload into uncmp_payload --- */
 
 	/* Timestamp (4 bytes) */
-	uint32_t timestamp = get_timestamp_ms();
+	uint32_t timestamp = fsin_timestamp_ms;  /* #68: stamped at FSIN, not at (possibly deferred) send time */
 	uncmp_payload[p_off++] = (uint8_t)(timestamp & 0xFF);
 	uncmp_payload[p_off++] = (uint8_t)((timestamp >> 8) & 0xFF);
 	uncmp_payload[p_off++] = (uint8_t)((timestamp >> 16) & 0xFF);
@@ -1857,7 +1864,7 @@ _Bool send_fake_data(void) {
 	packet_buffer[offset++] = (uint8_t)((total_size >> 24) & 0xFF);
 	
 	// --- Timestamp ---
-	uint32_t timestamp = get_timestamp_ms();
+	uint32_t timestamp = fsin_timestamp_ms;  /* #68: stamped at FSIN, not at (possibly deferred) send time */
 	packet_buffer[offset++] = (uint8_t)(timestamp & 0xFF);
 	packet_buffer[offset++] = (uint8_t)((timestamp >> 8) & 0xFF);
 	packet_buffer[offset++] = (uint8_t)((timestamp >> 16) & 0xFF);

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -1100,9 +1100,13 @@ _Bool configure_camera_testpattern(uint8_t cam_id, uint8_t test_pattern)
 
 static void poll_camera_temperatures(void)
 {
-    uint32_t now = get_timestamp_ms();
+    /* HAL_GetTick(), NOT get_timestamp_ms(): the TIM5-derived clock wraps at
+     * 2^32/100 ms (~11.93 h of uptime), so deadlines scheduled on it freeze
+     * this gate for hours — or forever, if scheduled within the last poll
+     * interval before the wrap (#73). */
+    uint32_t now = HAL_GetTick();
 
-    if ((next_temp_ms == 0u) || (now >= next_temp_ms))
+    if ((int32_t)(now - next_temp_ms) >= 0)
     {
         /* Schedule from current time to keep a constant cadence without catch-up bursts. */
         next_temp_ms = now + CAM_TEMP_POLL_INTERVAL_MS;
@@ -1197,7 +1201,9 @@ static void camera_death_isolate(uint8_t cam_id)
     cam->isProgrammed = false;
     cam->isConfigured = false;
     cam->streaming_enabled = false;
-    cam->recovery_repower_at = get_timestamp_ms() + CAMERA_RECOVERY_OFF_MS;
+    /* HAL_GetTick(), NOT get_timestamp_ms(): the TIM5-derived clock wraps at
+     * ~11.93 h, which stretched this 10 s cool-off into hours (#73). */
+    cam->recovery_repower_at = HAL_GetTick() + CAMERA_RECOVERY_OFF_MS;
 
     printf("Camera %d: rail off for %u ms (regulator cool-off)\r\n",
            cam_id + 1, (unsigned)CAMERA_RECOVERY_OFF_MS);
@@ -1210,7 +1216,7 @@ static void camera_death_isolate(uint8_t cam_id)
  * bring-up at the next scan. Main-loop only. */
 static void camera_recovery_tick(void)
 {
-    uint32_t now = get_timestamp_ms();
+    uint32_t now = HAL_GetTick();  /* must match camera_death_isolate's timebase */
 
     for (uint8_t cam_id = 0; cam_id < CAMERA_COUNT; cam_id++) {
         CameraDevice *cam = &cam_array[cam_id];
@@ -1361,10 +1367,12 @@ _Bool capture_single_histogram(uint8_t cam_id)
 	HAL_GPIO_WritePin(FSIN_GPIO_Port, FSIN_Pin, GPIO_PIN_RESET);
 	delay_ms(2);
 
-	uint32_t timeout = get_timestamp_ms() + 5000; // 100ms timeout example
+	/* HAL_GetTick() + wrap-safe compare: a get_timestamp_ms() deadline set
+	 * within 5 s of its ~11.93 h wrap is unreachable → infinite loop (#73). */
+	uint32_t timeout = HAL_GetTick() + 5000;
 
 	while(!event_bits) {
-	    if (get_timestamp_ms() > timeout) {
+	    if ((int32_t)(HAL_GetTick() - timeout) >= 0) {
 	        printf("HISTO receive timeout!\r\n");
 	        if(cam->useUsart) {
 	            HAL_DMA_Abort(cam->pUart->hdmarx); // safely abort DMA

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -2062,6 +2062,20 @@ _Bool enable_camera_stream(uint8_t cam_id){
 	event_bits &= ~(1u << cam_id);
 	__enable_irq();
 
+	/* Flush this camera's receive buffer before arming DMA. The FPGA is
+	 * re-programmed at every scan start (its frame counter resets to 1), but
+	 * the MCU's frame_buffer/spi6_buffer still holds the PREVIOUS scan's last
+	 * DMA'd frame — old FPGA frame_id and timestamp. If a send fires before
+	 * the first fresh DMA completes, that stale frame ships ahead of frame 1,
+	 * desyncing the host's frame-id unwrap and dark schedule (issue #172:
+	 * left-sensor "stale 255/173 with negative timestamps at scan start").
+	 * Zeroing it makes any premature send an obvious empty frame, not stale
+	 * data. capture_single_histogram() clears the buffer the same way. */
+	if (cam->pRecieveHistoBuffer != NULL) {
+		memset((uint8_t *)cam->pRecieveHistoBuffer, 0,
+			cam->useUsart ? USART_PACKET_LENGTH : SPI_PACKET_LENGTH);
+	}
+
 	/* Arm DMA BEFORE stream_on so the receiver is ready when the sensor
 	 * starts clocking data.  Arming after stream_on causes an immediate SPI
 	 * overrun on fast cameras (e.g. SPI4 / cam 8). */

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -82,6 +82,19 @@ static volatile uint32_t streaming_start_time = 0;
 static bool streaming_active = false;
 static bool streaming_first_frame = false;
 
+/* #75: DEBUG_FLAG_HISTO_STALL — deterministic host-visible stall repro for the
+ * bloodflow app's E-303 all-cameras-stalled watchdog (app#248/app#174/PR #294).
+ * When the flag is set, streaming runs normally for HISTO_STALL_TRIGGER_FRAMES
+ * frames, then send_data() silently stops emitting histogram USB frames while
+ * everything else stays healthy: cameras keep streaming, event bits keep being
+ * consumed, SPI receptions keep re-arming (so check_camera_failures() never
+ * trips and no rail-off recovery fires), temp polling and command handling
+ * continue, USB stays enumerated. This simulates the HOST-visible signature of
+ * the #68 FSIN-ISR starvation fault on demand. State resets at scan start. */
+#define HISTO_STALL_TRIGGER_FRAMES 1800u  /* ~45 s at 40 fps */
+static uint32_t histo_stall_frame_count = 0;
+static bool histo_stall_tripped = false;
+
 // Camera failure detection
 #define CAMERA_FAILURE_THRESHOLD_CYCLES 3  // Number of consecutive cycles before reporting failure
 static uint8_t camera_failure_counters[CAMERA_COUNT] = {0};  // Track consecutive cycles without event bits
@@ -1450,6 +1463,26 @@ static void check_camera_failures(void) {
 	}
 }
 
+/* #75: consume this frame's camera data WITHOUT sending it to the host.
+ * Mirrors the event-bit consume + per-camera re-arm that send_histogram_data()
+ * would have done (same masking rationale — see the comment there), so the
+ * cameras/SPI pipeline keeps flowing and check_camera_failures() stays happy;
+ * only the USB HISTO frame is withheld. Short-circuits BEFORE compression, so
+ * the #70 cmp budget guard never runs on a suppressed frame. */
+static _Bool histo_stall_suppress_frame(void) {
+	uint8_t ready_bits;
+	__disable_irq();
+	ready_bits = event_bits & event_bits_enabled;
+	event_bits = 0x00;
+	__enable_irq();
+	for (uint8_t cam_id = 0; cam_id < CAMERA_COUNT; ++cam_id) {
+		if ((ready_bits & (1u << cam_id)) != 0) {
+			start_data_reception(cam_id);
+		}
+	}
+	return true;  /* pretend success, like DEBUG_FLAG_HISTO_THROTTLE does */
+}
+
 _Bool send_data(void) {
 
 	// Take care of statistics
@@ -1469,6 +1502,14 @@ _Bool send_data(void) {
 		cmp_timeout_count = 0;
 		cmp_fallback_count = 0;
 		cmp_max_time_us = 0;
+		/* #75: re-arm the histo-stall repro each scan (stall persists until scan
+		 * stop; the next scan streams normally again until the trigger point). */
+		histo_stall_frame_count = 0;
+		histo_stall_tripped = false;
+		if ((logging_get_debug_flags() & DEBUG_FLAG_HISTO_STALL) != 0u) {
+			printf("DEBUG: histo stall armed, trips at frame %lu\r\n",
+			       (unsigned long)HISTO_STALL_TRIGGER_FRAMES);
+		}
 	}
 
 	// Sometimes the frame sync fires 4ms after the previous frame due to electrical noise. Ignore these.
@@ -1494,7 +1535,25 @@ _Bool send_data(void) {
 	
 	bool success = false;
 	uint32_t dflags = logging_get_debug_flags();
-	if ((dflags & DEBUG_FLAG_FAKE_DATA) != 0u) {
+	/* #75: DEBUG_FLAG_HISTO_STALL — count frames; past the trigger point,
+	 * suppress the send entirely (all modes: fake, compressed, plain). This
+	 * runs at the common send entry, so it behaves identically whether
+	 * send_data() was called from the FSIN ISR or deferred to the main loop
+	 * by DEBUG_FLAG_SEND_DEFER (#68). Unreachable with the flag clear. */
+	bool histo_stall_this_frame = false;
+	if ((dflags & DEBUG_FLAG_HISTO_STALL) != 0u) {
+		histo_stall_frame_count++;
+		histo_stall_this_frame =
+			(histo_stall_frame_count > HISTO_STALL_TRIGGER_FRAMES);
+		if (histo_stall_this_frame && !histo_stall_tripped) {
+			histo_stall_tripped = true;
+			printf("DEBUG: histo stall tripped at frame %lu\r\n",
+			       (unsigned long)histo_stall_frame_count);
+		}
+	}
+	if (histo_stall_this_frame) {
+		success = histo_stall_suppress_frame();
+	} else if ((dflags & DEBUG_FLAG_FAKE_DATA) != 0u) {
 		success = send_fake_data();
 	} else if ((dflags & DEBUG_FLAG_HISTO_CMP) != 0u) {
 		success = send_histogram_data_cmp();

--- a/Core/Src/if_commands.c
+++ b/Core/Src/if_commands.c
@@ -57,6 +57,16 @@ static void process_basic_command(UartPacket *uartResp, UartPacket cmd)
 		uartResp->command = OW_CMD_NOP;
 		uartResp->packet_type = OW_RESP;
 		break;
+	case OW_CMD_DIAG_STATS: {
+		VERBOSE_CMD("[CMD] OW_CMD_DIAG_STATS\r\n");
+		uartResp->command = OW_CMD_DIAG_STATS;
+		uartResp->packet_type = OW_RESP;
+		static cam_diag_stats_t diag_stats_resp;
+		camera_manager_get_diag_stats(&diag_stats_resp);
+		uartResp->data_len = sizeof(diag_stats_resp);
+		uartResp->data = (uint8_t *)&diag_stats_resp;
+		break;
+	}
 	case OW_CMD_PING:
 		VERBOSE_CMD("[CMD] OW_CMD_PING\r\n");
 		uartResp->command = OW_CMD_PING;

--- a/Core/Src/if_commands.c
+++ b/Core/Src/if_commands.c
@@ -17,6 +17,7 @@
 #include "ICM20948.h"
 #include "0X02C1B.h"
 #include "histo_fake.h"
+#include "usbd_histo.h"
 #include "motion_config.h"
 #include "sensor_serial.h"
 #include "logging.h"
@@ -724,6 +725,13 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 			}
 			uartResp->packet_type = OW_ACK;
 			break;
+		}
+		/* Scan start: drop any histogram packets left over from the previous
+		 * scan so they can't ship ahead of frame 1 with a stale timestamp /
+		 * frame_id (leftover-frame bug). Flush once, before arming cameras.
+		 * Enable path only (reserved==1). */
+		if (cmd.reserved == 1) {
+			USBD_HISTO_FlushQueue();
 		}
 		uint8_t status = 0;
 		for (uint8_t i = 0; i < 8; i++) {

--- a/Core/Src/if_commands.c
+++ b/Core/Src/if_commands.c
@@ -726,12 +726,10 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 			uartResp->packet_type = OW_ACK;
 			break;
 		}
-		/* Scan start: drop any histogram packets left over from the previous
-		 * scan so they can't ship ahead of frame 1 with a stale timestamp /
-		 * frame_id (leftover-frame bug). Flush once, before arming cameras.
-		 * Enable path only (reserved==1). */
+		/* Scan start: clear any leftover frames before arming cameras — a
+		 * backstop to the stop-path drain below. Enable path only. */
 		if (cmd.reserved == 1) {
-			USBD_HISTO_FlushQueue();
+			USBD_HISTO_FlushQueue("start");
 		}
 		uint8_t status = 0;
 		for (uint8_t i = 0; i < 8; i++) {
@@ -744,6 +742,13 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 				}
 	        }
 	    }
+		/* Scan stop: drain any leftover frames so none carry into the next
+		 * scan. Cameras are already disabled above, so the queue can only
+		 * shrink from here. Disable path only — this is the primary "keep it
+		 * from getting dirty" guard; the start-path flush is just a backstop. */
+		if (cmd.reserved == 0) {
+			USBD_HISTO_FlushQueue("stop");
+		}
 		if(status != cmd.addr) // if the status bits are not true for all the cameras addressed, error
 		{
 			uartResp->packet_type = OW_ERROR;

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -35,6 +35,7 @@
 #include "ICM20948.h"
 #include "camera_manager.h"
 #include "system_monitor.h"
+#include "common.h"        /* DEBUG_FLAG_* (e.g. DEBUG_FLAG_SEND_DEFER) */
 
 #include <stdio.h>
 #include <string.h>
@@ -130,6 +131,10 @@ volatile uint16_t pulse_count = 0;
 extern volatile uint32_t imu_frame_counter;
 volatile bool _enter_dfu = false;
 volatile uint8_t imu_sample_due = 0; // set by the TIM14 ISR, serviced by imu_service()
+/* #68 experiment: when DEBUG_FLAG_SEND_DEFER is active, the FSIN ISRs only set this
+ * flag and the main loop runs send_data() — moving the heavy per-frame send out of
+ * interrupt context so it can't block/starve the camera SPI/USART transport IRQs. */
+volatile bool send_data_flag = false;
 
 ICM_Axis3D a;
 ICM_Axis3D m;
@@ -424,6 +429,10 @@ int main(void)
     /* USER CODE END WHILE */
 
     /* USER CODE BEGIN 3 */
+    /* #68 experiment: run the deferred per-frame send in thread context (set by the
+     * FSIN ISR when DEBUG_FLAG_SEND_DEFER is active). Runs below every interrupt, so it
+     * cannot block the camera SPI/USART transport IRQs the way the ISR-context send does. */
+    if (send_data_flag) { send_data_flag = false; send_data(); }
   	comms_host_check_received(); // check comms
     imu_service();           /* Sample the ICM if the 200 Hz timer ticked */
     camera_i2c_service();    /* Camera-bus work deferred from the frame ISRs (temp poll, mux disables) */
@@ -1815,6 +1824,7 @@ void HAL_USART_ErrorCallback(USART_HandleTypeDef *husart)
   {
     printf("Overrun error ");
     __HAL_USART_CLEAR_OREFLAG(husart);
+    if (cam_id >= 0) { cam_overrun_count[cam_id]++; }  /* #68 instrumentation */
   }
   if (husart->ErrorCode & HAL_USART_ERROR_DMA)
   {
@@ -1886,6 +1896,7 @@ void HAL_SPI_ErrorCallback(SPI_HandleTypeDef *hspi)
   {
     printf("Overrun error ");
     __HAL_SPI_CLEAR_OVRFLAG(hspi);
+    if (cam_id >= 0) { cam_overrun_count[cam_id]++; }  /* #68 instrumentation */
   }
   if (hspi->ErrorCode & HAL_SPI_ERROR_MODF)
   {
@@ -1997,7 +2008,12 @@ void HAL_TIM_PWM_PulseFinishedCallback(TIM_HandleTypeDef *htim)
 {
   if (htim->Instance == TIM4) // Call data sender (internal FSIN))
   {
-    send_data();
+    /* #68 experiment: defer the heavy send to the main loop when enabled. */
+    if ((logging_get_debug_flags() & DEBUG_FLAG_SEND_DEFER) != 0u) {
+      send_data_flag = true;
+    } else {
+      send_data();
+    }
   }
 }
 
@@ -2006,7 +2022,12 @@ void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin)
     if (GPIO_Pin == GPIO_PIN_13) // Call REAL data sender if interrupt hit and enabled
     {
       pulse_count++;
-      send_data();
+      /* #68 experiment: defer the heavy send to the main loop when enabled. */
+      if ((logging_get_debug_flags() & DEBUG_FLAG_SEND_DEFER) != 0u) {
+        send_data_flag = true;
+      } else {
+        send_data();
+      }
     }
 }
 

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -135,6 +135,11 @@ volatile uint8_t imu_sample_due = 0; // set by the TIM14 ISR, serviced by imu_se
  * flag and the main loop runs send_data() — moving the heavy per-frame send out of
  * interrupt context so it can't block/starve the camera SPI/USART transport IRQs. */
 volatile bool send_data_flag = false;
+/* #68: histogram-frame timestamp captured at the FSIN rising edge (in the ISR).
+ * The send path uses this instead of sampling the clock itself, so the packet
+ * timestamp reflects the frame-sync instant even when the send is deferred to
+ * the main loop (where it would otherwise lag by the main-loop service latency). */
+volatile uint32_t fsin_timestamp_ms = 0;
 
 ICM_Axis3D a;
 ICM_Axis3D m;
@@ -2008,6 +2013,7 @@ void HAL_TIM_PWM_PulseFinishedCallback(TIM_HandleTypeDef *htim)
 {
   if (htim->Instance == TIM4) // Call data sender (internal FSIN))
   {
+    fsin_timestamp_ms = get_timestamp_ms();  /* #68: stamp the frame at FSIN */
     /* #68 experiment: defer the heavy send to the main loop when enabled. */
     if ((logging_get_debug_flags() & DEBUG_FLAG_SEND_DEFER) != 0u) {
       send_data_flag = true;
@@ -2022,6 +2028,7 @@ void HAL_GPIO_EXTI_Callback(uint16_t GPIO_Pin)
     if (GPIO_Pin == GPIO_PIN_13) // Call REAL data sender if interrupt hit and enabled
     {
       pulse_count++;
+      fsin_timestamp_ms = get_timestamp_ms();  /* #68: stamp the frame at the FSIN rising edge */
       /* #68 experiment: defer the heavy send to the main loop when enabled. */
       if ((logging_get_debug_flags() & DEBUG_FLAG_SEND_DEFER) != 0u) {
         send_data_flag = true;

--- a/Core/Src/utils.c
+++ b/Core/Src/utils.c
@@ -103,7 +103,13 @@ void delay_us(uint32_t us)
     while ((DWT->CYCCNT - start) < delay_cycles) { }
 }
 
-// get timestamp ms will grab the current timestamp in milliseconds as counted by tim5
+/* Frame/scan timestamp in ms, counted by free-running TIM5 (100 kHz).
+ * WARNING: wraps at 2^32/100 ms ≈ 11.93 h of uptime — NOT at 2^32 ms — so:
+ * (a) never schedule deadlines on this clock; use HAL_GetTick() instead (#73);
+ * (b) the host SDK unwraps histogram-frame timestamps assuming exactly this
+ *     period (MotionProcessing._TIMESTAMP_ROLLOVER_S = 2^32/100/1000 s) —
+ *     changing this timebase breaks host-side unwrapping unless the SDK
+ *     constant changes in lockstep. */
 uint32_t get_timestamp_ms(void)
 {
     uint32_t timestamp = TIM5->CNT/100;

--- a/USB/Class/HISTO/Inc/usbd_histo.h
+++ b/USB/Class/HISTO/Inc/usbd_histo.h
@@ -27,6 +27,7 @@ extern USBD_ClassTypeDef USBD_HISTO;
 uint8_t  USBD_HISTO_SetTxBuffer(USBD_HandleTypeDef *pdev, uint8_t  *pbuff, uint16_t length);
 uint8_t  USBD_HISTO_SendData(USBD_HandleTypeDef *pdev, uint8_t *data, uint16_t len, uint8_t ep_idx);
 void USBD_HISTO_TxCpltCallback(uint8_t *Buf, uint32_t Len, uint8_t epnum);
+void USBD_HISTO_FlushQueue(void);
 
 #ifdef __cplusplus
 }

--- a/USB/Class/HISTO/Inc/usbd_histo.h
+++ b/USB/Class/HISTO/Inc/usbd_histo.h
@@ -27,7 +27,7 @@ extern USBD_ClassTypeDef USBD_HISTO;
 uint8_t  USBD_HISTO_SetTxBuffer(USBD_HandleTypeDef *pdev, uint8_t  *pbuff, uint16_t length);
 uint8_t  USBD_HISTO_SendData(USBD_HandleTypeDef *pdev, uint8_t *data, uint16_t len, uint8_t ep_idx);
 void USBD_HISTO_TxCpltCallback(uint8_t *Buf, uint32_t Len, uint8_t epnum);
-void USBD_HISTO_FlushQueue(void);
+void USBD_HISTO_FlushQueue(const char *who);
 
 #ifdef __cplusplus
 }

--- a/USB/Class/HISTO/Src/usbd_histo.c
+++ b/USB/Class/HISTO/Src/usbd_histo.c
@@ -399,6 +399,38 @@ uint8_t USBD_HISTO_SendData(USBD_HandleTypeDef *pdev, uint8_t *data, uint16_t le
   return histo_queue_enqueue(data, len);
 }
 
+/* Drop any histogram packets left in the software TX queue (and the
+ * hardware EP FIFO) from a previous scan.  The queue is otherwise only
+ * reset on USB (de)enumeration, so packets still queued when a scan stops
+ * drain into the NEXT scan carrying that scan's TIM5 timestamp and
+ * frame_id — the host renders them as negative scan-relative timestamps
+ * and out-of-order frame_ids (the leftover-frame / "stale frame" bug).
+ * Call this at scan start (OW_CAMERA_STREAM enable) BEFORE arming the
+ * cameras, so frame 1 of the new scan is the first packet the host sees.
+ * Touches state shared with the frame ISR (USBD_HISTO_SendData) and the
+ * USB ISR (USBD_Histo_DataIn), so it runs in a critical section. */
+void USBD_HISTO_FlushQueue(void)
+{
+  __disable_irq();
+
+  /* Empty the software queue. */
+  histo_queue_head = 0;
+  histo_queue_tail = 0;
+  histo_queue_count = 0;
+
+  /* Abandon any in-flight / partially-sent transfer from the prior scan. */
+  histo_ep_data = 0;
+  tx_histo_ptr = 0;
+  tx_histo_total_len = 0;
+
+  /* Drop whatever the hardware EP FIFO still holds. */
+  if (histo_pdev != NULL && histo_ep_enabled != 0) {
+    USBD_LL_FlushEP(histo_pdev, HISTOInEpAdd);
+  }
+
+  __enable_irq();
+}
+
 uint8_t  USBD_HISTO_SetTxBuffer(USBD_HandleTypeDef *pdev, uint8_t  *pbuff, uint16_t length)
 {
 	uint8_t ret = USBD_OK;

--- a/USB/Class/HISTO/Src/usbd_histo.c
+++ b/USB/Class/HISTO/Src/usbd_histo.c
@@ -25,11 +25,18 @@ typedef struct {
 #define MIN(a,b) (((a)<(b))?(a):(b))
 #endif
 
-/* Private variables */
+/* Private variables.
+ * head/tail/count are shared between the frame ISR (enqueue, via
+ * USBD_HISTO_SendData) and the USB OTG_HS ISR (dequeue, via USBD_Histo_DataIn).
+ * On the external-FSIN path the USB ISR (NVIC prio 0) can PREEMPT the frame ISR
+ * (prio 2) mid read-modify-write, so these must be volatile AND every mutation
+ * runs in a __disable_irq critical section (see enqueue/dequeue). Without that,
+ * a lost count++/count-- drifts the count, stranding a never-dequeued slot whose
+ * stale bytes re-ship into a later scan. */
 static histo_queue_entry_t histo_queue[HISTO_QUEUE_SIZE];
-static uint8_t histo_queue_head = 0;
-static uint8_t histo_queue_tail = 0;
-static uint8_t histo_queue_count = 0;
+static volatile uint8_t histo_queue_head = 0;
+static volatile uint8_t histo_queue_tail = 0;
+static volatile uint8_t histo_queue_count = 0;
 static USBD_HandleTypeDef *histo_pdev = NULL;
 
 /* Private function prototypes */
@@ -92,8 +99,8 @@ __ALIGN_BEGIN static uint8_t USBD_Histo_GetDeviceQualifierDescriptor[USB_LEN_DEV
 
 extern uint8_t HISTO_InstID;
 static uint8_t* pTxHistoBuff = 0;
-static uint16_t tx_histo_total_len = 0;
-static uint16_t tx_histo_ptr = 0;
+static volatile uint16_t tx_histo_total_len = 0;
+static volatile uint16_t tx_histo_ptr = 0;
 static __IO uint8_t histo_ep_enabled = 0;
 __IO uint8_t histo_ep_data = 0;
 static uint8_t HISTOInEpAdd = HISTO_IN_EP;
@@ -234,31 +241,45 @@ static uint8_t histo_queue_enqueue(uint8_t *data, uint16_t length)
     return USBD_FAIL;
   }
 
-  /* Copy data into queue entry buffer */
-  memcpy(histo_queue[histo_queue_tail].buffer, data, length);
-  histo_queue[histo_queue_tail].length = length;
+  /* Copy into the current tail slot BEFORE publishing it. enqueue runs only in
+   * the frame ISR (non-reentrant), so `tail` is private here and the slot stays
+   * invisible to the dequeue path until count++ commits below. The 32 KB memcpy
+   * is deliberately OUTSIDE the critical section — never hold off IRQs across it. */
+  uint8_t slot = histo_queue_tail;
+  memcpy(histo_queue[slot].buffer, data, length);
+  histo_queue[slot].length = length;
 
-  /* Update queue pointers */
-  histo_queue_tail = (histo_queue_tail + 1) % HISTO_QUEUE_SIZE;
+  /* Publish atomically: `count` is shared with the dequeue path (USB ISR), which
+   * can preempt this frame-ISR enqueue, so the RMW must not be interruptible. */
+  uint32_t primask = __get_PRIMASK();
+  __disable_irq();
+  histo_queue_tail = (uint8_t)((slot + 1) % HISTO_QUEUE_SIZE);
   histo_queue_count++;
   histo_enq_count++;
+  __set_PRIMASK(primask);
 
   return USBD_OK;
 }
 
 static uint8_t histo_queue_dequeue(uint8_t **data, uint16_t *length)
 {
-  if (histo_queue_is_empty() != 0) {
+  /* Empty-check + head advance + count-- as one atomic step: dequeue is called
+   * from BOTH the frame ISR and the USB ISR, so two concurrent dequeues must not
+   * both claim the same head slot. */
+  uint32_t primask = __get_PRIMASK();
+  __disable_irq();
+  if (histo_queue_count == 0) {
+    __set_PRIMASK(primask);
     return USBD_FAIL;
   }
-
-  *data = histo_queue[histo_queue_head].buffer;
-  *length = histo_queue[histo_queue_head].length;
-
-  /* Update queue pointers */
-  histo_queue_head = (histo_queue_head + 1) % HISTO_QUEUE_SIZE;
+  uint8_t slot = histo_queue_head;
+  histo_queue_head = (uint8_t)((slot + 1) % HISTO_QUEUE_SIZE);
   histo_queue_count--;
   histo_deq_count++;
+  __set_PRIMASK(primask);
+
+  *data = histo_queue[slot].buffer;
+  *length = histo_queue[slot].length;
 
   return USBD_OK;
 }
@@ -318,6 +339,9 @@ static uint8_t USBD_Histo_DataIn(USBD_HandleTypeDef *pdev, uint8_t epnum)
           if (ret != USBD_OK) {
             histo_tx_fail_count++;
             histo_ep_data = 0;
+            /* Mid-transfer failure: resume draining so a tx error doesn't wedge
+             * the EP and strand the rest of the queue until the next scan. */
+            histo_process_queue();
           }
       }
       else
@@ -409,26 +433,36 @@ uint8_t USBD_HISTO_SendData(USBD_HandleTypeDef *pdev, uint8_t *data, uint16_t le
  * cameras, so frame 1 of the new scan is the first packet the host sees.
  * Touches state shared with the frame ISR (USBD_HISTO_SendData) and the
  * USB ISR (USBD_Histo_DataIn), so it runs in a critical section. */
-void USBD_HISTO_FlushQueue(void)
+void USBD_HISTO_FlushQueue(const char *who)
 {
+  uint32_t primask = __get_PRIMASK();
   __disable_irq();
 
-  /* Empty the software queue. */
+  /* Snapshot what was still in the queue before we clear it. */
+  uint8_t pending  = histo_queue_count;
+  uint8_t inflight = histo_ep_data;
+  long    gap      = (long)histo_enq_count - (long)histo_deq_count;
+
+  /* Empty the software queue + abandon any in-flight transfer + drop the EP
+   * FIFO, so nothing from this scan can carry into the next. */
   histo_queue_head = 0;
   histo_queue_tail = 0;
   histo_queue_count = 0;
-
-  /* Abandon any in-flight / partially-sent transfer from the prior scan. */
   histo_ep_data = 0;
   tx_histo_ptr = 0;
   tx_histo_total_len = 0;
-
-  /* Drop whatever the hardware EP FIFO still holds. */
   if (histo_pdev != NULL && histo_ep_enabled != 0) {
     USBD_LL_FlushEP(histo_pdev, HISTOInEpAdd);
   }
 
-  __enable_irq();
+  __set_PRIMASK(primask);
+
+  /* Diagnostic (short, single-chunk — the USB printf channel splits long lines):
+   *   q  = frames still queued at the boundary (the leftover source)
+   *   ep = a transfer was still in flight
+   *   e-d= enq-deq; this should EQUAL q. If e-d != q the count was corrupted by
+   *        a cross-ISR race; if e-d == q > 0 the scan honestly left frames unsent. */
+  printf("HISTO flush(%s): q=%u ep=%u e-d=%ld\r\n", who, pending, inflight, gap);
 }
 
 uint8_t  USBD_HISTO_SetTxBuffer(USBD_HandleTypeDef *pdev, uint8_t  *pbuff, uint16_t length)


### PR DESCRIPTION
Promote `next` to `main` for the **1.8.1** release.

Highlights since 1.8.0:
- **fix:** histogram queue residue — race-proof indices + drain at scan stop (#172)
- **fix:** flush histogram queue at scan start to drop leftover frames (#172)
- **feat:** stamp histogram frames at the FSIN ISR; fix terminal-frame timestamp; opt-in FSIN send deferral + per-camera overrun counters (#68)
- **feat:** time-bound RLE compression with uncompressed fallback + diag stats (#70)
- **fix:** schedule camera temp polls + latch recovery off `HAL_GetTick` (#73)
- **fix:** camera exposure tuning — 122→62→70→72 rows, always clear test-pattern reg in config
- **feat:** `DEBUG_FLAG_HISTO_STALL` (0x100) — suppress histogram sends mid-scan for deterministic camera-stall repro

Known open issues (not addressed in this release):
- #82 — host-upload FPGA SRAM path programs zeros (`xi2c_write_long` clobbers its own source buffer)
- #68 — RIGHT sensor: intermittent 15–30 s histogram stall mid-scan under laser-on

To be tagged `1.8.1` on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)