### PR TITLE
feat: DEBUG_FLAG_CAMERA_RAW (0x400) — raw scientific-sensor mode (no on-sensor corrections)

### DIFF
--- a/Core/Inc/common.h
+++ b/Core/Inc/common.h
@@ -36,6 +36,9 @@
                                           * cameras/SPI/USB stay alive — deterministic host-visible stall repro */
 #define DEBUG_FLAG_CAMERA_CROP (1u << 9) /* #86: crop camera output to 1720x1280 (drop right 200 columns) when
                                           * cameras are (re)configured — misaligned-optic A/B test. See 0X02C1B.c */
+#define DEBUG_FLAG_CAMERA_RAW (1u << 10) /* #89: raw "scientific sensor" mode — disable every on-sensor pixel
+                                          * correction (BLC/DC-BLC/dither/OTP-DPC) when cameras are
+                                          * (re)configured. See X02C1B_raw_sensor in 0X02C1B.c */
 
 
 #define I2C_IRQ_PRIORITY 0

--- a/Core/Src/0X02C1B.c
+++ b/Core/Src/0X02C1B.c
@@ -25,6 +25,41 @@ static const struct regval_list X02C1B_crop_1720[] = {
     {0x3809, X02C1B_CROP_WIDTH & 0xff},
 };
 
+/*
+ * #89 raw "scientific sensor" mode: strip every on-sensor pixel correction so
+ * the output is the bare ADC codes (analog gain/exposure are signal chain, not
+ * processing, and keep their per-camera values). Register basis: OX02C1B DS 1.0
+ * + OVT AE thread (see issue #89 for the full proposal table).
+ *
+ * Functional changes vs the base table:
+ *   0x4001 0x23 -> 0x00  BLC block off ([0] blc_en, [1] dc_blc_en, [5] dither).
+ *                        No OB-row servo subtraction: the raw per-channel
+ *                        pedestal (~255 DN @1x, ~495 DN @16x gain) stays in the
+ *                        data and eats headroom on high-gain cameras.
+ *   0x5000 0x34 -> 0x30  [2] OTP static defect-pixel correction off — the last
+ *                        pixel modifier still enabled in production; defect
+ *                        pixels become visible. [3] DPC, [1] WB, [0] pre-ISP
+ *                        were already 0; [5] ISP + [4] window stay 1 so output
+ *                        geometry/timing are unchanged.
+ * The rest re-asserts states the base table already establishes (test pattern
+ * off, digital gain 1x, ISP manual overrides off, AEC/AGC manual): runtime
+ * register writes survive OW_CAMERA_SET_CONFIG (it skips already-configured
+ * cameras), so the flag must guarantee the raw contract, not assume it.
+ * The base table always programs the corrected values, so clearing the flag
+ * and reconfiguring (after a camera power-cycle) reverts. Test patterns rewrite
+ * 0x5000 (X02C1B_set_test_pattern) — don't combine them with raw mode.
+ */
+static const struct regval_list X02C1B_raw_sensor[] = {
+    {0x4001, 0x00},  /* BLC / DC-BLC / dither off            (was 0x23) */
+    {0x5000, 0x30},  /* OTP DPC off; window + ISP kept       (was 0x34) */
+    {0x5100, 0x00},  /* assert: test patterns off */
+    {0x350a, 0x01},  /* assert: digital gain 1.000x */
+    {0x350b, 0x00},
+    {0x350c, 0x00},
+    {0x5006, 0x00},  /* assert: ISP manual-override paths disabled */
+    {0x3503, 0xa8},  /* assert: AEC + AGC manual */
+};
+
 static volatile _Bool ext_fsin_enabled = false;
 #define I2C_TIMEOUT 1000 // Set an appropriate timeout for I2C transactions
 
@@ -126,6 +161,16 @@ int X02C1B_configure_sensor(CameraDevice *cam) {
         }
         printf("Camera %d cropped to %ux1280 (right %u cols dropped)\r\n",
                cam->id+1, X02C1B_CROP_WIDTH, 1920u - X02C1B_CROP_WIDTH);
+    }
+
+    /* #89: optional raw "scientific sensor" mode — no on-sensor corrections. */
+    if ((logging_get_debug_flags() & DEBUG_FLAG_CAMERA_RAW) != 0u) {
+        ret = X02C1B_write_array(cam->pI2c, X02C1B_raw_sensor, ARRAY_SIZE(X02C1B_raw_sensor));
+        if (ret < 0) {
+            printf("Camera %d raw-mode override failed\r\n", cam->id+1);
+            return ret;
+        }
+        printf("Camera %d RAW mode: BLC/DC-BLC/dither/OTP-DPC off\r\n", cam->id+1);
     }
 
 	delay_ms(100);

--- a/Core/Src/logging.c
+++ b/Core/Src/logging.c
@@ -102,7 +102,7 @@ void logging_set_debug_flags(uint32_t flags) {
 	uint32_t prev_flags = debug_flags;
 	debug_flags = flags;
 	if (prev_flags != debug_flags) {
-		printf("Debug flags changed: 0x%08lX -> 0x%08lX%s%s%s%s%s%s\r\n",
+		printf("Debug flags changed: 0x%08lX -> 0x%08lX%s%s%s%s%s%s%s\r\n",
 		       (unsigned long)prev_flags,
 		       (unsigned long)debug_flags,
 		       (debug_flags & DEBUG_FLAG_USB_PRINTF) ? " (USB printf ON)" : " (USB printf OFF)",
@@ -110,7 +110,8 @@ void logging_set_debug_flags(uint32_t flags) {
 		       (debug_flags & DEBUG_FLAG_COMM_VERBOSE) ? " (comm verbose ON)" : "",
 		       (debug_flags & DEBUG_FLAG_CMD_VERBOSE) ? " (verbose cmd ON)" : "",
 		       (debug_flags & DEBUG_FLAG_HISTO_CMP) ? " (histo compress ON)" : "",
-		       (debug_flags & DEBUG_FLAG_CAMERA_CROP) ? " (camera crop 1720 ON)" : "");
+		       (debug_flags & DEBUG_FLAG_CAMERA_CROP) ? " (camera crop 1720 ON)" : "",
+		       (debug_flags & DEBUG_FLAG_CAMERA_RAW) ? " (camera RAW ON)" : "");
 	}
 	if ((debug_flags & DEBUG_FLAG_USB_PRINTF) == 0u) {
 		// Drop any buffered log data so it doesn't flush later.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -181,6 +181,7 @@ All command and response traffic on the COMMS interface uses a fixed binary pack
 | 5 | `DEBUG_FLAG_CMD_VERBOSE` | Enable `printf` inside command handlers |
 | 6 | `DEBUG_FLAG_HISTO_CMP` | Send compressed histogram packets (`TYPE_HISTO_CMP`) |
 | 9 | `DEBUG_FLAG_CAMERA_CROP` | Crop camera output to 1720×1280 (drop rightmost 200 columns) when cameras are (re)configured — misaligned-optic test |
+| 10 | `DEBUG_FLAG_CAMERA_RAW` | Raw "scientific sensor" mode: disable all on-sensor pixel corrections (BLC, DC-BLC, dither, OTP DPC) when cameras are (re)configured. Pedestal becomes the raw per-channel offset (~255 DN @1×, ~495 DN @16×); not for production scans |
 
 ---
 


### PR DESCRIPTION
Adds `DEBUG_FLAG_CAMERA_RAW (1u << 10, 0x400)`: when set at camera (re)configuration time, an override list is written after the base `X02C1B_SENSOR_CONFIG` table that disables **every on-sensor pixel correction** on the OX02C1B, so the output is bare ADC codes — "scientific sensor" mode. Same structural pattern as `DEBUG_FLAG_CAMERA_CROP` (#86/PR #87): base table always programs the corrected values, overrides apply on top, clearing the flag + reconfiguring reverts.

Refs #89 (full proposal + basis discussion there).

## The register list (the thing to review)

Sources: OX02C1S/OX02C1B datasheet DS 1.0, OVT AE bit-map emails (Mar–Aug 2024), OVT's own `..._DPC-WB-BLC-off` reference settings file, and the July 2026 drift-campaign silicon A/Bs.

**Functional changes (2):**

| Reg | Base | Raw | Disables | Confidence |
|---|---|---|---|---|
| `0x4001` | `0x23` | `0x00` | [0] `blc_en` — OB-row black-level servo (no offset subtraction at all); [1] `dc_blc_en` — dark-current BLC; [5] `dither_en` — BLC dither | High (DS A-25; OVT's BLC-off file clears bit0; campaign 007 toggled bit1 on silicon) |
| `0x5000` | `0x34` | `0x30` | [2] **OTP static defect-pixel correction** — the last pixel modifier still enabled in production. [3] DPC / [1] WB / [0] pre-ISP already 0; [5] ISP + [4] window stay 1 → geometry/timing unchanged | High (DS table 5-1) |

**Assertions** (already the effective production state; written because runtime register writes survive `OW_CAMERA_SET_CONFIG`'s skip-if-configured, so the flag guarantees the raw contract instead of assuming it):

| Reg | Value | Asserts |
|---|---|---|
| `0x5100` | `0x00` | test patterns off |
| `0x350A/B/C` | `0x01/0x00/0x00` | digital gain 1.000× |
| `0x5006` | `0x00` | ISP manual-override paths disabled |
| `0x3503` | `0xA8` | AEC + AGC manual |

**Reviewed, deliberately unchanged:** BLC servo plumbing (`0x4000`, kcoef, targets — inert once `blc_en=0`), per-camera analog gain ladder + exposure (signal chain, not processing), LCG/DCG (`0x3A93`, already manual), OTP auto-load (keeps analog trim + TPM cal; the OTP *defect list* is neutralized by `0x5000[2]=0` instead), output clip regs (full-range as programmed), WB gains (1× and out of path), vendor blocks `0x6000s/0x4E0xs/0x8xxx` (unknowns, untouched).

## What raw frames/histograms will look like

- Dark level jumps from the servoed 128 DN target to the raw per-channel pedestal — historically **~255 DN @1× and ~495 DN @16×** (OVT thread, Jun 2024). Dark current itself is negligible at 648 µs (<3 DN, campaign dark-PTC); the pedestal is static circuit offset, gain-scaled.
- Histograms shift right accordingly; 16× outer cameras lose ~⅓ of code-range headroom. SDK `PEDESTAL_HEIGHT`(=128) assumptions (dark subtraction, `DarkIntegrityWarning`) are invalid while the flag is set. **Not for production scans.**
- Per-readout-channel offsets appear as column-periodic fixed pattern; OTP defect pixels reappear as hot/dead outliers.
- No BLC re-servo "staircase" events — pedestal moves only with physics (temperature).

## Caveats

- Toggling takes effect only on a configure that actually runs: `OW_CAMERA_SET_CONFIG` skips already-configured cameras (same caveat as #86) — power-cycle cameras first.
- Don't run test patterns in raw mode: `X02C1B_set_test_pattern` rewrites `0x5000` and re-enables ISP blocks.

## Verification

- Debug and Release both build clean (Debug: FLASH 74.60%; Release: 59.78%).
- Not hardware-tested in this session. Suggested bench check: set flag → power-cycle cameras → configure → confirm per-camera "RAW mode" prints, then a dark capture should show means ≈ raw pedestal (≫128, gain-ordered) instead of 128 ± noise, and `0x4001/0x5000` read back `0x00/0x30`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
