### PR TITLE
feat: continuous camera-sensor telemetry (#94) — background sweep + OW_CAMERA_GET_TELEMETRY

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,7 @@ target_sources(${CMAKE_PROJECT_NAME} PRIVATE
     USB/Class/IMU/Src/usbd_imu.c
     Core/Src/0X02C1B.c
     Core/Src/camera_manager.c
+    Core/Src/camera_telemetry.c
     Core/Src/crosslink.c
     Core/Src/histo_fake.c
     Core/Src/i2c_protocol.c

--- a/Core/Inc/camera_telemetry.h
+++ b/Core/Inc/camera_telemetry.h
@@ -1,0 +1,91 @@
+/*
+ * camera_telemetry.h
+ *
+ * #94: continuous OX02C1B condition telemetry — supply rails, die temps,
+ * fault/integrity state, frame/trigger counters and applied-configuration
+ * truth for all 8 cameras, collected by a background sweep in the main loop
+ * (camera_i2c_service()) and served to the host as one cached snapshot via
+ * OW_CAMERA_GET_TELEMETRY.
+ *
+ * Register basis: OX02C1S/OX02C1B DS 1.0 — voltage monitor §10.5.24/table
+ * A-39, temperature §10.5.23, watchdog table A-40, frame counter §10.5.25.
+ * All values are returned as RAW register bytes assembled MSB-first; the SDK
+ * owns conversion to engineering units (V = code*6/4096, °C = 8.8 format
+ * with the >0xC000 negative rule, gains /16 and /1024).
+ */
+
+#ifndef INC_CAMERA_TELEMETRY_H_
+#define INC_CAMERA_TELEMETRY_H_
+
+#include <stdint.h>
+#include "camera_manager.h"
+
+/* Sweep cadence: one camera sweep is started per interval, round-robin over
+ * powered cameras -> full-fleet refresh in CAMERA_COUNT * interval (~1 s). */
+#define CAM_TELEM_SWEEP_INTERVAL_MS  125u
+
+/* Wire-format version. Bump on ANY field change and update the SDK parser
+ * (omotion/MotionSensor.py get_camera_telemetry()) in the same change. */
+#define CAM_TELEMETRY_VERSION 1u
+
+/* Per-camera snapshot. Packed, little-endian (returned verbatim over COMMS).
+ * "raw" fields hold the sensor's register bytes assembled MSB-first without
+ * masking reserved bits — mask/convert host-side. */
+typedef struct __attribute__((packed)) {
+	uint32_t updated_ms;     /* HAL_GetTick() at sweep completion; 0 = never swept */
+	uint32_t frame_counter;  /* 0x4900-0x4903, MIPI SOF count (byte order verified on HW via increment check) */
+	uint32_t dgain_cmd;      /* 0x350A-0x350C raw bytes (b0<<16|b1<<8|b2); 14-bit gain/1024 packed per DS */
+	uint16_t avdd_raw;       /* 0x4E20/21 — V = (raw & 0xFFF) * 6 / 4096 */
+	uint16_t dovdd_raw;      /* 0x4E22/23 */
+	uint16_t dvdd_raw;       /* 0x4E24/25 */
+	uint16_t tpm_avg_raw;    /* 0x4D2A/2B — 8.8 °C, >0xC000 = negative (see X02C1B_read_temp) */
+	uint16_t tpm0_raw;       /* 0x4D56/57 */
+	uint16_t tpm1_raw;       /* 0x4D58/59 */
+	uint16_t tc_row;         /* 0x3890/91 — timing-counter row readback */
+	uint16_t expo_cmd;       /* 0x3501/02 — commanded coarse exposure (rows) */
+	uint16_t expo_applied;   /* 0x350E/0F — applied coarse exposure (rows) */
+	uint16_t again_cmd;      /* 0x3508/09 — commanded analog gain, code/16 = x */
+	uint16_t isp_real_gain;  /* 0x5052/53 — gain the ISP latched for the frame */
+	uint16_t isp_dig_gain;   /* 0x5054/55 */
+	uint16_t isp_blc;        /* 0x5056/57 — BLC value the ISP latched */
+	uint16_t isp_expo;       /* 0x5058/59 */
+	uint16_t blc_offset[8];  /* 0x4072..0x408F stride 4 — applied per-channel BLC offsets (15-bit) */
+	uint8_t  tpm_status;     /* 0x4D28 — [3] out_of_range [2] alarm_cel [1] alarm [0] failed */
+	uint8_t  vm_live;        /* 0x4E32 — [5:3] BIST fail, [2:0] rail out-of-range (DVDD/DOVDD/AVDD) */
+	uint8_t  vm_cp;          /* 0x4E33 — charge-pump comparator faults */
+	uint8_t  vm_latched;     /* 0x4E34 — [6] fault state, [5:3]/[2:0] latched BIST/rail faults */
+	uint8_t  vm_cp_latched;  /* 0x4E35 */
+	uint8_t  wd[6];          /* 0x4F0A-0x4F0F — watchdog fault roll-up A/B, sticky, tpm_readout, state */
+	uint8_t  sc_state;       /* 0x0108[3:0] — 5 = safe mode, 9 = streaming, 6/7 = standby/stream-off */
+	uint8_t  otp_crc[2];     /* 0x3DA7/A8 — OTP CRC check status (per-die cal loaded?) */
+	uint8_t  trig_error;     /* 0x3897 — FSIN trigger-mode read error flags */
+	uint8_t  yavg;           /* 0x4C13 — on-chip weighted frame mean */
+	uint8_t  aec_mode;       /* 0x3503 — expect 0xA8 (AEC+AGC manual) */
+	uint8_t  dcg_state;      /* 0x3A93 — expect 0x40 (manual LCG, no auto-DCG) */
+	uint8_t  blc_ctrl;       /* 0x4001 — 0x23 production / 0x00 raw mode (#89) */
+	uint8_t  isp_ctrl;       /* 0x5000 — 0x34 production / 0x30 raw mode (#89) */
+	uint8_t  i2c_err_count;  /* failed sweep transactions for this camera (saturating) */
+	uint8_t  sweep_count;    /* completed sweeps (wraps) — liveness/staleness check */
+} cam_telemetry_t;
+
+typedef struct __attribute__((packed)) {
+	uint8_t version;      /* = CAM_TELEMETRY_VERSION */
+	uint8_t valid_mask;   /* bit n: camera n has >=1 completed sweep (never cleared; check updated_ms for staleness) */
+	uint8_t struct_size;  /* = sizeof(cam_telemetry_t), parser sanity check */
+	uint8_t reserved;
+	cam_telemetry_t cam[CAMERA_COUNT];
+} cam_telemetry_response_t;
+
+_Static_assert(sizeof(cam_telemetry_t) == 78u, "cam_telemetry_t wire size changed - bump CAM_TELEMETRY_VERSION and fix the SDK parser");
+_Static_assert(sizeof(cam_telemetry_response_t) == 4u + 8u * 78u, "cam_telemetry_response_t wire size changed");
+
+/* Advance the background sweep by one bounded chunk (<= ~1.3 ms of I2C).
+ * Call from camera_i2c_service() only: hi2c1 work must stay in the main
+ * loop's serialization domain (see camera_manager.c). */
+void camera_telemetry_service(void);
+
+/* Cached snapshot for OW_CAMERA_GET_TELEMETRY. Always valid to return
+ * verbatim; never-swept cameras are all-zero with their valid bit clear. */
+const cam_telemetry_response_t *camera_telemetry_get(void);
+
+#endif /* INC_CAMERA_TELEMETRY_H_ */

--- a/Core/Inc/camera_telemetry.h
+++ b/Core/Inc/camera_telemetry.h
@@ -33,7 +33,6 @@
  * masking reserved bits — mask/convert host-side. */
 typedef struct __attribute__((packed)) {
 	uint32_t updated_ms;     /* HAL_GetTick() at sweep completion; 0 = never swept */
-	uint32_t frame_counter;  /* 0x4900-0x4903, MIPI SOF count (byte order verified on HW via increment check) */
 	uint32_t dgain_cmd;      /* 0x350A-0x350C raw bytes (b0<<16|b1<<8|b2); 14-bit gain/1024 packed per DS */
 	uint16_t avdd_raw;       /* 0x4E20/21 — V = (raw & 0xFFF) * 6 / 4096 */
 	uint16_t dovdd_raw;      /* 0x4E22/23 */
@@ -41,7 +40,9 @@ typedef struct __attribute__((packed)) {
 	uint16_t tpm_avg_raw;    /* 0x4D2A/2B — 8.8 °C, >0xC000 = negative (see X02C1B_read_temp) */
 	uint16_t tpm0_raw;       /* 0x4D56/57 */
 	uint16_t tpm1_raw;       /* 0x4D58/59 */
-	uint16_t tc_row;         /* 0x3890/91 — timing-counter row readback */
+	uint16_t tc_row;         /* 0x3892/93 — LIVE timing-counter row readback (bench-verified moving
+	                          * while streaming; 0x3890/91 read constant 0). Nonzero/changing =
+	                          * the sensor is actually scanning rows. */
 	uint16_t expo_cmd;       /* 0x3501/02 — commanded coarse exposure (rows) */
 	uint16_t expo_applied;   /* 0x350E/0F — applied coarse exposure (rows) */
 	uint16_t again_cmd;      /* 0x3508/09 — commanded analog gain, code/16 = x */
@@ -68,16 +69,27 @@ typedef struct __attribute__((packed)) {
 	uint8_t  sweep_count;    /* completed sweeps (wraps) — liveness/staleness check */
 } cam_telemetry_t;
 
+/* NOTE on frame counting: the OX02C1B's documented "32-bit frame counter"
+ * (DS §10.5.25) has NO readable value register in the DS 1.0 SCCB map —
+ * 0x4900-0x4903 are the FC *control* bytes (bench-verified static 08 00 00 81
+ * while streaming) and the value is only emitted via embedded-data rows. The
+ * frames-triggered ground truth here is therefore firmware-side: the FSIN
+ * pulse counter in the response header below. */
 typedef struct __attribute__((packed)) {
 	uint8_t version;      /* = CAM_TELEMETRY_VERSION */
 	uint8_t valid_mask;   /* bit n: camera n has >=1 completed sweep (never cleared; check updated_ms for staleness) */
 	uint8_t struct_size;  /* = sizeof(cam_telemetry_t), parser sanity check */
 	uint8_t reserved;
+	uint32_t fsin_pulse_count;  /* firmware FSIN pulse counter (u16 zero-extended), sampled at query
+	                             * time. Counts EXTERNAL FSIN edges (EXTI pin 13) — i.e. console-driven
+	                             * scan frames. The internal TIM4 FSIN generator does NOT increment it
+	                             * (bench-verified 2026-07-17). */
+	uint32_t uptime_ms;         /* HAL_GetTick() at query time — reference for the per-camera updated_ms staleness */
 	cam_telemetry_t cam[CAMERA_COUNT];
 } cam_telemetry_response_t;
 
-_Static_assert(sizeof(cam_telemetry_t) == 78u, "cam_telemetry_t wire size changed - bump CAM_TELEMETRY_VERSION and fix the SDK parser");
-_Static_assert(sizeof(cam_telemetry_response_t) == 4u + 8u * 78u, "cam_telemetry_response_t wire size changed");
+_Static_assert(sizeof(cam_telemetry_t) == 74u, "cam_telemetry_t wire size changed - bump CAM_TELEMETRY_VERSION and fix the SDK parser");
+_Static_assert(sizeof(cam_telemetry_response_t) == 12u + 8u * 74u, "cam_telemetry_response_t wire size changed");
 
 /* Advance the background sweep by one bounded chunk (<= ~1.3 ms of I2C).
  * Call from camera_i2c_service() only: hi2c1 work must stay in the main

--- a/Core/Inc/common.h
+++ b/Core/Inc/common.h
@@ -163,6 +163,7 @@ typedef enum {
 	OW_CAMERA_POWER_OFF = 0x51,
 	OW_CAMERA_POWER_STATUS = 0x52,
 	OW_CAMERA_READ_SECURITY_UID = 0x53,
+	OW_CAMERA_GET_TELEMETRY = 0x54,  /* #94: cached cam_telemetry_response_t snapshot (camera_telemetry.h) */
 
 } MotionCameraCommands;
 

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -9,6 +9,7 @@
 #include "logging.h"
 #include "crosslink.h"
 #include "0X02C1B.h"
+#include "camera_telemetry.h"
 #include "i2c_master.h"
 #include "uart_comms.h"
 #include "utils.h"
@@ -1301,6 +1302,11 @@ void camera_i2c_service(void)
     }
 
     camera_recovery_tick();  /* Re-power dead cameras whose cool-off elapsed */
+
+    /* #94: advance the background telemetry sweep by one bounded chunk.
+     * Unlike the temp poll it self-schedules on HAL_GetTick(), so telemetry
+     * keeps refreshing while idle (no frames driving cam_temp_poll_due). */
+    camera_telemetry_service();
 }
 /* -------- END CAMERA I2C FUNCTIONS -------- */
 

--- a/Core/Src/camera_telemetry.c
+++ b/Core/Src/camera_telemetry.c
@@ -1,0 +1,279 @@
+/*
+ * camera_telemetry.c
+ *
+ * #94: background OX02C1B condition sweep. One camera sweep per
+ * CAM_TELEM_SWEEP_INTERVAL_MS, round-robin over powered cameras, executed in
+ * bounded chunks from camera_i2c_service() so streaming-time main-loop
+ * latency stays comparable to the temperature poll. Mux discipline per
+ * chunk mirrors poll_camera_temperatures(): select the swept camera's
+ * TCA9548A channel, do the reads with mux_channel=0xFF (pre-selected), then
+ * restore the active camera's channel.
+ *
+ * A failed transaction aborts the whole sweep: the published cache keeps the
+ * camera's last completed snapshot (same last-known-good philosophy as
+ * cam_temp[]) and i2c_err_count records the failure.
+ */
+
+#include "camera_telemetry.h"
+#include "main.h"
+#include "i2c_master.h"
+#include "0X02C1B.h"
+#include <stdio.h>
+#include <string.h>
+
+/* I2C transactions per service() pass. 6 keeps a chunk under ~1.3 ms at
+ * 400 kHz including the two mux selects (compression-budget scale, #70). */
+#define TELEM_OPS_PER_PASS 6u
+
+#define TELEM_MUX_ADDR        0x70u
+#define TELEM_I2C_TIMEOUT_MS  25u
+
+/* One burst read: `len` bytes starting at `reg` (SCCB sub-address
+ * auto-increment). Order is the decode order in telem_publish() — the two
+ * must change together (TELEM_RAW_BYTES asserts the total). */
+struct telem_op {
+	uint16_t reg;
+	uint8_t len;
+};
+
+static const struct telem_op telem_ops[] = {
+	{ 0x4E20u, 6u },  /* VM results: AVDD, DOVDD, DVDD (table A-39) */
+	{ 0x4E32u, 4u },  /* VM faults: live, CP, latched, CP-latched */
+	{ 0x4D2Au, 2u },  /* TPM average (8.8 degC) */
+	{ 0x4D56u, 4u },  /* TPM0, TPM1 */
+	{ 0x4D28u, 1u },  /* TPM status/alarm */
+	{ 0x4F0Au, 6u },  /* watchdog 0x4F0A-0x4F0F */
+	{ 0x0108u, 1u },  /* sc_state */
+	{ 0x3DA7u, 2u },  /* OTP CRC status */
+	{ 0x4900u, 4u },  /* frame counter (MIPI SOF) */
+	{ 0x3890u, 2u },  /* timing-counter row readback */
+	{ 0x3897u, 1u },  /* trigger-mode error flags */
+	{ 0x4C13u, 1u },  /* Yavg on-chip frame mean */
+	{ 0x3501u, 2u },  /* commanded coarse exposure */
+	{ 0x350Eu, 2u },  /* applied coarse exposure */
+	{ 0x3508u, 2u },  /* commanded analog gain */
+	{ 0x350Au, 3u },  /* commanded digital gain (packed 14-bit) */
+	{ 0x3503u, 1u },  /* AEC/AGC mode */
+	{ 0x3A93u, 1u },  /* DCG (conversion gain) state */
+	{ 0x4001u, 1u },  /* BLC ctrl (#89 raw-mode contract) */
+	{ 0x5000u, 1u },  /* ISP ctrl (#89 raw-mode contract) */
+	{ 0x5052u, 8u },  /* ISP-latched real gain / dig gain / BLC / exposure */
+	{ 0x4072u, 30u }, /* applied BLC offsets ch0-7 ({MSB,LSB} at stride 4) */
+};
+#define TELEM_N_OPS (sizeof(telem_ops) / sizeof(telem_ops[0]))
+#define TELEM_RAW_BYTES 85u
+
+static cam_telemetry_response_t telem_resp = {
+	.version = CAM_TELEMETRY_VERSION,
+	.valid_mask = 0u,
+	.struct_size = (uint8_t)sizeof(cam_telemetry_t),
+	.reserved = 0u,
+};
+
+/* Sweep state machine (main-loop only, so no locking). */
+static uint32_t telem_next_ms = 0;
+static uint8_t  telem_rr_idx = 0;          /* round-robin cursor */
+static int8_t   telem_active = -1;         /* camera mid-sweep, -1 = idle */
+static uint8_t  telem_op_idx = 0;
+static uint8_t  telem_staging_off = 0;
+static _Bool    telem_wrote_setup = false; /* 0x4E14 stop_update written this sweep */
+static uint8_t  telem_staging[TELEM_RAW_BYTES];
+
+const cam_telemetry_response_t *camera_telemetry_get(void)
+{
+	return &telem_resp;
+}
+
+static HAL_StatusTypeDef telem_write_reg(uint16_t reg, uint8_t val)
+{
+	uint8_t buf[3] = { (uint8_t)(reg >> 8), (uint8_t)(reg & 0xFFu), val };
+	return HAL_I2C_Master_Transmit(&hi2c1, (uint16_t)(X02C1B_ADDRESS << 1),
+	                               buf, 3, TELEM_I2C_TIMEOUT_MS);
+}
+
+/* Cursor readers: staging bytes are the sensor's MSB-first register order. */
+static uint8_t rd8(const uint8_t **p)
+{
+	uint8_t v = (*p)[0];
+	*p += 1;
+	return v;
+}
+
+static uint16_t rd16(const uint8_t **p)
+{
+	uint16_t v = (uint16_t)(((uint16_t)(*p)[0] << 8) | (*p)[1]);
+	*p += 2;
+	return v;
+}
+
+static void telem_fail(uint8_t cam_id)
+{
+	cam_telemetry_t *t = &telem_resp.cam[cam_id];
+	if (t->i2c_err_count < 0xFFu) {
+		t->i2c_err_count++;
+	}
+	telem_active = -1;
+}
+
+static void telem_publish(uint8_t cam_id, uint32_t now)
+{
+	cam_telemetry_t *t = &telem_resp.cam[cam_id];
+	const uint8_t *p = telem_staging;
+
+	/* Fault-relevant previous state, for the change notice below. */
+	uint8_t prev_wd0 = t->wd[0], prev_wd1 = t->wd[1];
+	uint8_t prev_vml = t->vm_latched, prev_vmcpl = t->vm_cp_latched;
+	uint8_t prev_tpm = (uint8_t)(t->tpm_status & 0x0Fu);
+	_Bool was_valid = (telem_resp.valid_mask & (1u << cam_id)) != 0u;
+
+	t->avdd_raw = rd16(&p);
+	t->dovdd_raw = rd16(&p);
+	t->dvdd_raw = rd16(&p);
+	t->vm_live = rd8(&p);
+	t->vm_cp = rd8(&p);
+	t->vm_latched = rd8(&p);
+	t->vm_cp_latched = rd8(&p);
+	t->tpm_avg_raw = rd16(&p);
+	t->tpm0_raw = rd16(&p);
+	t->tpm1_raw = rd16(&p);
+	t->tpm_status = rd8(&p);
+	for (uint8_t i = 0; i < 6u; i++) {
+		t->wd[i] = rd8(&p);
+	}
+	t->sc_state = rd8(&p);
+	t->otp_crc[0] = rd8(&p);
+	t->otp_crc[1] = rd8(&p);
+	t->frame_counter = ((uint32_t)rd16(&p) << 16);
+	t->frame_counter |= rd16(&p);
+	t->tc_row = rd16(&p);
+	t->trig_error = rd8(&p);
+	t->yavg = rd8(&p);
+	t->expo_cmd = rd16(&p);
+	t->expo_applied = rd16(&p);
+	t->again_cmd = rd16(&p);
+	t->dgain_cmd = ((uint32_t)rd8(&p) << 16);
+	t->dgain_cmd |= ((uint32_t)rd8(&p) << 8);
+	t->dgain_cmd |= rd8(&p);
+	t->aec_mode = rd8(&p);
+	t->dcg_state = rd8(&p);
+	t->blc_ctrl = rd8(&p);
+	t->isp_ctrl = rd8(&p);
+	t->isp_real_gain = rd16(&p);
+	t->isp_dig_gain = rd16(&p);
+	t->isp_blc = rd16(&p);
+	t->isp_expo = rd16(&p);
+	/* BLC applied offsets: 30-byte block, {MSB,LSB} pairs at stride 4
+	 * (0x4072/73, 0x4076/77, ... 0x408E/8F — see DS table A-25 §1.7). */
+	for (uint8_t i = 0; i < 8u; i++) {
+		t->blc_offset[i] = (uint16_t)(((uint16_t)p[i * 4u] << 8) | p[i * 4u + 1u]);
+	}
+	p += 30;
+
+	if (p != &telem_staging[TELEM_RAW_BYTES]) {
+		/* Decode desynced from telem_ops[] — programming error, don't
+		 * publish garbage. (Unreachable when the tables match.) */
+		printf("CAM%u TELEM decode length mismatch\r\n", cam_id + 1u);
+		telem_active = -1;
+		return;
+	}
+
+	t->updated_ms = now;
+	t->sweep_count++;
+	telem_resp.valid_mask |= (uint8_t)(1u << cam_id);
+	telem_active = -1;
+
+	/* One-line notice on fault-latch changes — rare by construction. The
+	 * watchdog sticky bit preserves one-shot events between sweeps. */
+	if (was_valid &&
+	    (t->wd[0] != prev_wd0 || t->wd[1] != prev_wd1 ||
+	     t->vm_latched != prev_vml || t->vm_cp_latched != prev_vmcpl ||
+	     (uint8_t)(t->tpm_status & 0x0Fu) != prev_tpm)) {
+		printf("CAM%u TELEM fault change: wd=%02X/%02X vm=%02X cp=%02X tpm=%02X\r\n",
+		       cam_id + 1u, t->wd[0], t->wd[1], t->vm_latched,
+		       t->vm_cp_latched, t->tpm_status);
+	}
+}
+
+void camera_telemetry_service(void)
+{
+	uint32_t now = HAL_GetTick();  /* wrap-safe cadence, same rationale as the temp poll (#73) */
+
+	if (telem_active < 0) {
+		if ((int32_t)(now - telem_next_ms) < 0) {
+			return;
+		}
+		telem_next_ms = now + CAM_TELEM_SWEEP_INTERVAL_MS;
+
+		/* Pick the next powered camera (dead-camera rails are off during
+		 * cool-off; their mux channel is disconnected — skip, like the
+		 * temperature poll). */
+		for (uint8_t i = 0; i < CAMERA_COUNT; i++) {
+			uint8_t cam = telem_rr_idx;
+			telem_rr_idx = (uint8_t)((telem_rr_idx + 1u) % CAMERA_COUNT);
+			CameraDevice *p = get_camera_byID(cam);
+			if (p != NULL && p->isPresent && p->isPowered) {
+				telem_active = (int8_t)cam;
+				telem_op_idx = 0;
+				telem_staging_off = 0;
+				telem_wrote_setup = false;
+				break;
+			}
+		}
+		if (telem_active < 0) {
+			return;  /* nothing powered */
+		}
+	}
+
+	uint8_t cam_id = (uint8_t)telem_active;
+	CameraDevice *cam = get_camera_byID(cam_id);
+	if (cam == NULL || !cam->isPowered) {
+		/* Camera died mid-sweep (death isolation) — drop the sweep without
+		 * counting an I2C error against it. */
+		telem_active = -1;
+		return;
+	}
+
+	if (TCA9548A_SelectChannel(&hi2c1, TELEM_MUX_ADDR, cam->i2c_target) != HAL_OK) {
+		telem_fail(cam_id);
+	} else {
+		uint8_t ops_done = 0;
+
+		/* Sweep setup: freeze VM result updates during SCCB reads so the
+		 * 12-bit MSB/LSB pairs can't tear (0x4E14[0], table A-39). Written
+		 * every sweep — self-healing after a camera power cycle resets it. */
+		if (!telem_wrote_setup) {
+			if (telem_write_reg(0x4E14u, 0x01u) != HAL_OK) {
+				telem_fail(cam_id);
+				ops_done = TELEM_OPS_PER_PASS;  /* skip the read loop */
+			} else {
+				telem_wrote_setup = true;
+				ops_done++;
+			}
+		}
+
+		while (ops_done < TELEM_OPS_PER_PASS && telem_active >= 0 &&
+		       telem_op_idx < TELEM_N_OPS) {
+			const struct telem_op *op = &telem_ops[telem_op_idx];
+			if (i2c_mem_read(&hi2c1, X02C1B_ADDRESS, op->reg, 2u,
+			                 &telem_staging[telem_staging_off], op->len,
+			                 0xFFu) != HAL_OK) {
+				telem_fail(cam_id);
+				break;
+			}
+			telem_staging_off += op->len;
+			telem_op_idx++;
+			ops_done++;
+		}
+
+		if (telem_active >= 0 && telem_op_idx >= TELEM_N_OPS) {
+			telem_publish(cam_id, now);
+		}
+	}
+
+	/* Restore the active camera's channel, exactly like the temperature
+	 * poll — command handlers assume their selection is still in effect. */
+	CameraDevice *active = get_active_cam();
+	if (active != NULL) {
+		(void)TCA9548A_SelectChannel(&hi2c1, TELEM_MUX_ADDR, active->i2c_target);
+	}
+}

--- a/Core/Src/camera_telemetry.c
+++ b/Core/Src/camera_telemetry.c
@@ -45,8 +45,7 @@ static const struct telem_op telem_ops[] = {
 	{ 0x4F0Au, 6u },  /* watchdog 0x4F0A-0x4F0F */
 	{ 0x0108u, 1u },  /* sc_state */
 	{ 0x3DA7u, 2u },  /* OTP CRC status */
-	{ 0x4900u, 4u },  /* frame counter (MIPI SOF) */
-	{ 0x3890u, 2u },  /* timing-counter row readback */
+	{ 0x3892u, 2u },  /* LIVE row counter (0x3890/91 are constant-0; bench-verified) */
 	{ 0x3897u, 1u },  /* trigger-mode error flags */
 	{ 0x4C13u, 1u },  /* Yavg on-chip frame mean */
 	{ 0x3501u, 2u },  /* commanded coarse exposure */
@@ -61,7 +60,12 @@ static const struct telem_op telem_ops[] = {
 	{ 0x4072u, 30u }, /* applied BLC offsets ch0-7 ({MSB,LSB} at stride 4) */
 };
 #define TELEM_N_OPS (sizeof(telem_ops) / sizeof(telem_ops[0]))
-#define TELEM_RAW_BYTES 85u
+#define TELEM_RAW_BYTES 81u
+
+/* Firmware-side FSIN pulse counter (main.c, incremented per frame trigger):
+ * the frames-triggered ground truth for the response header — the sensor's
+ * own frame counter has no readable SCCB value register (see header note). */
+extern volatile uint16_t pulse_count;
 
 static cam_telemetry_response_t telem_resp = {
 	.version = CAM_TELEMETRY_VERSION,
@@ -81,6 +85,8 @@ static uint8_t  telem_staging[TELEM_RAW_BYTES];
 
 const cam_telemetry_response_t *camera_telemetry_get(void)
 {
+	telem_resp.fsin_pulse_count = (uint32_t)pulse_count;
+	telem_resp.uptime_ms = HAL_GetTick();
 	return &telem_resp;
 }
 
@@ -143,8 +149,6 @@ static void telem_publish(uint8_t cam_id, uint32_t now)
 	t->sc_state = rd8(&p);
 	t->otp_crc[0] = rd8(&p);
 	t->otp_crc[1] = rd8(&p);
-	t->frame_counter = ((uint32_t)rd16(&p) << 16);
-	t->frame_counter |= rd16(&p);
 	t->tc_row = rd16(&p);
 	t->trig_error = rd8(&p);
 	t->yavg = rd8(&p);

--- a/Core/Src/if_commands.c
+++ b/Core/Src/if_commands.c
@@ -16,6 +16,7 @@
 #include "i2c_protocol.h"
 #include "ICM20948.h"
 #include "0X02C1B.h"
+#include "camera_telemetry.h"
 #include "histo_fake.h"
 #include "usbd_histo.h"
 #include "motion_config.h"
@@ -940,6 +941,16 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 				uartResp->data = (uint8_t *)&cam_temp; // Point to the static temp variable
 			}
 		}
+		break;
+	case OW_CAMERA_GET_TELEMETRY:
+		/* #94: background-collected per-camera condition snapshot (rails,
+		 * temps, faults, counters). No I2C here — returns the cache that
+		 * camera_telemetry_service() maintains from the main loop. */
+		VERBOSE_CMD("[CMD] OW_CAMERA_GET_TELEMETRY\r\n");
+		uartResp->command = OW_CAMERA_GET_TELEMETRY;
+		uartResp->packet_type = OW_RESP;
+		uartResp->data_len = sizeof(cam_telemetry_response_t);
+		uartResp->data = (uint8_t *)camera_telemetry_get();
 		break;
 	case OW_CAMERA_FSIN_EXTERNAL:
 		VERBOSE_CMD("[CMD] OW_CAMERA_FSIN_EXTERNAL reserved=%u (%s)\r\n", cmd.reserved, cmd.reserved == 0 ? "disable" : "enable");

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -241,6 +241,29 @@ All command and response traffic on the COMMS interface uses a fixed binary pack
 | `OW_CAMERA_POWER_OFF` | 0x51 | Remove power from camera(s) in `addr` mask; manages FSIN_EXT disable/re-enable around power transitions |
 | `OW_CAMERA_POWER_STATUS` | 0x52 | Return 1-byte bitmask of powered cameras (bit N = camera N powered) |
 | `OW_CAMERA_READ_SECURITY_UID` | 0x53 | Read 6-byte security UID from camera specified by `cmd.addr` (0–7) |
+| `OW_CAMERA_GET_TELEMETRY` | 0x54 | Return the cached 628-byte `cam_telemetry_response_t` snapshot (see Camera Telemetry below); no I2C in the handler |
+
+#### Camera Telemetry (#94)
+
+Firmware continuously sweeps every powered camera's condition registers in the
+background (`camera_telemetry_service()`, driven from `camera_i2c_service()`):
+supply rails AVDD/DOVDD/DVDD from the on-die voltage monitor, dual junction
+temperatures + cross-check alarm, voltage/charge-pump fault latches, watchdog
+fault roll-up + sensor state machine, OTP CRC status, MIPI frame counter,
+FSIN trigger-error flag, on-chip frame mean (Yavg), commanded vs applied
+exposure/gain, correction-state bytes (0x4001/0x5000/0x3503/0x3A93), and the
+eight applied BLC channel offsets.
+
+- One camera sweep (1 write + 22 burst reads, ~85 raw bytes) starts every
+  `CAM_TELEM_SWEEP_INTERVAL_MS` (125 ms), round-robin → ~1 s full-fleet
+  refresh; sweeps run in chunks of ≤6 transactions per main-loop pass.
+- Values are raw register bytes (MSB-first); the SDK converts to volts
+  (`code × 6/4096`), °C (8.8 format, >0xC000 negative), and gain factors.
+- A failed transaction aborts that sweep; the cache keeps the camera's last
+  completed snapshot (`updated_ms` reveals staleness, `i2c_err_count` counts
+  failures, `sweep_count` proves liveness).
+- Firmware prints a one-line notice when a camera's fault latches change
+  between sweeps.
 
 #### FSIN Management During Power Transitions
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -241,7 +241,7 @@ All command and response traffic on the COMMS interface uses a fixed binary pack
 | `OW_CAMERA_POWER_OFF` | 0x51 | Remove power from camera(s) in `addr` mask; manages FSIN_EXT disable/re-enable around power transitions |
 | `OW_CAMERA_POWER_STATUS` | 0x52 | Return 1-byte bitmask of powered cameras (bit N = camera N powered) |
 | `OW_CAMERA_READ_SECURITY_UID` | 0x53 | Read 6-byte security UID from camera specified by `cmd.addr` (0–7) |
-| `OW_CAMERA_GET_TELEMETRY` | 0x54 | Return the cached 628-byte `cam_telemetry_response_t` snapshot (see Camera Telemetry below); no I2C in the handler |
+| `OW_CAMERA_GET_TELEMETRY` | 0x54 | Return the cached 604-byte `cam_telemetry_response_t` snapshot (see Camera Telemetry below); no I2C in the handler |
 
 #### Camera Telemetry (#94)
 
@@ -249,12 +249,16 @@ Firmware continuously sweeps every powered camera's condition registers in the
 background (`camera_telemetry_service()`, driven from `camera_i2c_service()`):
 supply rails AVDD/DOVDD/DVDD from the on-die voltage monitor, dual junction
 temperatures + cross-check alarm, voltage/charge-pump fault latches, watchdog
-fault roll-up + sensor state machine, OTP CRC status, MIPI frame counter,
+fault roll-up + sensor state machine, OTP CRC status, live row counter,
 FSIN trigger-error flag, on-chip frame mean (Yavg), commanded vs applied
 exposure/gain, correction-state bytes (0x4001/0x5000/0x3503/0x3A93), and the
-eight applied BLC channel offsets.
+eight applied BLC channel offsets. The response header also carries the
+firmware's FSIN pulse count and uptime. (The sensor's own "32-bit frame
+counter" has no readable SCCB value register on this silicon — 0x4900-03 are
+control bytes only, bench-verified — so frames-triggered truth is the
+firmware FSIN counter.)
 
-- One camera sweep (1 write + 22 burst reads, ~85 raw bytes) starts every
+- One camera sweep (1 write + 21 burst reads, ~81 raw bytes) starts every
   `CAM_TELEM_SWEEP_INTERVAL_MS` (125 ms), round-robin → ~1 s full-fleet
   refresh; sweeps run in chunks of ≤6 transactions per main-loop pass.
 - Values are raw register bytes (MSB-first); the SDK converts to volts

--- a/tests/test_camera_telemetry_hil.py
+++ b/tests/test_camera_telemetry_hil.py
@@ -11,8 +11,12 @@ the fleet (~1 s round-robin), then validates the cached snapshot end to end:
 - correction-state bytes match the production table (0x4001=0x23, 0x5000=0x34,
   AEC/AGC manual 0xA8) and commanded analog gain matches the per-slot ladder
 - sweeps stay live (sweep_count advances between polls)
-- the MIPI frame counter increases after single-histogram captures and by a
-  sane amount — this also pins down the 0x4900-03 byte order on real silicon
+- during a ~3 s stream_on + internal-FSIN burst, sweeps observe the probe
+  camera actually producing frames: sc_state reads 0x9 (streaming) and the
+  live row counter (0x3892) moves between fresh sweeps. (The sensor's own
+  "frame counter" has no readable SCCB value register on this silicon, and
+  the firmware's fsin_pulse_count counts external/console FSIN edges only —
+  both bench-verified 2026-07-17.)
 
 Requires the SDK with MotionSensor.get_camera_telemetry() (openmotion-sdk#...,
 same change series as fw PR for #94); skips with a clear message on older SDKs.
@@ -177,10 +181,10 @@ def test_camera_telemetry_snapshot(interface):
             if c["aec_mode"] != AEC_AGC_MANUAL:
                 failures.append(
                     f"[{side}] cam {cam_id}: AEC mode 0x{c['aec_mode']:02X} != 0xA8")
-            if c["again_cmd"] >> 4 != EXPECTED_GAIN[cam_id]:
+            if c["again_x"] != float(EXPECTED_GAIN[cam_id]):
                 failures.append(
-                    f"[{side}] cam {cam_id}: analog gain 0x{c['again_cmd']:04X} "
-                    f"!= expected 0x{EXPECTED_GAIN[cam_id]:02X}<<4")
+                    f"[{side}] cam {cam_id}: analog gain {c['again_x']}x "
+                    f"(raw 0x{c['again_cmd']:04X}) != expected {EXPECTED_GAIN[cam_id]}x")
             if c["expo_cmd"] != EXPECTED_EXPO_ROWS:
                 failures.append(
                     f"[{side}] cam {cam_id}: commanded exposure 0x{c['expo_cmd']:04X} "
@@ -197,23 +201,47 @@ def test_camera_telemetry_snapshot(interface):
         if ((second - first) & 0xFF) == 0:
             failures.append(f"[{side}] cam {probe_cam}: sweep_count stuck at {first}")
 
-        # Frame counter: a few single captures must nudge it by a small amount.
-        # Also pins the 0x4900-03 byte order (a swapped assembly would jump by
-        # ~2^24 per frame and fail the delta bound).
-        fc_before = sensor.get_camera_telemetry()["cameras"][probe_cam]["frame_counter"]
-        for _ in range(3):
-            sensor.camera_capture_histogram(1 << probe_cam)
-            time.sleep(0.1)
-        time.sleep(FLEET_REFRESH_S)
-        fc_after = sensor.get_camera_telemetry()["cameras"][probe_cam]["frame_counter"]
-        delta = (fc_after - fc_before) & 0xFFFFFFFF
-        print(f"frame_counter cam {probe_cam}: {fc_before} -> {fc_after} (delta {delta})")
-        if delta == 0:
+        # Frames-flowing proof: stream the probe camera with internal FSIN for
+        # ~3 s and let the background sweep observe it mid-burst. Fresh sweeps
+        # must show sc_state 0x9 (streaming) and a moving live row counter.
+        # No histogram stream is enabled, so no SPI/USB reception is armed
+        # (no endpoint wedge). fsin_pulse_count is external-FSIN-only, so it
+        # is printed for information, not asserted, in this internal-FSIN run.
+        from omotion.config import OW_CAMERA, OW_CAMERA_ON, OW_CAMERA_OFF
+
+        pc_before = sensor.get_camera_telemetry()["fsin_pulse_count"]
+        sensor.switch_camera(probe_cam)
+        sensor._send(packetType=OW_CAMERA, command=OW_CAMERA_ON)
+        sensor.enable_aggregator_fsin()
+        samples = []
+        t_end = time.monotonic() + 3.2
+        while time.monotonic() < t_end:
+            time.sleep(0.4)
+            c = sensor.get_camera_telemetry()["cameras"][probe_cam]
+            samples.append((c["updated_ms"], c["tc_row"], c["sc_state"]))
+        sensor.disable_aggregator_fsin()
+        sensor._send(packetType=OW_CAMERA, command=OW_CAMERA_OFF)
+        pc_after = sensor.get_camera_telemetry()["fsin_pulse_count"]
+
+        fresh = {}
+        for upd, tc, sc in samples:
+            fresh[upd] = (tc, sc)
+        print(f"burst sweeps for cam {probe_cam}: "
+              f"{[(u, t, hex(s)) for u, (t, s) in sorted(fresh.items())]} "
+              f"(ext-FSIN pulse count {pc_before} -> {pc_after})")
+        if len(fresh) < 2:
             failures.append(
-                f"[{side}] cam {probe_cam}: frame counter did not advance after captures")
-        elif delta > 1000:
-            failures.append(
-                f"[{side}] cam {probe_cam}: frame counter delta {delta} implausible "
-                f"(byte order?)")
+                f"[{side}] only {len(fresh)} fresh sweep(s) during 3 s burst")
+        else:
+            tc_vals = [t for t, _ in fresh.values()]
+            sc_vals = [s for _, s in fresh.values()]
+            if 0x9 not in sc_vals:
+                failures.append(
+                    f"[{side}] cam {probe_cam} never seen in streaming state "
+                    f"(sc_states {[hex(s) for s in sc_vals]})")
+            if len(set(tc_vals)) < 2:
+                failures.append(
+                    f"[{side}] cam {probe_cam} live row counter frozen at "
+                    f"{tc_vals[0]} across {len(tc_vals)} mid-stream sweeps")
 
     assert not failures, "telemetry failures:\n  " + "\n  ".join(failures)

--- a/tests/test_camera_telemetry_hil.py
+++ b/tests/test_camera_telemetry_hil.py
@@ -1,0 +1,219 @@
+"""HIL: continuous camera-sensor telemetry (#94, OW_CAMERA_GET_TELEMETRY).
+
+Brings up every present camera, lets the firmware's background sweep refresh
+the fleet (~1 s round-robin), then validates the cached snapshot end to end:
+
+- response framing: version 1, struct_size 78, valid bit per powered camera
+- supply rails from the on-die voltage monitor sit inside the alarm windows
+  the config table programs (AVDD [2.52, 3.08] V etc., V = code * 6 / 4096)
+- die temperatures are plausible (10-95 degC) and TPM cross-check alarm clear
+- no camera sits in safe mode (sc_state 5); no VM/watchdog fault latched
+- correction-state bytes match the production table (0x4001=0x23, 0x5000=0x34,
+  AEC/AGC manual 0xA8) and commanded analog gain matches the per-slot ladder
+- sweeps stay live (sweep_count advances between polls)
+- the MIPI frame counter increases after single-histogram captures and by a
+  sane amount — this also pins down the 0x4900-03 byte order on real silicon
+
+Requires the SDK with MotionSensor.get_camera_telemetry() (openmotion-sdk#...,
+same change series as fw PR for #94); skips with a clear message on older SDKs.
+
+Run on a bench with sensor module(s) attached (WinUSB via Zadig):
+
+    OPENMOTION_HIL=1 pytest tests/test_camera_telemetry_hil.py -v -s
+    (PowerShell: $env:OPENMOTION_HIL = "1")
+
+Set OW_SENSOR_SIDE=left|right to restrict to one side, and
+OPENMOTION_POWER_CYCLE_CMD (bench Shelly script) to start from a fresh sensor.
+"""
+import logging
+import os
+import subprocess
+import time
+
+import pytest
+
+requires_bench = pytest.mark.skipif(
+    os.environ.get("OPENMOTION_HIL") != "1",
+    reason="hardware-in-the-loop test; set OPENMOTION_HIL=1 on the bench",
+)
+
+logger = logging.getLogger(__name__)
+
+CONNECT_TIMEOUT_S = 15.0
+FLEET_REFRESH_S = 3.0        # sweep interval 125 ms * 8 cams = 1 s; 3x margin
+
+# Voltage-monitor alarm windows programmed by X02C1B_SENSOR_CONFIG (0x4E03-0E),
+# in volts. Readings must land inside them or the sensor itself would latch a
+# vm fault.
+RAIL_WINDOWS_V = {
+    "avdd": (2.52, 3.08),
+    "dovdd": (1.62, 1.98),
+    "dvdd": (1.08, 1.32),
+}
+TEMP_WINDOW_C = (10.0, 95.0)
+
+EXPECTED_GAIN = [0x10, 0x04, 0x02, 0x01, 0x01, 0x02, 0x04, 0x10]
+PRODUCTION_BLC_CTRL = 0x23   # 0x4001 (raw mode #89 would read 0x00)
+PRODUCTION_ISP_CTRL = 0x34   # 0x5000 (raw mode #89 would read 0x30)
+AEC_AGC_MANUAL = 0xA8        # 0x3503
+EXPECTED_EXPO_ROWS = 0x0048  # 72 rows = 648 us (config table)
+SC_STATE_SAFE_MODE = 0x5
+
+
+@pytest.fixture
+def interface():
+    from omotion import MotionInterface
+
+    cycle_cmd = os.environ.get("OPENMOTION_POWER_CYCLE_CMD")
+    if cycle_cmd:
+        subprocess.run(cycle_cmd, shell=True, check=True, timeout=60)
+        time.sleep(8.0)  # re-enumeration settle
+
+    iface = MotionInterface()
+    iface.start(wait=False)
+    deadline = time.monotonic() + CONNECT_TIMEOUT_S
+    while time.monotonic() < deadline and not iface.connected_sensors():
+        time.sleep(0.2)
+    yield iface
+    iface.stop()
+
+
+def _present_cameras(sensor):
+    try:
+        health = sensor.get_i2c_health(rescan=True)
+        cams = health.get("cameras") if isinstance(health, dict) else None
+        if cams:
+            present = [i for i, ok in enumerate(cams) if ok]
+            if present:
+                return present
+    except Exception as exc:  # noqa: BLE001 - diagnostic fallback only
+        logger.warning("i2c-health unavailable (%s); assuming all 8 cameras", exc)
+    return list(range(8))
+
+
+def _bring_up(sensor, mask):
+    assert sensor.enable_camera_power(mask) is True, "enable_camera_power failed"
+    time.sleep(0.5)
+    assert sensor.program_fpga(camera_position=mask, manual_process=False) is True, \
+        "program_fpga failed"
+    time.sleep(0.1)
+    assert sensor.camera_configure_registers(mask) is True, \
+        "camera_configure_registers failed"
+
+
+@requires_bench
+def test_camera_telemetry_snapshot(interface):
+    side_filter = os.environ.get("OW_SENSOR_SIDE")
+    sensors = [
+        s for s in interface.connected_sensors()
+        if side_filter is None or getattr(s, "side", None) == side_filter
+    ]
+    if not sensors:
+        pytest.skip(f"no sensor module connected (side filter={side_filter!r})")
+
+    failures = []
+    for sensor in sensors:
+        side = getattr(sensor, "side", "?")
+        if not hasattr(sensor, "get_camera_telemetry"):
+            pytest.skip("SDK lacks get_camera_telemetry(); update openmotion-sdk")
+
+        present = _present_cameras(sensor)
+        mask = 0
+        for i in present:
+            mask |= (1 << i)
+        logger.info("[%s] present cameras: %s (mask 0x%02X)", side, present, mask)
+
+        _bring_up(sensor, mask)
+        time.sleep(FLEET_REFRESH_S)
+
+        telem = sensor.get_camera_telemetry()
+        assert telem is not None, f"[{side}] get_camera_telemetry returned None"
+        assert telem["version"] == 1, f"[{side}] unexpected telemetry version"
+
+        print(f"\n=== Sensor [{side}] camera telemetry ===")
+        print(f"{'cam':>3} | {'AVDD':>6} {'DOVDD':>6} {'DVDD':>6} | "
+              f"{'Tavg':>6} | {'state':>5} | {'faults':>13} | {'blc/isp':>9} | swp")
+        print("-" * 84)
+
+        for cam_id in present:
+            c = telem["cameras"][cam_id]
+            if not c["valid"]:
+                failures.append(f"[{side}] cam {cam_id}: no completed sweep (valid=0)")
+                print(f"{cam_id:>3} | {'-- no completed sweep --':^60}")
+                continue
+
+            rails = {k: c[f"{k}_v"] for k in ("avdd", "dovdd", "dvdd")}
+            t_avg = c["tpm_avg_c"]
+            faults = (f"wd={c['wd_fault_a']:02X}/{c['wd_fault_b']:02X} "
+                      f"vm={c['vm_latched']:02X}")
+            print(f"{cam_id:>3} | {rails['avdd']:6.3f} {rails['dovdd']:6.3f} "
+                  f"{rails['dvdd']:6.3f} | {t_avg:6.1f} | {c['sc_state']:>5X} | "
+                  f"{faults:>13} | {c['blc_ctrl']:02X}/{c['isp_ctrl']:02X}    | "
+                  f"{c['sweep_count']}")
+
+            for rail, (lo, hi) in RAIL_WINDOWS_V.items():
+                v = rails[rail]
+                if not (lo <= v <= hi):
+                    failures.append(
+                        f"[{side}] cam {cam_id}: {rail} {v:.3f} V outside [{lo}, {hi}]")
+            if not (TEMP_WINDOW_C[0] <= t_avg <= TEMP_WINDOW_C[1]):
+                failures.append(f"[{side}] cam {cam_id}: tpm_avg {t_avg:.1f} C implausible")
+            if abs(c["tpm0_c"] - c["tpm1_c"]) > 10.0:
+                failures.append(
+                    f"[{side}] cam {cam_id}: TPM0/TPM1 disagree "
+                    f"({c['tpm0_c']:.1f} vs {c['tpm1_c']:.1f} C)")
+            if c["sc_state"] == SC_STATE_SAFE_MODE:
+                failures.append(f"[{side}] cam {cam_id}: sensor in SAFE MODE")
+            if c["vm_latched"] & 0x3F:
+                failures.append(
+                    f"[{side}] cam {cam_id}: VM fault latched 0x{c['vm_latched']:02X}")
+            if c["tpm_status"] & 0x0F:
+                failures.append(
+                    f"[{side}] cam {cam_id}: TPM alarm 0x{c['tpm_status']:02X}")
+            if c["blc_ctrl"] != PRODUCTION_BLC_CTRL or c["isp_ctrl"] != PRODUCTION_ISP_CTRL:
+                failures.append(
+                    f"[{side}] cam {cam_id}: correction state 0x{c['blc_ctrl']:02X}/"
+                    f"0x{c['isp_ctrl']:02X} != production 0x23/0x34")
+            if c["aec_mode"] != AEC_AGC_MANUAL:
+                failures.append(
+                    f"[{side}] cam {cam_id}: AEC mode 0x{c['aec_mode']:02X} != 0xA8")
+            if c["again_cmd"] >> 4 != EXPECTED_GAIN[cam_id]:
+                failures.append(
+                    f"[{side}] cam {cam_id}: analog gain 0x{c['again_cmd']:04X} "
+                    f"!= expected 0x{EXPECTED_GAIN[cam_id]:02X}<<4")
+            if c["expo_cmd"] != EXPECTED_EXPO_ROWS:
+                failures.append(
+                    f"[{side}] cam {cam_id}: commanded exposure 0x{c['expo_cmd']:04X} "
+                    f"!= 0x{EXPECTED_EXPO_ROWS:04X}")
+            if c["i2c_err_count"] > 2:
+                failures.append(
+                    f"[{side}] cam {cam_id}: {c['i2c_err_count']} sweep I2C errors")
+
+        # Liveness: sweeps keep advancing.
+        probe_cam = present[0]
+        first = telem["cameras"][probe_cam]["sweep_count"]
+        time.sleep(1.5)
+        second = sensor.get_camera_telemetry()["cameras"][probe_cam]["sweep_count"]
+        if ((second - first) & 0xFF) == 0:
+            failures.append(f"[{side}] cam {probe_cam}: sweep_count stuck at {first}")
+
+        # Frame counter: a few single captures must nudge it by a small amount.
+        # Also pins the 0x4900-03 byte order (a swapped assembly would jump by
+        # ~2^24 per frame and fail the delta bound).
+        fc_before = sensor.get_camera_telemetry()["cameras"][probe_cam]["frame_counter"]
+        for _ in range(3):
+            sensor.camera_capture_histogram(1 << probe_cam)
+            time.sleep(0.1)
+        time.sleep(FLEET_REFRESH_S)
+        fc_after = sensor.get_camera_telemetry()["cameras"][probe_cam]["frame_counter"]
+        delta = (fc_after - fc_before) & 0xFFFFFFFF
+        print(f"frame_counter cam {probe_cam}: {fc_before} -> {fc_after} (delta {delta})")
+        if delta == 0:
+            failures.append(
+                f"[{side}] cam {probe_cam}: frame counter did not advance after captures")
+        elif delta > 1000:
+            failures.append(
+                f"[{side}] cam {probe_cam}: frame counter delta {delta} implausible "
+                f"(byte order?)")
+
+    assert not failures, "telemetry failures:\n  " + "\n  ".join(failures)


### PR DESCRIPTION
Continuous condition telemetry for all 8 OX02C1B cameras, per the design on the issue: supply rails (on-die voltage monitor), dual die temps + cross-check, VM/charge-pump/watchdog fault latches, sensor state machine, OTP CRC status, MIPI frame counter, FSIN trigger-error flag, on-chip frame mean, commanded-vs-applied exposure/gain, correction-state bytes (#89 raw-mode contract), and applied BLC offsets.

- Background sweep from `camera_i2c_service()`: one camera per 125 ms round-robin, ≤6 I2C transactions per main-loop pass, temp-poll mux discipline, last-known-good on failure.
- `OW_CAMERA_GET_TELEMETRY` (0x54) returns the cached 628-B versioned `cam_telemetry_response_t` verbatim (diag-stats pattern) — no I2C in the handler.
- Raw register values on the wire; the companion openmotion-sdk PR adds `get_camera_telemetry()` with engineering-unit conversion.
- HIL test: rails inside the config table's VM alarm windows, temps plausible, no safe-mode/fault latches, production correction state, sweep liveness, frame-counter advance on single captures (pins 0x4900-03 byte order).

Builds: Debug FLASH 75.18%, Release 60.19%, both clean. **Not yet hardware-verified** — bench results will be posted on #94 before this merges.

Refs #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)