### PR TITLE
fix: host-upload FPGA SRAM path programs zeros (xi2c_write_long buffer clobber)

### DIFF
--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -787,7 +787,7 @@ _Bool exit_sram_prog_fpga(uint8_t cam_id)
 		return false;
 	}
 
-	if(fpga_enter_sram_prog_mode(cam->pI2c, cam->device_address) == 1)
+	if(fpga_exit_prog_mode(cam->pI2c, cam->device_address) == 1)
 	{
 		printf("Activate FPGA Camera %d Failed\r\n", cam_id+1);
 		return false;
@@ -907,6 +907,15 @@ _Bool program_sram_fpga(uint8_t cam_id, bool rom_bitstream, uint8_t* pData, uint
 	}else{
 		cam->isProgrammed = true;
 		camera_recovery_complete(cam);
+	}
+
+	/* Same USART realign the program_fpga() path performs: pin glitches
+	 * during configuration leave the USART receiver bit-shifted (data
+	 * arrives multiplied by a power of two). */
+	if(cam->useUsart)
+	{
+		cam->pUart->Instance->CR1 &= ~USART_CR1_UE;
+		cam->pUart->Instance->CR1 |= USART_CR1_UE;
 	}
 	printf("done\r\n");
 	return true;

--- a/Core/Src/crosslink.c
+++ b/Core/Src/crosslink.c
@@ -85,6 +85,13 @@ int xi2c_write_and_read(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *w
     return HAL_OK;
 }
 
+/* First-chunk staging only: the command byte(s) plus the leading data slice
+ * are copied here; every later chunk transmits straight from the caller's
+ * data pointer. The previous implementation staged the WHOLE stream in
+ * bitstream_buffer, zeroing the very data it was asked to send whenever the
+ * caller's data WAS bitstream_buffer (the host-upload SRAM path, issue #82). */
+static uint8_t xfer_stage[BITSTREAM_CHUNK_SIZE];
+
 static HAL_StatusTypeDef xi2c_write_long(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *cmd, int cmd_len, uint8_t *data, size_t data_len) {
 	HAL_StatusTypeDef ret;
     size_t offset = 0;
@@ -93,10 +100,11 @@ static HAL_StatusTypeDef xi2c_write_long(I2C_HandleTypeDef *hi2c, uint16_t DevAd
     int num_chunks = (total_len + BITSTREAM_CHUNK_SIZE - 1) / BITSTREAM_CHUNK_SIZE;  // Calculate number of chunks
     uint8_t *pData;
 	uint16_t datalen;
+	size_t first_data_len = ((total_len > BITSTREAM_CHUNK_SIZE)
+	                          ? BITSTREAM_CHUNK_SIZE : total_len) - (size_t)cmd_len;
 
-	memset(bitstream_buffer, 0, MAX_BITSTREAM_SIZE);
-    memcpy(bitstream_buffer, cmd, cmd_len);  // copy the long write command in
-    memcpy(bitstream_buffer + cmd_len, data, data_len);
+    memcpy(xfer_stage, cmd, cmd_len);
+    memcpy(xfer_stage + cmd_len, data, first_data_len);
 
     for (int i = 0; i < num_chunks; i++) {
         size_t current_chunk_size = (total_len - offset > BITSTREAM_CHUNK_SIZE)
@@ -120,7 +128,9 @@ static HAL_StatusTypeDef xi2c_write_long(I2C_HandleTypeDef *hi2c, uint16_t DevAd
             delay_ms(1);  // Add a small delay to avoid busy looping
         }
 
-        pData = (uint8_t*)&bitstream_buffer[offset];
+        /* chunk 0 = staged cmd+data head; chunks 1..n stream directly from
+         * the source at (stream offset - cmd_len) */
+        pData = (i == 0) ? xfer_stage : data + (offset - (size_t)cmd_len);
         datalen = (uint16_t)current_chunk_size;
 
         // Reset completion flags
@@ -405,7 +415,9 @@ int fpga_program_sram(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, bool rom_bit
     if(rom_bitstream)
     {
     	write_buf[0] = 0x7A; write_buf[1] = 0x00; write_buf[2] = 0x00; write_buf[3] = 0x00;
-    	if(xi2c_write_long(hi2c, DevAddress, write_buf, 4, (uint8_t *)bitstream_buffer, bitstream_len) != HAL_OK)
+    	/* Host uploads land at bitstream_buffer + 4 (OW_FPGA_BITSTREAM keeps
+    	 * the first 4 bytes free — legacy of the old in-place cmd staging). */
+    	if(xi2c_write_long(hi2c, DevAddress, write_buf, 4, (uint8_t *)bitstream_buffer + 4, bitstream_len) != HAL_OK)
     	{
     		return 1; // program sram failed
     	}

--- a/Core/Src/if_commands.c
+++ b/Core/Src/if_commands.c
@@ -485,15 +485,23 @@ static void process_fpga_commands(UartPacket *uartResp, UartPacket cmd)
 		VERBOSE_CMD("[CMD] OW_FPGA_PROG_SRAM addr=0x%02X reserved=%u\r\n", cmd.addr, cmd.reserved);
 		uartResp->command = OW_FPGA_PROG_SRAM;
 		uartResp->packet_type = OW_RESP;
-		// TODO: Add parameter to force update currently defaults to false
+		/* #68: reserved==2 forces the SRAM load — with force off, an
+		 * NVCM-programmed part skips the SRAM load and silently keeps
+		 * running the burned image, so a newer BUNDLED bitstream never
+		 * takes effect (~10 s/camera when forced). */
 	    for (uint8_t i = 0; i < 8; i++) {
 	        if (((cmd.addr >> i) & 0x01) != 0) {
 	        	_Bool func_ret = false;
+	        	_Bool force_sram = (cmd.reserved == 2);
 
-	        	if(cmd.reserved == 1) {
-	        		func_ret = program_fpga(i, false);
+	        	if(cmd.reserved == 1 || force_sram) {
+	        		func_ret = program_fpga(i, force_sram);
 	        	} else {
-	        		func_ret = program_sram_fpga(i, true, 0, 0, false);
+	        		/* reserved==0: host-uploaded bitstream, NVCM-gated.
+	        		 * reserved==3: host-uploaded bitstream, FORCED — skips the
+	        		 * isProgrammed/NVCM gates (required on NVCM-burned parts,
+	        		 * same rationale as reserved==2). */
+	        		func_ret = program_sram_fpga(i, true, 0, 0, cmd.reserved == 3);
 	        	}
 	    		if(!func_ret)
 	    		{


### PR DESCRIPTION
## What

One commit: `fix: make the host-upload FPGA SRAM path work end to end`.

Stock firmware cannot program host-uploaded FPGA bitstreams: `xi2c_write_long` clobbers its own source buffer, so the SRAM upload path programs zeros (#82).

## Why now

The camera-fpga full-frame image readout tooling (OpenwaterHealth/openmotion-camera-fpga#7, branch `feature/5-i2c-line-readout`) uploads its bitstream to FPGA SRAM at capture time and requires this fix on **both** sensors. That feature is intentionally staying on its branch for multi-bench replication rather than merging now — this draft PR makes the firmware dependency visible, reviewable, and protected from branch cleanup.

## Validation

Ran on both sensor modules as `1.8.1-rc.3-dirty` (tag + this patch) during the 2026-07-05 16-camera full-frame capture campaign — 32/32 complete frames, zero missing lines. Replication recipe: `tools/full_frame_capture/RUNBOOK.md` on the camera-fpga branch.

Refs #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)
