### PR TITLE
feat: DEBUG_FLAG_CAMERA_CROP — crop camera output to 1720x1280 (drop right 200 cols)

### DIFF
--- a/Core/Inc/common.h
+++ b/Core/Inc/common.h
@@ -34,6 +34,8 @@
 #define DEBUG_FLAG_SEND_DEFER (1u << 7)  /* #68: FSIN ISR only flips send_data_flag; main loop runs send_data() */
 #define DEBUG_FLAG_HISTO_STALL (1u << 8) /* #75: stop sending histogram frames after HISTO_STALL_TRIGGER_FRAMES;
                                           * cameras/SPI/USB stay alive — deterministic host-visible stall repro */
+#define DEBUG_FLAG_CAMERA_CROP (1u << 9) /* #86: crop camera output to 1720x1280 (drop right 200 columns) when
+                                          * cameras are (re)configured — misaligned-optic A/B test. See 0X02C1B.c */
 
 
 #define I2C_IRQ_PRIORITY 0

--- a/Core/Src/0X02C1B.c
+++ b/Core/Src/0X02C1B.c
@@ -6,8 +6,24 @@
  */
 #include "0X02C1B.h"
 #include "X02C1B_Sensor_Config.h"
+#include "logging.h"
 #include "utils.h"
 #include <stdio.h>
+
+/*
+ * #86 debug crop: shrink horizontal output from 1920 to 1720, dropping the
+ * rightmost 200 columns of the active region (misaligned-optic A/B test).
+ * The output window is left-anchored (ISP X offset 0x3811 = 8), so only
+ * X_OUTPUT_SIZE (0x3808/0x3809) changes: 0x0780 (1920) -> 0x06B8 (1720).
+ * Left edge, height (1280), framerate and line timing are all untouched.
+ * Applied after the base config table (which always programs 1920), so
+ * clearing DEBUG_FLAG_CAMERA_CROP and reconfiguring reverts to full frame.
+ */
+#define X02C1B_CROP_WIDTH 1720u
+static const struct regval_list X02C1B_crop_1720[] = {
+    {0x3808, (X02C1B_CROP_WIDTH >> 8) & 0xff},
+    {0x3809, X02C1B_CROP_WIDTH & 0xff},
+};
 
 static volatile _Bool ext_fsin_enabled = false;
 #define I2C_TIMEOUT 1000 // Set an appropriate timeout for I2C transactions
@@ -100,6 +116,17 @@ int X02C1B_configure_sensor(CameraDevice *cam) {
 		printf("Camera %d Failed to stop streaming\r\n", cam->id+1);
 		return ret;
 	}
+
+    /* #86: optional debug crop to 1720x1280 (drop rightmost 200 columns). */
+    if ((logging_get_debug_flags() & DEBUG_FLAG_CAMERA_CROP) != 0u) {
+        ret = X02C1B_write_array(cam->pI2c, X02C1B_crop_1720, ARRAY_SIZE(X02C1B_crop_1720));
+        if (ret < 0) {
+            printf("Camera %d crop override failed\r\n", cam->id+1);
+            return ret;
+        }
+        printf("Camera %d cropped to %ux1280 (right %u cols dropped)\r\n",
+               cam->id+1, X02C1B_CROP_WIDTH, 1920u - X02C1B_CROP_WIDTH);
+    }
 
 	delay_ms(100);
     return 0;

--- a/Core/Src/logging.c
+++ b/Core/Src/logging.c
@@ -102,14 +102,15 @@ void logging_set_debug_flags(uint32_t flags) {
 	uint32_t prev_flags = debug_flags;
 	debug_flags = flags;
 	if (prev_flags != debug_flags) {
-		printf("Debug flags changed: 0x%08lX -> 0x%08lX%s%s%s%s%s\r\n",
+		printf("Debug flags changed: 0x%08lX -> 0x%08lX%s%s%s%s%s%s\r\n",
 		       (unsigned long)prev_flags,
 		       (unsigned long)debug_flags,
 		       (debug_flags & DEBUG_FLAG_USB_PRINTF) ? " (USB printf ON)" : " (USB printf OFF)",
 		       (debug_flags & DEBUG_FLAG_HISTO_SPARSE) ? " (HISTO sparse ON)" : "",
 		       (debug_flags & DEBUG_FLAG_COMM_VERBOSE) ? " (comm verbose ON)" : "",
 		       (debug_flags & DEBUG_FLAG_CMD_VERBOSE) ? " (verbose cmd ON)" : "",
-		       (debug_flags & DEBUG_FLAG_HISTO_CMP) ? " (histo compress ON)" : "");
+		       (debug_flags & DEBUG_FLAG_HISTO_CMP) ? " (histo compress ON)" : "",
+		       (debug_flags & DEBUG_FLAG_CAMERA_CROP) ? " (camera crop 1720 ON)" : "");
 	}
 	if ((debug_flags & DEBUG_FLAG_USB_PRINTF) == 0u) {
 		// Drop any buffered log data so it doesn't flush later.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -180,6 +180,7 @@ All command and response traffic on the COMMS interface uses a fixed binary pack
 | 4 | `DEBUG_FLAG_COMM_VERBOSE` | Enable verbose logging in `uart_comms.c` |
 | 5 | `DEBUG_FLAG_CMD_VERBOSE` | Enable `printf` inside command handlers |
 | 6 | `DEBUG_FLAG_HISTO_CMP` | Send compressed histogram packets (`TYPE_HISTO_CMP`) |
+| 9 | `DEBUG_FLAG_CAMERA_CROP` | Crop camera output to 1720×1280 (drop rightmost 200 columns) when cameras are (re)configured — misaligned-optic test |
 
 ---
 


### PR DESCRIPTION
## Summary
Adds `DEBUG_FLAG_CAMERA_CROP` (bit 9, `0x200`), a debug toggle that crops the OV2312 (X02C1B) horizontal output from **1920 → 1720**, dropping the **rightmost 200 columns** of the active region. Purpose: A/B test whether excluding a misaligned right-edge optic changes the speckle/histogram statistics.

## How it works
When the flag is set at camera (re)configuration time, `X02C1B_configure_sensor()` writes a crop override after the base register table:
- `0x3808/0x3809` X_OUTPUT_SIZE: `0x0780` (1920) → `0x06B8` (1720)

The output window is **left-anchored** (ISP X offset `0x3811` = 8), so only the width shrinks — left edge, height (1280), framerate and line timing are unchanged. No binning is active (`0x3814/15` = 0x11), so 1 output px = 1 array px and exactly 200 columns are removed from the right.

Base config always programs 1920 first, so **clearing the flag and reconfiguring reverts to full frame** — ideal for direct comparison.

## Usage
1. `OW_CMD_DEBUG_FLAGS` set, value `| 0x200`.
2. `OW_CAMERA_SET_CONFIG` (reconfigure the cameras) → they stream 1720×1280.
3. Clear `0x200` + reconfigure → back to 1920×1280.

UART banner reports ` (camera crop 1720 ON)`; per-camera `printf` confirms the crop on config.

## Changes
- `Core/Inc/common.h` — flag define (bit 9)
- `Core/Src/0X02C1B.c` — crop regval list + conditional write in `X02C1B_configure_sensor()`
- `Core/Src/logging.c` — banner string
- `docs/requirements.md` — debug-flag table row

## Verification
- ✅ Builds clean (`cmake --build build/Debug`), links OK (FLASH 74.55%).
- ⏳ **Bench validation pending.** MCU-side is safe; the histogram FPGA (`openmotion-camera-fpga`) consumes the MIPI stream — if its line/frame logic follows CSI-2 line-sync packets (expected) a 1720-wide frame just works; if it hardcodes 1920, it may need a matching tweak. To be confirmed on hardware.

Refs #86