### PR TITLE
docs: correct camera part number OV2312 -> OX02C1B in prose/comments

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # openmotion-sensor-fw — Claude guide
 
-Firmware for the sensor-module MCU (STM32H743VIH6). Drives 8 OV2312 cameras through a Lattice CrossLink FPGA, exposes a composite USB device (three bulk interfaces: COMMS, HISTO, IMU) to the host, and ships a `.hex` that merges the firmware + the FPGA bitstream into one programmable image.
+Firmware for the sensor-module MCU (STM32H743VIH6). Drives 8 OX02C1B cameras through a Lattice CrossLink FPGA, exposes a composite USB device (three bulk interfaces: COMMS, HISTO, IMU) to the host, and ships a `.hex` that merges the firmware + the FPGA bitstream into one programmable image.
 
 Cross-repo context + shared protocol: [../CLAUDE.md](../CLAUDE.md). Authoritative protocol spec lives in [../openmotion-console-fw/CommandHandling.md](../openmotion-console-fw/CommandHandling.md).
 
@@ -108,7 +108,7 @@ Note: the parent CLAUDE.md historically claimed 384 KB for the FPGA region — t
 | `Core/Src/main.c` | Init, event loop, USB setup, GPIO / IRQ handlers. |
 | `Core/Src/if_commands.c` | Command dispatcher — handlers in `app_handle_uartframe()`. |
 | `Core/Src/camera_manager.c` | 8-camera orchestration, histogram streaming. SPI6 read from FPGA → `frame_buffer` → USB HISTO. |
-| `Core/Src/0X02C1B.c` | OV2312 image-sensor register config (the file is literally named after the part). |
+| `Core/Src/0X02C1B.c` | OX02C1B image-sensor register config (the file is named after the part). |
 | `Core/Src/crosslink.c` | Lattice CrossLink FPGA — I2C activation, IDCODE check, SRAM erase/program, status verify. Bitstream size hardcoded as `163489`. |
 | `Core/Src/ICM20948.c` | 6-DOF IMU + magnetometer driver. |
 | `Core/Src/uart_comms.c` | UART packet framing with CRC-16. |

--- a/Core/Inc/camera_manager.h
+++ b/Core/Inc/camera_manager.h
@@ -51,7 +51,7 @@ typedef struct {
 
 #define CAMERA_COUNT	8
 /* How long a dead camera's rail is held off so the camera-module PCB power
- * regulator (supplies both the CrossLink FPGA and the OV2312) can cool and
+ * regulator (supplies both the CrossLink FPGA and the OX02C1B) can cool and
  * clear its thermal-shutdown latch. */
 #define CAMERA_RECOVERY_OFF_MS	10000
 #define HISTOGRAM_DATA_SIZE	4100

--- a/Core/Inc/i2c_health.h
+++ b/Core/Inc/i2c_health.h
@@ -21,7 +21,7 @@ typedef struct __attribute__((packed)) {
 	uint8_t version;          /* = I2C_HEALTH_VERSION */
 	uint8_t mux_present;      /* TCA9548A 0x70 ACK on the main bus */
 	uint8_t imu_present;      /* ICM-20948 0x68 ACK on the main bus */
-	uint8_t camera_present;   /* bit i = OV2312 (0x36) found on mux channel i */
+	uint8_t camera_present;   /* bit i = OX02C1B (0x36) found on mux channel i */
 	uint8_t fpga_present;     /* bit i = CrossLink (0x40) found on mux channel i */
 	uint8_t cameras_expected; /* = 0xFF (all 8 — both sensors fully connected) */
 	uint8_t all_present;      /* 1 iff mux & imu & camera==0xFF & fpga==0xFF */

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -1174,7 +1174,7 @@ static void poll_camera_temperatures(void)
                     {
                         /* Keep last-known-good on failed reads: read_temp
                          * returns a negative error code on I2C failure, and
-                         * a live OV2312 die never legitimately reads <= 0 °C
+                         * a live OX02C1B die never legitimately reads <= 0 °C
                          * (self-heating), so treat non-positive as failure. */
                         float t = X02C1B_read_temp(pCam);
                         if (t > 0.0f) {
@@ -1251,7 +1251,7 @@ static void camera_death_isolate(uint8_t cam_id)
 }
 
 /* Re-power a dead camera's rail once its cool-off has elapsed, keeping
- * CRESETB low: the FPGA stays unbooted and quiet, while the OV2312 (direct
+ * CRESETB low: the FPGA stays unbooted and quiet, while the OX02C1B (direct
  * I2C behind the mux) comes back up so temperature telemetry resumes.
  * needs_recovery stays set until program_fpga() completes the real
  * bring-up at the next scan. Main-loop only. */
@@ -1471,7 +1471,7 @@ static void check_camera_failures(void) {
 						/* Mark dead via needs_recovery — NOT isPresent, which keeps
 						 * the presence determination from scan start. The likely
 						 * cause is the camera PCB's power regulator hitting thermal
-						 * shutdown (kills both FPGA and OV2312), so the camera
+						 * shutdown (kills both FPGA and OX02C1B), so the camera
 						 * needs a timed rail cycle, done from the main loop. */
 						cam_array[cam_id].needs_recovery = true;
 						printf("Camera %d has stopped posting data\r\n", cam_id + 1);

--- a/Core/Src/i2c_health.c
+++ b/Core/Src/i2c_health.c
@@ -22,7 +22,7 @@ extern IWDG_HandleTypeDef hiwdg1;
 
 #define MUX_I2C_ADDR        0x70u  /* TCA9548A */
 #define IMU_I2C_ADDR        0x68u  /* ICM-20948, AD0=0 */
-#define CAM_SENSOR_I2C_ADDR 0x36u  /* OV2312 */
+#define CAM_SENSOR_I2C_ADDR 0x36u  /* OX02C1B */
 
 /* HAL_I2C_IsDeviceReady tuning: a couple of trials, short bounded timeout so a
  * missing/wedged device can't stall the boot scan. */
@@ -39,7 +39,7 @@ static bool ping(uint8_t addr7)
 }
 
 /*
- * Probe one camera slot.  The OV2312 (0x36) and the CrossLink config port
+ * Probe one camera slot.  The OX02C1B (0x36) and the CrossLink config port
  * (0x40) are reachable in MUTUALLY-EXCLUSIVE FPGA states, so each is checked in
  * its own state within a single power cycle:
  *   - FPGA: rail on with CRESETB held low (forced slave-config) + activation

--- a/docs/fpga-nvcm-autodetect.md
+++ b/docs/fpga-nvcm-autodetect.md
@@ -115,7 +115,7 @@ the i2cem/isp path depends on index 5 first.)
 
 ### Background
 
-Each sensor module has 8 OV2312 cameras, each with its own Lattice CrossLink
+Each sensor module has 8 OX02C1B cameras, each with its own Lattice CrossLink
 FPGA behind a TCA9548A I2C mux at address 0x70.  The FPGAs compute histograms
 from MIPI CSI-2 camera data.
 

--- a/tests/test_camera_gain_hil.py
+++ b/tests/test_camera_gain_hil.py
@@ -1,7 +1,7 @@
 """HIL: configure all cameras, then read back each camera's analog-gain
 register and verify it matches the per-position gain the firmware writes.
 
-The OV2312 image sensor lives at I2C 0x36; its analog-gain register is 0x3508
+The OX02C1B image sensor lives at I2C 0x36; its analog-gain register is 0x3508
 (16-bit register address). During camera_configure_registers(), the firmware
 (X02C1B_configure_sensor in Core/Src/0X02C1B.c) writes the default config table
 and then overrides 0x3508 with a per-position gain by camera id:
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 CONNECT_TIMEOUT_S = 15.0
 
 OV2312_ADDR = 0x36
-GAIN_REG = 0x3508            # OV2312 analog gain, 16-bit register address
+GAIN_REG = 0x3508            # OX02C1B analog gain, 16-bit register address
 IMU_ADDR = 0x68             # ICM20948, on the main bus (not behind the mux)
 IMU_WHOAMI_REG = 0x00
 IMU_WHOAMI_EXPECTED = 0xEA
@@ -71,7 +71,7 @@ def interface():
 
 
 def _present_cameras(sensor):
-    """0-based positions whose OV2312 responded; fall back to all 8."""
+    """0-based positions whose OX02C1B responded; fall back to all 8."""
     try:
         health = sensor.get_i2c_health(rescan=True)
         cams = health.get("cameras") if isinstance(health, dict) else None

--- a/tests/test_i2c_health_hil.py
+++ b/tests/test_i2c_health_hil.py
@@ -2,7 +2,7 @@
 
 At startup the firmware brings up each camera one at a time and verifies
 that every expected I2C device responds: the TCA9548A mux (0x70), the
-ICM-20948 IMU (0x68), and all 8 cameras (OV2312 0x36) + 8 FPGAs
+ICM-20948 IMU (0x68), and all 8 cameras (OX02C1B 0x36) + 8 FPGAs
 (CrossLink 0x40) behind the mux. The result is cached and queryable over
 OW_CMD_I2C_STATUS (SDK: MotionSensor.get_i2c_health()).
 


### PR DESCRIPTION
## Summary

The image sensor is the OmniVision **OX02C1B** (global shutter, 1920x1280 RAW10); several docs and code comments called it "OV2312", a different OmniVision part. This sweeps every stale prose/comment reference in the repo:

- `CLAUDE.md` — repo intro + the layout-table row for `Core/Src/0X02C1B.c` (which self-contradictorily said "OV2312 ... the file is literally named after the part")
- `docs/fpga-nvcm-autodetect.md`
- `Core/Src/i2c_health.c`, `Core/Inc/i2c_health.h`
- `Core/Src/camera_manager.c`, `Core/Inc/camera_manager.h`
- `tests/test_i2c_health_hil.py`, `tests/test_camera_gain_hil.py` (docstrings/comments)

**Not changed:** the `OV2312_ADDR` identifier in `tests/test_camera_gain_hil.py` and all file names — prose-only sweep, no functional change.

Refs #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)
