### PR TITLE
feat: drip-scan image receive mode (OW_CAMERA_IMAGE_MODE 0x30 + data-paced 2408 B line forwarding)

### DIFF
--- a/Core/Inc/camera_manager.h
+++ b/Core/Inc/camera_manager.h
@@ -149,6 +149,29 @@ _Bool disable_camera_power(uint8_t cam_id);
 _Bool get_camera_power_status(uint8_t cam_id);
 void power_off_all_cameras(void);
 
+/* --- Drip-scan image mode (camera-fpga#8) --------------------------------- */
+/* Wire response for OW_CAMERA_IMAGE_MODE. Fixed packed layout returned
+ * verbatim (same convention as cam_diag_stats_t above) -- do not reorder
+ * fields without an SDK-side parser change. */
+typedef struct __attribute__((packed)) {
+	uint8_t  active;                  /* 1 = image mode currently active */
+	uint8_t  mask;                    /* camera bitmask in image mode (0 when inactive) */
+	uint8_t  reserved[2];
+	uint32_t gap_count[CAMERA_COUNT]; /* per-camera lost-line events since the last enter:
+	                                   * line timeouts + USB send drops + link-error
+	                                   * recoveries. The host retries missing lines via the
+	                                   * FPGA sweep-start-line register. */
+} image_mode_resp_t;                  /* 36 B */
+
+_Bool camera_image_mode_enter(uint8_t mask);
+_Bool camera_image_mode_exit(void);
+bool  camera_image_mode_active(uint8_t cam_id); /* cam is in the active image mask */
+bool  camera_image_mode_rx(uint8_t cam_id);     /* HAL RxCplt hook; true = consumed by image path */
+void  camera_image_link_error(uint8_t cam_id);  /* HAL error-callback recovery while in image mode */
+void  camera_image_rearm_service(void);         /* LPTIM5 software-IRQ body: deferred DMA re-arm */
+void  camera_image_service(void);               /* main-loop line-timeout tick (~2 ms) */
+void  camera_image_get_status(image_mode_resp_t *out);
+
 void Camera_USART_RxCpltCallback_Handler(USART_HandleTypeDef *husart);
 void Camera_SPI_RxCpltCallback_Handler(SPI_HandleTypeDef *hspi);
 uint32_t read_status_fpga(uint8_t cam_id);

--- a/Core/Inc/camera_manager.h
+++ b/Core/Inc/camera_manager.h
@@ -74,6 +74,19 @@ typedef struct {
  * transport-level CRC that only covers the compressed bytes. */
 #define HISTO_CMP_UNCMP_CRC_SIZE 2
 
+/* --- Drip-scan image mode (camera-fpga#8) ---------------------------------
+ * USB envelope for one image line, built IN PLACE around the DMA'd line in
+ * the camera's existing receive buffer:
+ *   [0]=HISTO_SOF [1]=TYPE_IMAGE [2..5]=total_size LE [6..9]=timestamp LE
+ *   [10]=HISTO_SOH [11]=cam_id [12..2419]=IMAGE_LINE_SIZE line bytes
+ *   [2420]=HISTO_EOH [2421..2422]=CRC-16 LE [2423]=HISTO_EOF
+ * Envelope CRC = util_crc16 over bytes [0..2419] -- mirrors
+ * send_histogram_data(), which computes util_crc16(packet_buffer, offset-1),
+ * i.e. SOF through the last payload byte EXCLUDING the final EOH. Quirk kept
+ * deliberately so the SDK's existing envelope-CRC convention applies. */
+#define IMAGE_PKT_LINE_OFFSET (HISTO_HEADER_SIZE + 4 + 2)                                  /* 12 */
+#define IMAGE_PKT_TOTAL_SIZE  (IMAGE_PKT_LINE_OFFSET + IMAGE_LINE_SIZE + 1 + HISTO_TRAILER_SIZE) /* 2424 */
+
 
 void init_camera_sensors(void);
 CameraDevice* get_active_cam(void);

--- a/Core/Inc/common.h
+++ b/Core/Inc/common.h
@@ -19,6 +19,22 @@
 #define SPI_PACKET_LENGTH 4100
 #define USART_PACKET_LENGTH 4100
 
+/* --- Drip-scan image mode (camera-fpga#8) ---------------------------------
+ * One packed RAW10 image line as pushed by the FPGA in sweep mode:
+ *   [0]=magic 0xB6, [1]=format version 0x01, [2]=line[7:0],
+ *   [3]={flags[3:0],line[11:8]} (flag bit0 = overrun since sweep start),
+ *   [4]=frame_cnt[7:0], [5]=reserved 0x00,
+ *   [6..2405]=2400 B packed RAW10 (4 px -> 5 B, 40-bit LE groups, low byte
+ *   first), [2406..2407]=CRC-16/CCITT-FALSE over bytes 0..2405 (same
+ *   algorithm as util_crc16: poly 0x1021, init 0xFFFF, MSB-first).
+ * The MCU forwards these 2408 bytes BLIND -- the host verifies the line CRC;
+ * only the DMA length here depends on the layout. */
+#define IMAGE_LINE_SIZE 2408
+/* Stream type byte for image-line packets on the HISTO USB endpoint
+ * (envelope byte[1]; TYPE_HISTO / TYPE_HISTO_CMP live in camera_manager.h).
+ * Must equal the SDK's OW_IMAGE_PACKET (omotion/config.py). */
+#define TYPE_IMAGE 0x03
+
 #define verbose_on false
 
 /* Camera temperature polling cadence (one camera sampled per interval). */
@@ -54,6 +70,13 @@
 #define DMA_IRQ_PRIORITY 0
 #define FSIN_IRQ_PRIORITY 2
 #define USB_IRQ_PRIORITY 0
+
+/* Drip-scan deferred DMA re-arm (software-pended LPTIM5 vector). MUST stay
+ * numerically ABOVE every camera link/DMA priority so the pend taken inside
+ * a RxCplt callback fires only after that ISR -- and the HAL driver's
+ * completion bookkeeping, which on USART sets State=READY only AFTER the
+ * callback -- has finished. */
+#define IMAGE_REARM_IRQ_PRIORITY 7
 
 // #define TIM8_BRK_TIM12_IRQ_PRIORITY 0
 // #define TIM8_TRG_COM_TIM14_IRQ_PRIORITY 0
@@ -164,6 +187,10 @@ typedef enum {
 	OW_CAMERA_POWER_STATUS = 0x52,
 	OW_CAMERA_READ_SECURITY_UID = 0x53,
 	OW_CAMERA_GET_TELEMETRY = 0x54,  /* #94: cached cam_telemetry_response_t snapshot (camera_telemetry.h) */
+	OW_CAMERA_IMAGE_MODE = 0x30,  /* drip-scan (camera-fpga#8): reserved = enable 0/1,
+	                               * data[0] = camera bitmask. Response = image_mode_resp_t.
+	                               * (0x30 also appears as OW_IMU_INIT, but that lives in the
+	                               * OW_IMU packet-type namespace -- dispatch is per type.) */
 
 } MotionCameraCommands;
 

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -46,6 +46,15 @@ static int _active_cam_idx = 0;
 
 static volatile bool usb_failed = false;
 
+/* Drip-scan (camera-fpga#8): set true on image-mode exit; send_data() consumes
+ * + discards the next histogram frame. The FPGA's first post-sweep histogram
+ * integrates counts across the whole image session (the existing feature/5
+ * first-frame-garbage caveat), so it must never reach the host as data. Hosts
+ * may keep their own discard as belt-and-braces. Declared here (ahead of
+ * send_data()) so the read there precedes the definition site in the
+ * image-mode block; only ever set true by camera_image_mode_exit(). */
+static volatile bool histo_discard_next = false;
+
 __ALIGN_BEGIN volatile uint8_t frame_buffer[1][CAMERA_COUNT * HISTOGRAM_DATA_SIZE] __ALIGN_END; // Double buffer
 __ALIGN_BEGIN uint8_t packet_buffer[HISTO_JSON_BUFFER_SIZE] __ALIGN_END;
 __ALIGN_BEGIN uint8_t uncmp_payload[HISTO_JSON_BUFFER_SIZE] __ALIGN_END;  // Staging buffer for compression
@@ -1565,7 +1574,16 @@ _Bool send_data(void) {
 	
 	// Check for camera failures before clearing event_bits
 	check_camera_failures();
-	
+
+	/* Drip-scan: the first histogram frame after image-mode exit integrates
+	 * the whole image session (feature/5 first-frame-garbage caveat) --
+	 * consume the event bits + re-arm WITHOUT sending, exactly like the #75
+	 * stall repro's suppress path. One frame only. */
+	if (histo_discard_next) {
+		histo_discard_next = false;
+		return histo_stall_suppress_frame();
+	}
+
 	bool success = false;
 	uint32_t dflags = logging_get_debug_flags();
 	/* #75: DEBUG_FLAG_HISTO_STALL — count frames; past the trigger point,
@@ -2236,6 +2254,220 @@ _Bool abort_data_reception(uint8_t cam_id){
 	if(verbose_on) { printf("done\r\n"); }
 	return true;
 }
+
+/* -------- BEGIN DRIP-SCAN IMAGE MODE (camera-fpga#8) -------- */
+/* Data-paced full-frame line receive (design spec 4.4). While active:
+ *  - Histogram streaming is SUSPENDED: event_bits_enabled is saved + zeroed,
+ *    so the FSIN ISR's send path goes quiet (send_histogram_data() returns
+ *    immediately when event_bits_enabled == 0). check_streaming() will close
+ *    the host-visible scan out after its 150 ms timeout -- its "Scan
+ *    finished" print shortly after image-mode entry is expected.
+ *  - Each masked camera runs a repeating 2408-B one-shot DMA into its
+ *    EXISTING receive buffer at offset IMAGE_PKT_LINE_OFFSET, so the USB
+ *    envelope is built in place around the line (zero copy). The buffers
+ *    already satisfy every DMA constraint -- cam 1 = spi6_buffer in SRAM4
+ *    for BDMA; D-cache is never enabled in this firmware -- because they are
+ *    the very buffers the histogram path DMAs into today.
+ *  - Pacing is the DATA, not FSIN: the FPGA pushes a line whenever its sweep
+ *    buffer fills. camera_image_mode_rx() (RxCplt context) forwards the line
+ *    and pends the LPTIM5 software IRQ (IMAGE_REARM_IRQ_PRIORITY, below all
+ *    camera link/DMA IRQs) which re-arms the DMA the instant the completing
+ *    ISR returns. The deferral is REQUIRED for the four USART cameras: the
+ *    H7 HAL calls HAL_USART_RxCpltCallback BEFORE setting State=READY
+ *    (USART_DMAReceiveCplt, stm32h7xx_hal_usart.c), so an in-callback
+ *    HAL_USART_Receive_DMA is rejected with HAL_BUSY and the driver would
+ *    then stomp the state under a live DMA. SPI sets READY before its
+ *    callback and would tolerate an inline re-arm, but both link types share
+ *    the one deferred path.
+ *  - camera_image_service() (main loop, HAL_GetTick) aborts + re-arms a
+ *    camera whose PARTIAL line made no byte progress for >2 ms (USART
+ *    byte-slip resync, spec risk table) and counts a gap.
+ */
+static volatile bool     image_mode_on = false;
+static volatile uint8_t  image_mode_mask = 0x00;
+static uint8_t           image_saved_event_enabled = 0x00;
+static volatile uint8_t  image_rearm_pending = 0x00;
+static volatile uint32_t image_gap_count[CAMERA_COUNT] = {0};
+/* Line-timeout progress tracking (camera_image_service, main loop only). */
+static uint32_t image_last_ndtr[CAMERA_COUNT];
+static uint32_t image_last_progress_tick[CAMERA_COUNT];
+/* histo_discard_next is defined near the top of this file (before send_data(),
+ * which reads it) so its declaration precedes that use; it is set true only on
+ * image-mode exit below. */
+
+#define IMAGE_LINE_TIMEOUT_MS 3u /* spec target ~2 ms; HAL_GetTick has 1 ms
+                                  * granularity, so >=3 ticks guarantees more
+                                  * than 2 ms of real mid-line silence */
+
+bool camera_image_mode_active(uint8_t cam_id)
+{
+	return image_mode_on && ((image_mode_mask & (1u << cam_id)) != 0u);
+}
+
+/* Arm (or re-arm) one camera's 2408-B line DMA at the in-place envelope
+ * offset. Returns true when a reception is armed after this call --
+ * including the already-armed case, which happens when an error-callback
+ * recovery re-armed the camera before the deferred LPTIM5 re-arm ran. */
+static _Bool camera_image_arm(uint8_t cam_id)
+{
+	CameraDevice *cam = &cam_array[cam_id];
+	uint8_t *dst = cam->pRecieveHistoBuffer + IMAGE_PKT_LINE_OFFSET;
+	HAL_StatusTypeDef status;
+
+	if (!image_mode_on) {
+		return false;
+	}
+	if (!cam->useDma) {
+		/* All 8 cameras are DMA (init_camera_sensors). IT-mode per-byte
+		 * interrupts at ~3.5 MB/s would be ~1.4M IRQ/s -- unsupported. */
+		return false;
+	}
+	if (cam->useUsart) {
+		if (cam->pUart->State == HAL_USART_STATE_BUSY_RX ||
+		    cam->pUart->State == HAL_USART_STATE_BUSY_TX_RX) {
+			return true; /* already armed */
+		}
+		status = HAL_USART_Receive_DMA(cam->pUart, dst, IMAGE_LINE_SIZE);
+	} else {
+		if (cam->pSpi->State == HAL_SPI_STATE_BUSY_RX ||
+		    cam->pSpi->State == HAL_SPI_STATE_BUSY_TX_RX) {
+			return true; /* already armed */
+		}
+		status = HAL_SPI_Receive_DMA(cam->pSpi, dst, IMAGE_LINE_SIZE);
+	}
+	return status == HAL_OK;
+}
+
+_Bool camera_image_mode_enter(uint8_t mask)
+{
+	if (image_mode_on) {
+		printf("Image mode already active\r\n");
+		return false;
+	}
+	if (mask == 0u) {
+		return false;
+	}
+	if ((logging_get_debug_flags() & DEBUG_FLAG_FAKE_DATA) != 0u) {
+		printf("Image mode refused: DEBUG_FLAG_FAKE_DATA active\r\n");
+		return false;
+	}
+	for (uint8_t i = 0; i < CAMERA_COUNT; i++) {
+		if ((mask & (1u << i)) != 0u && !camera_request_is_valid(i)) {
+			printf("Image mode refused: camera %d invalid\r\n", i + 1);
+			return false;
+		}
+	}
+
+	/* Suspend histogram streaming (see block comment). Non-masked cameras
+	 * that were streaming keep their armed 4100-B DMA; it completes at most
+	 * once more (nothing re-arms it while enables are zeroed) and is
+	 * re-armed on exit. */
+	__disable_irq();
+	image_saved_event_enabled = event_bits_enabled;
+	event_bits_enabled = 0x00;
+	event_bits = 0x00;
+	__enable_irq();
+
+	/* Drop queued histogram frames so the host's image reader starts clean
+	 * (same hygiene as the OW_CAMERA_STREAM enable path). */
+	USBD_HISTO_FlushQueue("image-enter");
+
+	/* Software re-arm IRQ: LPTIM5's vector is borrowed as a pure software
+	 * interrupt (the LPTIM5 peripheral is never clocked); the handler in
+	 * stm32h7xx_it.c calls camera_image_rearm_service(). */
+	HAL_NVIC_SetPriority(LPTIM5_IRQn, IMAGE_REARM_IRQ_PRIORITY, 0);
+	HAL_NVIC_EnableIRQ(LPTIM5_IRQn);
+
+	uint32_t now = HAL_GetTick();
+	for (uint8_t i = 0; i < CAMERA_COUNT; i++) {
+		image_gap_count[i] = 0;
+		image_last_ndtr[i] = IMAGE_LINE_SIZE;
+		image_last_progress_tick[i] = now;
+	}
+	image_rearm_pending = 0x00;
+	image_mode_mask = mask;
+	image_mode_on = true; /* BEFORE arming, so RxCplt/error callbacks route image-side */
+
+	_Bool ok = true;
+	for (uint8_t i = 0; i < CAMERA_COUNT; i++) {
+		if ((mask & (1u << i)) == 0u) {
+			continue;
+		}
+		abort_data_reception(i); /* kill any in-flight 4100-B histogram DMA */
+		memset((uint8_t *)cam_array[i].pRecieveHistoBuffer, 0, IMAGE_PKT_TOTAL_SIZE);
+		if (!camera_image_arm(i)) {
+			printf("Image mode: failed to arm camera %d\r\n", i + 1);
+			ok = false;
+		}
+	}
+	if (!ok) {
+		camera_image_mode_exit();
+		return false;
+	}
+	printf("Image mode ON mask=0x%02X\r\n", mask);
+	return true;
+}
+
+_Bool camera_image_mode_exit(void)
+{
+	if (!image_mode_on) {
+		return true; /* idempotent, like disable_camera_stream on a stopped camera --
+		              * also lets the host re-read final gap counters via a second
+		              * disable command */
+	}
+	uint8_t mask = image_mode_mask;
+	uint8_t restore = image_saved_event_enabled;
+
+	image_mode_on = false; /* stop RxCplt routing + deferred re-arms first */
+	image_mode_mask = 0x00;
+	image_rearm_pending = 0x00;
+
+	for (uint8_t i = 0; i < CAMERA_COUNT; i++) {
+		uint8_t bit = (uint8_t)(1u << i);
+		if (((mask | restore) & bit) == 0u) {
+			continue;
+		}
+		/* Masked cams: abort the image DMA. Previously-streaming cams: abort
+		 * the stale histogram DMA left from suspension. */
+		abort_data_reception(i);
+		/* #172 hygiene, same as enable_camera_stream(): never leave stale
+		 * bytes where the next scan's first frame could ship them. */
+		if (cam_array[i].pRecieveHistoBuffer != NULL) {
+			memset((uint8_t *)cam_array[i].pRecieveHistoBuffer, 0,
+			       cam_array[i].useUsart ? USART_PACKET_LENGTH : SPI_PACKET_LENGTH);
+		}
+		if ((restore & bit) != 0u) {
+			start_data_reception(i); /* restore the 4100-B histogram arming */
+		}
+	}
+
+	__disable_irq();
+	event_bits = 0x00;
+	event_bits_enabled = restore;
+	__enable_irq();
+	image_saved_event_enabled = 0x00;
+	if (restore != 0u) {
+		histo_discard_next = true; /* consumed by send_data() */
+	}
+	/* Drop any image lines still queued so they can't bleed into the
+	 * histogram stream (same convention as the scan-stop flush). The host
+	 * exits image mode only after it has collected or given up on lines. */
+	USBD_HISTO_FlushQueue("image-exit");
+	printf("Image mode OFF\r\n");
+	return true;
+}
+
+void camera_image_get_status(image_mode_resp_t *out)
+{
+	out->active = image_mode_on ? 1u : 0u;
+	out->mask = image_mode_mask;
+	out->reserved[0] = 0;
+	out->reserved[1] = 0;
+	for (uint8_t i = 0; i < CAMERA_COUNT; i++) {
+		out->gap_count[i] = image_gap_count[i];
+	}
+}
+/* -------- END DRIP-SCAN IMAGE MODE -------- */
 
 _Bool enable_camera_stream(uint8_t cam_id){
 	// printf("C%d: enable...", cam_id+1);

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -2558,6 +2558,56 @@ void camera_image_rearm_service(void)
 		}
 	}
 }
+/* Main-loop line-timeout tick (wired next to camera_i2c_service() in
+ * main.c). Deadline clock is HAL_GetTick(), NOT get_timestamp_ms() -- the
+ * TIM5 timestamp wraps at ~11.93 h and is documented (utils.c, #73) as
+ * unsafe for deadlines.
+ *
+ * Progress probe: the DMA remaining-transfer count, via
+ * __HAL_DMA_GET_COUNTER -- which reads NDTR for DMA streams and CNDTR for
+ * BDMA channels (stm32h7xx_hal_dma.h), so cam 1's SPI6/BDMA path needs no
+ * special case. Semantics:
+ *   remaining == IMAGE_LINE_SIZE  -> no line in flight (idle between sweeps
+ *                                    / FPGA not pushing) -- NOT a fault.
+ *   remaining == 0                -> transfer complete, callback/re-arm
+ *                                    pending -- NOT a fault.
+ *   0 < remaining < IMAGE_LINE_SIZE, unchanged >2 ms -> a stalled PARTIAL
+ *     line (mid-line byte slip on a USART link, spec risk table): abort,
+ *     re-arm, count a gap. The host retries via the sweep start line. */
+void camera_image_service(void)
+{
+	if (!image_mode_on) {
+		return;
+	}
+	uint32_t now = HAL_GetTick();
+	for (uint8_t i = 0; i < CAMERA_COUNT; i++) {
+		if ((image_mode_mask & (1u << i)) == 0u) {
+			continue;
+		}
+		CameraDevice *cam = &cam_array[i];
+		DMA_HandleTypeDef *hdma = cam->useUsart ? cam->pUart->hdmarx : cam->pSpi->hdmarx;
+		if (hdma == NULL) {
+			continue;
+		}
+		uint32_t remaining = __HAL_DMA_GET_COUNTER(hdma);
+		if (remaining != image_last_ndtr[i]) {
+			image_last_ndtr[i] = remaining;
+			image_last_progress_tick[i] = now;
+			continue;
+		}
+		if (remaining == IMAGE_LINE_SIZE || remaining == 0u) {
+			image_last_progress_tick[i] = now;
+			continue;
+		}
+		if ((now - image_last_progress_tick[i]) >= IMAGE_LINE_TIMEOUT_MS) {
+			image_gap_count[i]++;
+			abort_data_reception(i);
+			(void)camera_image_arm(i); /* on failure the next pass retries */
+			image_last_ndtr[i] = IMAGE_LINE_SIZE;
+			image_last_progress_tick[i] = now;
+		}
+	}
+}
 /* -------- END DRIP-SCAN IMAGE MODE -------- */
 
 _Bool enable_camera_stream(uint8_t cam_id){

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -2467,6 +2467,97 @@ void camera_image_get_status(image_mode_resp_t *out)
 		out->gap_count[i] = image_gap_count[i];
 	}
 }
+
+/* Called from HAL_SPI_RxCpltCallback / HAL_USART_RxCpltCallback (main.c).
+ * Returns true when the completion belonged to the image path (the caller
+ * must then NOT set the histogram event bit). Builds the 2424-B USB envelope
+ * IN PLACE around the just-DMA'd line and queues it on the HISTO endpoint,
+ * then pends the LPTIM5 software IRQ to re-arm this camera's DMA.
+ *
+ * Buffer reuse is safe immediately: USBD_HISTO_SendData COPIES the packet
+ * before returning (memcpy into histo_tx_buffer on the direct path /
+ * histo_queue_buffers[slot] on the queued path -- usbd_histo.c).
+ *
+ * ISR budget: header/trailer writes + util_crc16 over 2420 B (~20-40 us at
+ * 480 MHz) + SendData's 2424-B copy. No printf (hot path).
+ *
+ * NOTE: DEBUG_FLAG_HISTO_THROTTLE / DEBUG_FLAG_HISTO_SPARSE act inside
+ * USBD_HISTO_SendData and would silently swallow image lines -- do not run
+ * image mode with those flags set (documented in CLAUDE.md). */
+bool camera_image_mode_rx(uint8_t cam_id)
+{
+	if (!camera_image_mode_active(cam_id)) {
+		return false;
+	}
+	CameraDevice *cam = &cam_array[cam_id];
+	uint8_t *pkt = cam->pRecieveHistoBuffer;
+	uint32_t ts = get_timestamp_ms(); /* same TIM5 timebase as histogram frames */
+	int offset = 0;
+
+	pkt[offset++] = HISTO_SOF;
+	pkt[offset++] = TYPE_IMAGE;
+	pkt[offset++] = (uint8_t)(IMAGE_PKT_TOTAL_SIZE & 0xFF);
+	pkt[offset++] = (uint8_t)((IMAGE_PKT_TOTAL_SIZE >> 8) & 0xFF);
+	pkt[offset++] = (uint8_t)((IMAGE_PKT_TOTAL_SIZE >> 16) & 0xFF);
+	pkt[offset++] = (uint8_t)((IMAGE_PKT_TOTAL_SIZE >> 24) & 0xFF);
+	pkt[offset++] = (uint8_t)(ts & 0xFF);
+	pkt[offset++] = (uint8_t)((ts >> 8) & 0xFF);
+	pkt[offset++] = (uint8_t)((ts >> 16) & 0xFF);
+	pkt[offset++] = (uint8_t)((ts >> 24) & 0xFF);
+	pkt[offset++] = HISTO_SOH;
+	pkt[offset++] = cam_id;
+	/* pkt[12..2419] = the 2408-B line, already DMA'd in place. */
+	offset += IMAGE_LINE_SIZE;
+	pkt[offset++] = HISTO_EOH;
+	/* Same CRC span quirk as send_histogram_data(): SOF through the last
+	 * payload byte, EXCLUDING the EOH just written (offset-1 bytes). */
+	uint16_t crc = util_crc16(pkt, offset - 1);
+	pkt[offset++] = (uint8_t)(crc & 0xFF);
+	pkt[offset++] = (uint8_t)((crc >> 8) & 0xFF);
+	pkt[offset++] = HISTO_EOF;
+
+	if (USBD_HISTO_SendData(&hUsbDeviceHS, pkt, IMAGE_PKT_TOTAL_SIZE, 0) != USBD_OK) {
+		image_gap_count[cam_id]++; /* dropped line -- host sees the gap, retries the sweep */
+	}
+
+	image_rearm_pending |= (uint8_t)(1u << cam_id);
+	NVIC_SetPendingIRQ(LPTIM5_IRQn); /* re-arm fires after this ISR returns */
+	return true;
+}
+
+/* HAL error-callback recovery while in image mode (main.c routes here
+ * instead of the histogram abort+start pair): recover to a fresh 2408-B line
+ * reception and count the lost line. Runs in ISR context -- the same context
+ * the histogram path already runs abort+restart from. */
+void camera_image_link_error(uint8_t cam_id)
+{
+	image_gap_count[cam_id]++;
+	abort_data_reception(cam_id);
+	(void)camera_image_arm(cam_id);
+}
+
+/* Body of the LPTIM5 software IRQ (stm32h7xx_it.c). Drains the pending mask
+ * in a loop so a camera pended DURING this service is not lost. */
+void camera_image_rearm_service(void)
+{
+	for (;;) {
+		uint8_t pending;
+		__disable_irq();
+		pending = image_rearm_pending;
+		image_rearm_pending = 0;
+		__enable_irq();
+		if (pending == 0u || !image_mode_on) {
+			return;
+		}
+		for (uint8_t i = 0; i < CAMERA_COUNT; i++) {
+			if ((pending & (1u << i)) != 0u) {
+				if (!camera_image_arm(i)) {
+					image_gap_count[i]++; /* arm failed; timeout service retries */
+				}
+			}
+		}
+	}
+}
 /* -------- END DRIP-SCAN IMAGE MODE -------- */
 
 _Bool enable_camera_stream(uint8_t cam_id){

--- a/Core/Src/if_commands.c
+++ b/Core/Src/if_commands.c
@@ -854,9 +854,7 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 			if (cmd.data_len != 1 || cmd.data[0] == 0) {
 				VERBOSE_CMD("Invalid image mode payload\r\n");
 				uartResp->packet_type = OW_ERROR;
-				break;
-			}
-			if (!camera_image_mode_enter(cmd.data[0])) {
+			} else if (!camera_image_mode_enter(cmd.data[0])) {
 				uartResp->packet_type = OW_ERROR;
 			}
 		} else {

--- a/Core/Src/if_commands.c
+++ b/Core/Src/if_commands.c
@@ -487,15 +487,24 @@ static void process_fpga_commands(UartPacket *uartResp, UartPacket cmd)
 		VERBOSE_CMD("[CMD] OW_FPGA_PROG_SRAM addr=0x%02X reserved=%u\r\n", cmd.addr, cmd.reserved);
 		uartResp->command = OW_FPGA_PROG_SRAM;
 		uartResp->packet_type = OW_RESP;
-		// TODO: Add parameter to force update currently defaults to false
+		/* #68: reserved==2 forces the SRAM load — with force off, an
+		 * NVCM-programmed part skips the SRAM load and silently keeps
+		 * running the burned image, so a newer BUNDLED bitstream never
+		 * takes effect (~10 s/camera when forced). Ported verbatim from
+		 * the bench-validated fix/82-sram-upload-path hunk. */
 	    for (uint8_t i = 0; i < 8; i++) {
 	        if (((cmd.addr >> i) & 0x01) != 0) {
 	        	_Bool func_ret = false;
+	        	_Bool force_sram = (cmd.reserved == 2);
 
-	        	if(cmd.reserved == 1) {
-	        		func_ret = program_fpga(i, false);
+	        	if(cmd.reserved == 1 || force_sram) {
+	        		func_ret = program_fpga(i, force_sram);
 	        	} else {
-	        		func_ret = program_sram_fpga(i, true, 0, 0, false);
+	        		/* reserved==0: host-uploaded bitstream, NVCM-gated.
+	        		 * reserved==3: host-uploaded bitstream, FORCED — skips the
+	        		 * isProgrammed/NVCM gates (required on NVCM-burned parts,
+	        		 * same rationale as reserved==2). */
+	        		func_ret = program_sram_fpga(i, true, 0, 0, cmd.reserved == 3);
 	        	}
 	    		if(!func_ret)
 	    		{

--- a/Core/Src/if_commands.c
+++ b/Core/Src/if_commands.c
@@ -36,6 +36,7 @@ extern volatile uint8_t event_bits_enabled;
 
 static uint32_t id_words[4] = {0};  /* 3 UID words + 1 zero-pad: HWID reply is 16B, so [3] would over-read 4B past the array */
 static uint8_t camera_status[8] = {0};
+static image_mode_resp_t image_mode_resp; /* OW_CAMERA_IMAGE_MODE reply buffer */
 static uint8_t i2c_reg_read_buf[I2C_REG_READ_MAX_LEN] = {0};
 static uint8_t camera_power_status = 0;
 static float cam_temp;
@@ -836,6 +837,36 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 	        	}
 	        }
 	    }
+		break;
+	case OW_CAMERA_IMAGE_MODE:
+		/* Drip-scan (camera-fpga#8): reserved = enable 0/1, data[0] = camera
+		 * bitmask (enable only). Host sequencing: enable cameras/streaming
+		 * first if a live sweep is wanted, enable image mode, THEN put the
+		 * FPGA into sweep mode via I2C (0x5A CTRL); reverse order on the way
+		 * out. Response is image_mode_resp_t either way -- the disable reply
+		 * carries the final per-camera gap tally, and a repeated disable is
+		 * an idempotent success that re-reads it. */
+		VERBOSE_CMD("[CMD] OW_CAMERA_IMAGE_MODE reserved=%u len=%u\r\n",
+		            cmd.reserved, (unsigned)cmd.data_len);
+		uartResp->command = OW_CAMERA_IMAGE_MODE;
+		uartResp->packet_type = OW_RESP;
+		if (cmd.reserved == 1) {
+			if (cmd.data_len != 1 || cmd.data[0] == 0) {
+				VERBOSE_CMD("Invalid image mode payload\r\n");
+				uartResp->packet_type = OW_ERROR;
+				break;
+			}
+			if (!camera_image_mode_enter(cmd.data[0])) {
+				uartResp->packet_type = OW_ERROR;
+			}
+		} else {
+			if (!camera_image_mode_exit()) {
+				uartResp->packet_type = OW_ERROR;
+			}
+		}
+		camera_image_get_status(&image_mode_resp);
+		uartResp->data_len = sizeof(image_mode_resp);
+		uartResp->data = (uint8_t *)&image_mode_resp;
 		break;
 	case OW_CAMERA_OFF:
 		VERBOSE_CMD("[CMD] OW_CAMERA_OFF\r\n");

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -1874,8 +1874,15 @@ void HAL_USART_ErrorCallback(USART_HandleTypeDef *husart)
    * Any error on a known camera USART is recoverable via abort+restart. */
   if (cam_id >= 0)
   {
-    abort_data_reception((uint8_t)cam_id);
-    start_data_reception((uint8_t)cam_id);
+    if (camera_image_mode_active((uint8_t)cam_id)) {
+      /* Image mode: recover to a fresh 2408-B line and count the loss --
+       * re-arming the 4100-B histogram reception here would wedge the
+       * line stream. */
+      camera_image_link_error((uint8_t)cam_id);
+    } else {
+      abort_data_reception((uint8_t)cam_id);
+      start_data_reception((uint8_t)cam_id);
+    }
     return;
   }
 
@@ -1982,8 +1989,15 @@ void HAL_SPI_ErrorCallback(SPI_HandleTypeDef *hspi)
    * Now any error on a known camera SPI triggers abort+restart instead. */
   if (cam_id >= 0)
   {
-    abort_data_reception((uint8_t)cam_id);
-    start_data_reception((uint8_t)cam_id);
+    if (camera_image_mode_active((uint8_t)cam_id)) {
+      /* Image mode: recover to a fresh 2408-B line and count the loss --
+       * re-arming the 4100-B histogram reception here would wedge the
+       * line stream. */
+      camera_image_link_error((uint8_t)cam_id);
+    } else {
+      abort_data_reception((uint8_t)cam_id);
+      start_data_reception((uint8_t)cam_id);
+    }
     return;
   }
 
@@ -2001,43 +2015,28 @@ void set_event_bit_atomic(uint32_t bit) {
 // Interrupt handler for SPI reception
 void HAL_SPI_RxCpltCallback(SPI_HandleTypeDef *hspi)
 {
-  if (hspi->Instance == SPI2)
-  {
-    set_event_bit_atomic(BIT_6);
-  }
-  else if (hspi->Instance == SPI3)
-  {
-    set_event_bit_atomic(BIT_5);
-  }
-  else if (hspi->Instance == SPI4)
-  {
-    set_event_bit_atomic(BIT_7);
-  }
-  else if (hspi->Instance == SPI6)
-  {
-    set_event_bit_atomic(BIT_1);
-  }
+  int8_t cam_id = -1;
+  if (hspi->Instance == SPI2)      { cam_id = 6; }
+  else if (hspi->Instance == SPI3) { cam_id = 5; }
+  else if (hspi->Instance == SPI4) { cam_id = 7; }
+  else if (hspi->Instance == SPI6) { cam_id = 1; }
+  if (cam_id < 0) { return; }
+  /* Drip-scan image mode: this completion is a 2408-B image line, not a
+   * histogram frame -- forwarded + re-armed by the image path. */
+  if (camera_image_mode_rx((uint8_t)cam_id)) { return; }
+  set_event_bit_atomic(1u << cam_id);
 }
 
 void HAL_USART_RxCpltCallback(USART_HandleTypeDef *husart)
 {
-  if (husart->Instance == USART1)
-  { // Check if the interrupt is for USART2
-    set_event_bit_atomic(BIT_4);
-  }
-  else if (husart->Instance == USART2)
-  { // Check if the interrupt is for USART2
-    set_event_bit_atomic(BIT_0);
-  }
-  else if (husart->Instance == USART3)
-  { // Check if the interrupt is for USART2
-    set_event_bit_atomic(BIT_2);
-  }
-  else if (husart->Instance == USART6)
-  { // Check if the interrupt is for USART2
-    set_event_bit_atomic(BIT_3);
-  }
-
+  int8_t cam_id = -1;
+  if (husart->Instance == USART1)      { cam_id = 4; }
+  else if (husart->Instance == USART2) { cam_id = 0; }
+  else if (husart->Instance == USART3) { cam_id = 2; }
+  else if (husart->Instance == USART6) { cam_id = 3; }
+  if (cam_id < 0) { return; }
+  if (camera_image_mode_rx((uint8_t)cam_id)) { return; }
+  set_event_bit_atomic(1u << cam_id);
 }
 
 void HAL_TIM_PWM_PulseFinishedCallback(TIM_HandleTypeDef *htim)

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -472,6 +472,7 @@ int main(void)
   	comms_host_check_received(); // check comms
     imu_service();           /* Sample the ICM if the 200 Hz timer ticked */
     camera_i2c_service();    /* Camera-bus work deferred from the frame ISRs (temp poll, mux disables) */
+    camera_image_service();  /* Drip-scan: per-camera image line timeout (no-op unless image mode is on) */
     logging_pump();          /* Flush USB log data buffered from ISR context */
     check_streaming();
     poll_mcu_temperature();  /* Print warning if MCU junction temp above threshold */

--- a/Core/Src/stm32h7xx_it.c
+++ b/Core/Src/stm32h7xx_it.c
@@ -22,6 +22,7 @@
 #include "stm32h7xx_it.h"
 /* Private includes ----------------------------------------------------------*/
 /* USER CODE BEGIN Includes */
+#include "camera_manager.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -643,5 +644,17 @@ void ECC_IRQHandler(void)
 void EXTI15_10_IRQHandler(void)
 {
     HAL_GPIO_EXTI_IRQHandler(GPIO_PIN_13);  // Handle EXTI line 13
+}
+
+/* Drip-scan image mode (camera-fpga#8): software-pended re-arm IRQ. The
+ * LPTIM5 peripheral is never used or clocked -- its vector is borrowed as a
+ * low-priority (IMAGE_REARM_IRQ_PRIORITY) software interrupt, pended from
+ * the camera RxCplt callbacks so the DMA re-arm runs immediately AFTER the
+ * HAL driver finishes its completion bookkeeping (required on USART, whose
+ * driver sets State=READY only after the RxCplt callback). Nothing to clear:
+ * a software pend auto-clears on entry. */
+void LPTIM5_IRQHandler(void)
+{
+  camera_image_rearm_service();
 }
 /* USER CODE END 1 */

--- a/tests/test_image_mode_hil.py
+++ b/tests/test_image_mode_hil.py
@@ -1,0 +1,320 @@
+"""HIL: drip-scan image receive mode (OW_CAMERA_IMAGE_MODE = 0x30).
+
+test_image_mode_enter_exit_and_histogram_resume -- runs against ANY FPGA
+bitstream. Starts a normal 2-camera histogram scan, enters image mode
+mid-stream (firmware must suspend histogram streaming and re-arm 2408-B
+receives), verifies TYPE_IMAGE (0x03) envelopes arrive on the HISTO endpoint
+(the FPGA, still in histogram mode, pushes 4100-B envelopes that the 2408-B
+DMA chops into one full 'line' + a stalled partial -- which also exercises
+the ~2 ms line timeout: gap counters must grow), exits image mode, and
+verifies histogram frames resume WITHOUT the host re-enabling anything.
+
+test_image_line_stream_smoke -- line-rate smoke with the FPGA in sweep mode.
+Requires the feature/8 camera-FPGA bitstream (register map v2 at I2C 0x5A,
+VERSION >= 0x02); skips otherwise. No sensor retiming (that is SDK-side
+orchestration): with production HTS the FPGA overruns and pushes lines at
+drain rate, which is exactly what a transport smoke needs. Validates the
+2424-B envelope framing, the envelope CRC (util_crc16 convention: bytes
+0..2419, i.e. excluding EOH), and the inner line magic/version.
+
+Camera mask 0x03 = cam 0 (USART2 link) + cam 1 (SPI6 link via BDMA/SRAM4)
+-- one camera from each link family, including the special-cased one.
+
+Deploy first (firmware-only flash is enough for test 1):
+
+    python scripts/deploy.py --device left --fw-only --no-confirm `
+      --power-cycle-cmd "python C:\\Users\\ethan\\Projects\\openmotion-bloodflow-app\\tests\\shelly.py cycle"
+
+Run on the bench:
+
+    $env:OPENMOTION_HIL = "1"
+    $env:OW_SENSOR_SIDE = "left"
+    $env:OPENMOTION_POWER_CYCLE_CMD = "python C:\\Users\\ethan\\Projects\\openmotion-bloodflow-app\\tests\\shelly.py cycle"
+    pytest tests/test_image_mode_hil.py -v -s
+
+Power-cycle the sensor between streaming HIL runs (repo CLAUDE.md: wedge
+risk when chaining streaming tests).
+"""
+import os
+import queue
+import struct
+import subprocess
+import threading
+import time
+
+import pytest
+
+requires_bench = pytest.mark.skipif(
+    os.environ.get("OPENMOTION_HIL") != "1",
+    reason="hardware-in-the-loop test; set OPENMOTION_HIL=1 on the bench",
+)
+
+CONNECT_TIMEOUT_S = 15.0
+CAM_MASK = 0x03          # cam 0 = USART2, cam 1 = SPI6/BDMA/SRAM4
+CAMS = [0, 1]
+
+OW_CAMERA_IMAGE_MODE = 0x30   # firmware Core/Inc/common.h (SDK constant lands with the companion SDK feature)
+IMAGE_PKT = 2424              # envelope size, camera_manager.h IMAGE_PKT_TOTAL_SIZE
+RESP_LEN = 36                 # image_mode_resp_t
+
+# One 2-camera histogram frame: 10-B header + 2*(SOH+cam+4096+temp4+EOH) + CRC2+EOF
+HISTO_FRAME_BYTES = 10 + 2 * (1 + 1 + 4096 + 4 + 1) + 3
+PHASE_SECONDS = 3.0
+MIN_HISTO_BYTES = 25 * HISTO_FRAME_BYTES   # ~120 frames nominal; 25 tolerates USB hiccups
+
+# FPGA register map (feature/5, extended by feature/8 -- see camera-fpga
+# tools/full_frame_capture/fpga_link.py)
+FPGA_ADDR = 0x5A
+REG_VERSION, REG_CTRL, REG_LINE_L, REG_LINE_H = 0x01, 0x03, 0x04, 0x05
+
+
+def _make_crc_table():
+    table = []
+    for i in range(256):
+        crc = i << 8
+        for _ in range(8):
+            crc = ((crc << 1) ^ 0x1021) & 0xFFFF if crc & 0x8000 else (crc << 1) & 0xFFFF
+        table.append(crc)
+    return table
+
+
+_CRC_TABLE = _make_crc_table()
+
+
+def _crc16(buf):
+    crc = 0xFFFF
+    for b in buf:
+        crc = ((crc << 8) ^ _CRC_TABLE[((crc >> 8) ^ b) & 0xFF]) & 0xFFFF
+    return crc
+
+
+def _extract_image_packets(buf: bytes):
+    """Scan a raw byte stream for well-formed 2424-B TYPE_IMAGE envelopes."""
+    pkts, i = [], 0
+    while True:
+        j = buf.find(b"\xaa\x03", i)
+        if j < 0 or j + IMAGE_PKT > len(buf):
+            break
+        pkt = buf[j:j + IMAGE_PKT]
+        size = int.from_bytes(pkt[2:6], "little")
+        if size == IMAGE_PKT and pkt[10] == 0xFF and pkt[2420] == 0xEE and pkt[2423] == 0xDD:
+            pkts.append(pkt)
+            i = j + IMAGE_PKT
+        else:
+            i = j + 1
+    return pkts
+
+
+def _envelope_crc_ok(pkt: bytes) -> bool:
+    # Firmware convention (mirrors send_histogram_data): CRC over bytes
+    # 0..2419 -- SOF through last payload byte, EXCLUDING the EOH.
+    return _crc16(pkt[:2420]) == (pkt[2421] | (pkt[2422] << 8))
+
+
+# Keep MotionInterface instances alive for the process lifetime (Win32
+# hotplug wndproc thunk issue -- see test_histo_wedge_recovery_hil.py).
+_INTERFACE_KEEPALIVE = []
+
+
+@pytest.fixture
+def sensor():
+    from omotion import MotionInterface
+
+    cycle_cmd = os.environ.get("OPENMOTION_POWER_CYCLE_CMD")
+    if cycle_cmd:
+        subprocess.run(cycle_cmd, shell=True, check=True, timeout=60)
+        time.sleep(8.0)  # re-enumeration settle
+
+    side = os.environ.get("OW_SENSOR_SIDE", "left")
+    interface = MotionInterface()
+    _INTERFACE_KEEPALIVE.append(interface)
+    interface.start(wait=False)
+    handle = interface.left if side == "left" else interface.right
+    deadline = time.monotonic() + CONNECT_TIMEOUT_S
+    while time.monotonic() < deadline and not handle.is_connected():
+        time.sleep(0.2)
+    if not handle.is_connected():
+        interface.stop()
+        pytest.fail(f"{side} sensor not reachable in {CONNECT_TIMEOUT_S:.0f}s")
+    yield handle
+    try:
+        _image_mode(handle, enable=False)          # never leave image mode on
+        handle.disable_aggregator_fsin()
+        handle.disable_camera(CAM_MASK)
+        handle.uart.histo.stop_streaming()
+        handle.uart.histo.drain_final(IMAGE_PKT)
+        handle.disable_camera_power(CAM_MASK)
+    except Exception:
+        pass
+    interface.stop()
+
+
+def _bring_up(sensor):
+    """Power -> FPGA -> configure, the production bring-up sequence."""
+    assert sensor.enable_camera_power(CAM_MASK) is True
+    time.sleep(0.5)
+    assert sensor.program_fpga(camera_position=CAM_MASK, manual_process=False) is True
+    time.sleep(0.1)
+    assert sensor.camera_configure_registers(CAM_MASK) is True
+
+
+def _image_mode(sensor, enable, mask=0):
+    """Send OW_CAMERA_IMAGE_MODE; return (active, mask, gap_counts)."""
+    from omotion.config import OW_CAMERA
+    from omotion.MotionSensor import _ERROR_TYPES
+
+    r = sensor._send(
+        packetType=OW_CAMERA, command=OW_CAMERA_IMAGE_MODE,
+        reserved=1 if enable else 0,
+        data=bytes([mask]) if enable else None)
+    assert r is not None and r.packetType not in _ERROR_TYPES, (
+        f"OW_CAMERA_IMAGE_MODE {'enable' if enable else 'disable'} failed")
+    assert r.data_len == RESP_LEN, f"unexpected response length {r.data_len}"
+    payload = bytes(r.data[:RESP_LEN])
+    active, rmask = payload[0], payload[1]
+    gaps = struct.unpack("<8I", payload[4:36])
+    return active, rmask, gaps
+
+
+class _ByteCollector:
+    """Accumulate raw HISTO-endpoint bytes off the stream queue."""
+
+    def __init__(self, histo, expected_size):
+        self._histo = histo
+        self._expected = expected_size
+        self._queue = queue.Queue(maxsize=1024)
+        self._stop = threading.Event()
+        self.buf = bytearray()
+        self._thread = threading.Thread(target=self._drain, daemon=True)
+
+    def _drain(self):
+        while not self._stop.is_set():
+            try:
+                chunk = self._queue.get(timeout=0.2)
+            except queue.Empty:
+                continue
+            if chunk:
+                self.buf.extend(bytes(chunk))
+
+    def start(self):
+        self._thread.start()
+        self._histo.start_streaming(self._queue, expected_size=self._expected)
+
+    def stop(self) -> bytes:
+        self._histo.stop_streaming()
+        self._stop.set()
+        self._thread.join(timeout=2.0)
+        return bytes(self.buf)
+
+
+def _fpga_read(sensor, cam, reg):
+    val = sensor.i2c_read_register(FPGA_ADDR, reg, read_len=1,
+                                   reg_addr_size=1, mux_channel=cam)
+    if val is False or not val:
+        return None
+    return val[0]
+
+
+def _fpga_write(sensor, cam, reg, value):
+    # feature/5 write trick: 16-bit 'register address' = [reg, value].
+    val = sensor.i2c_read_register(FPGA_ADDR, ((reg & 0xFF) << 8) | (value & 0xFF),
+                                   read_len=1, reg_addr_size=2, mux_channel=cam)
+    assert val is not False and val, f"cam{cam}: FPGA reg 0x{reg:02X} write failed"
+
+
+@requires_bench
+def test_image_mode_enter_exit_and_histogram_resume(sensor):
+    assert sensor.ping() is True
+    _bring_up(sensor)
+    histo = sensor.uart.histo
+    histo.flush_stale_data(HISTO_FRAME_BYTES)
+
+    # Phase 1: normal histogram streaming must work first.
+    col = _ByteCollector(histo, HISTO_FRAME_BYTES)
+    col.start()
+    assert sensor.enable_camera(CAM_MASK) is True
+    assert sensor.enable_aggregator_fsin() is True
+    time.sleep(PHASE_SECONDS)
+    phase1 = col.stop()
+    assert len(phase1) >= MIN_HISTO_BYTES, (
+        f"histogram stream never started: {len(phase1)} B in {PHASE_SECONDS}s")
+
+    # Phase 2: enter image mode MID-STREAM. Firmware suspends histograms.
+    active, rmask, gaps0 = _image_mode(sensor, enable=True, mask=CAM_MASK)
+    assert active == 1 and rmask == CAM_MASK
+    assert all(g == 0 for g in gaps0), "gap counters must reset on enter"
+
+    col = _ByteCollector(histo, IMAGE_PKT)
+    col.start()
+    time.sleep(PHASE_SECONDS)
+    phase2 = col.stop()
+    img_pkts = _extract_image_packets(phase2)
+    # FPGA is still in histogram mode: each 40 Hz 4100-B envelope yields one
+    # full 2408-B 'line' packet (then a stalled partial -> timeout resync).
+    assert len(img_pkts) >= 10, (
+        f"no TYPE_IMAGE packets while image mode active (got {len(img_pkts)})")
+    assert all(p[11] in CAMS for p in img_pkts), "cam_id field out of mask"
+    assert any(_envelope_crc_ok(p) for p in img_pkts), (
+        "no image envelope passed the util_crc16 check -- framing broken")
+
+    # The stalled-partial pattern must have exercised the line timeout.
+    _, _, gaps1 = _image_mode(sensor, enable=False)
+    assert any(gaps1[c] > 0 for c in CAMS), (
+        f"line timeout never fired (gaps={gaps1}) -- watchdog not working")
+
+    # Phase 3: histograms must RESUME with no host re-enable (firmware
+    # restored event_bits_enabled + re-armed 4100-B receptions on exit).
+    histo.flush_stale_data(HISTO_FRAME_BYTES)
+    col = _ByteCollector(histo, HISTO_FRAME_BYTES)
+    col.start()
+    time.sleep(PHASE_SECONDS)
+    phase3 = col.stop()
+    assert len(phase3) >= MIN_HISTO_BYTES, (
+        f"histogram stream did not resume after image-mode exit: {len(phase3)} B")
+    assert sensor.ping() is True, "command interface unhealthy after image mode"
+
+
+@requires_bench
+def test_image_line_stream_smoke(sensor):
+    assert sensor.ping() is True
+    _bring_up(sensor)
+
+    ver = _fpga_read(sensor, CAMS[0], REG_VERSION)
+    if ver is None or ver < 0x02:
+        pytest.skip(
+            f"camera FPGA register map v2 required (VERSION={ver!r}); load the "
+            "feature/8 bitstream (camera-fpga tools/full_frame_capture/"
+            "update_bitstream.py) and re-run")
+
+    histo = sensor.uart.histo
+    histo.flush_stale_data(IMAGE_PKT)
+    assert sensor.enable_camera(CAM_MASK) is True
+    assert sensor.enable_aggregator_fsin() is True
+
+    active, _, _ = _image_mode(sensor, enable=True, mask=CAM_MASK)
+    assert active == 1
+
+    col = _ByteCollector(histo, IMAGE_PKT)
+    col.start()
+    for cam in CAMS:
+        _fpga_write(sensor, cam, REG_LINE_L, 0)
+        _fpga_write(sensor, cam, REG_LINE_H, 0)   # H commits the pair
+        _fpga_write(sensor, cam, REG_CTRL, 0x03)  # bit0 image + bit1 SWEEP
+    time.sleep(PHASE_SECONDS)
+    for cam in CAMS:
+        _fpga_write(sensor, cam, REG_CTRL, 0x00)
+    raw = col.stop()
+
+    pkts = _extract_image_packets(raw)
+    # No sensor retiming here (production HTS): the FPGA overruns and pushes
+    # at drain rate (~1.4 kHz/camera) -- thousands of lines in 3 s. Demand a
+    # conservative floor so USB hiccups don't flake the test.
+    assert len(pkts) >= 100, f"sweep produced only {len(pkts)} line packets"
+    crc_ok = [p for p in pkts if _envelope_crc_ok(p)]
+    assert len(crc_ok) >= len(pkts) // 2, (
+        f"only {len(crc_ok)}/{len(pkts)} envelopes CRC-clean")
+    # Inner line header: magic 0xB6, format version 0x01 at the line offset.
+    magic_ok = [p for p in crc_ok if p[12] == 0xB6 and p[13] == 0x01]
+    assert magic_ok, "no envelope carried a valid FPGA line header (B6 01)"
+    _image_mode(sensor, enable=False)
+    assert sensor.ping() is True

--- a/tests/test_image_mode_hil.py
+++ b/tests/test_image_mode_hil.py
@@ -150,10 +150,27 @@ def sensor():
 
 
 def _bring_up(sensor):
-    """Power -> FPGA -> configure, the production bring-up sequence."""
+    """Power -> FPGA (FORCED) -> configure.
+
+    Bench finding: the fleet cameras are NVCM-programmed, so the stock
+    (non-forced) program path detects NVCM and silently skips the SRAM load,
+    leaving the burned production image running. OW_FPGA_PROG_SRAM with
+    reserved=2 (#68 hunk, firmware fe3f64e+) forces the flash-resident
+    bitstream into SRAM (~10 s per camera)."""
+    from omotion.config import OW_FPGA, OW_FPGA_PROG_SRAM
+    from omotion.MotionSensor import _ERROR_TYPES
+
     assert sensor.enable_camera_power(CAM_MASK) is True
     time.sleep(0.5)
-    assert sensor.program_fpga(camera_position=CAM_MASK, manual_process=False) is True
+    # ONE CAMERA PER COMMAND: each force blocks the MCU main loop ~10.5 s;
+    # a multi-camera mask in a single command blocks >20 s and stalls the
+    # COMMS USB endpoint (bench-reproduced twice). Per-camera is also the
+    # fleet-validated pattern (smoke_test.py / feature/5 RUNBOOK).
+    for cam in CAMS:
+        r = sensor._send(packetType=OW_FPGA, command=OW_FPGA_PROG_SRAM,
+                         addr=(1 << cam), reserved=2, timeout=120)
+        assert r is not None and r.packetType not in _ERROR_TYPES, (
+            f"forced SRAM load failed on cam {cam}")
     time.sleep(0.1)
     assert sensor.camera_configure_registers(CAM_MASK) is True
 

--- a/tests/test_image_packet_format.py
+++ b/tests/test_image_packet_format.py
@@ -1,0 +1,98 @@
+"""Off-bench checks pinning the drip-scan image-mode wire format.
+
+These parse the REAL firmware sources (no compilation) and fail if constants
+the SDK/FPGA sides depend on ever drift:
+
+* test_image_line_and_packet_constants -- IMAGE_LINE_SIZE / TYPE_IMAGE exist
+  in Core/Inc/common.h with the pinned values; the envelope offset macros
+  exist in camera_manager.h; the 2424-B envelope fits one HISTO USB transfer
+  (USB_HISTO_MAX_SIZE) and the in-place receive slot (HISTOGRAM_DATA_SIZE).
+* test_crc16_table_is_ccitt_false -- the 256-entry crc16_tab in
+  Core/Src/utils.c is exactly the CRC-16/CCITT-FALSE table (poly 0x1021,
+  MSB-first) and util_crc16's algorithm (init 0xFFFF, no reflection, no final
+  XOR) reproduces the documented vectors. The FPGA's per-line CRC and the
+  SDK's envelope verifier must both match these byte-for-byte.
+
+Run anywhere: pytest tests/test_image_packet_format.py -v
+"""
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+COMMON_H = ROOT / "Core" / "Inc" / "common.h"
+CAMERA_MANAGER_H = ROOT / "Core" / "Inc" / "camera_manager.h"
+USBD_HISTO_H = ROOT / "USB" / "Class" / "HISTO" / "Inc" / "usbd_histo.h"
+UTILS_C = ROOT / "Core" / "Src" / "utils.c"
+
+
+def _define(text, name):
+    m = re.search(rf"#define\s+{name}\s+\(?\s*(0x[0-9A-Fa-f]+|\d+)", text)
+    assert m, f"#define {name} not found"
+    return int(m.group(1), 0)
+
+
+def test_image_line_and_packet_constants():
+    common = COMMON_H.read_text()
+    cam_h = CAMERA_MANAGER_H.read_text()
+    histo_h = USBD_HISTO_H.read_text()
+
+    image_line_size = _define(common, "IMAGE_LINE_SIZE")
+    type_image = _define(common, "TYPE_IMAGE")
+    # 6-B line header + 2400-B packed RAW10 (4 px -> 5 B) + 2-B line CRC.
+    assert image_line_size == 2408
+    # Must equal the SDK's OW_IMAGE_PACKET (omotion/config.py).
+    assert type_image == 0x03
+
+    # Envelope math: SOF+type+size4 (6) + timestamp4 + SOH + cam_id = 12,
+    # then the line, then EOH (1) + CRC16 (2) + EOF (1).
+    line_offset = 6 + 4 + 2
+    total = line_offset + image_line_size + 1 + 3
+    assert total == 2424
+    assert "IMAGE_PKT_LINE_OFFSET" in cam_h
+    assert "IMAGE_PKT_TOTAL_SIZE" in cam_h
+
+    usb_max = _define(histo_h, "USB_HISTO_MAX_SIZE")
+    assert total <= usb_max, "image packet must fit one HISTO transfer"
+
+    slot = _define(cam_h, "HISTOGRAM_DATA_SIZE")
+    assert total <= slot, (
+        "the envelope is built in place inside each camera's existing "
+        "receive-buffer slot, so it must fit HISTOGRAM_DATA_SIZE")
+
+
+def _parse_fw_crc_table():
+    text = UTILS_C.read_text()
+    m = re.search(r"crc16_tab\[256\]\s*=\s*\{(.*?)\};", text, re.S)
+    assert m, "crc16_tab not found in utils.c"
+    entries = [int(x, 16) for x in re.findall(r"0x[0-9A-Fa-f]{4}", m.group(1))]
+    assert len(entries) == 256
+    return entries
+
+
+def _make_ccitt_table():
+    table = []
+    for i in range(256):
+        crc = i << 8
+        for _ in range(8):
+            crc = ((crc << 1) ^ 0x1021) & 0xFFFF if crc & 0x8000 else (crc << 1) & 0xFFFF
+        table.append(crc)
+    return table
+
+
+def _crc16(table, buf):
+    crc = 0xFFFF
+    for b in buf:
+        crc = ((crc << 8) ^ table[((crc >> 8) ^ b) & 0xFF]) & 0xFFFF
+    return crc
+
+
+def test_crc16_table_is_ccitt_false():
+    fw_table = _parse_fw_crc_table()
+    assert fw_table == _make_ccitt_table(), (
+        "utils.c crc16_tab is not the CRC-16/CCITT-FALSE (poly 0x1021) table")
+    # Standard CRC-16/CCITT-FALSE check value.
+    assert _crc16(fw_table, b"123456789") == 0x29B1
+    # Image-line vector: header B6 01 2A 00 07 00 (line 42, flags 0,
+    # frame_cnt 7) + 2400 zero pixel bytes = 2406 input bytes.
+    line = bytes([0xB6, 0x01, 0x2A, 0x00, 0x07, 0x00]) + bytes(2400)
+    assert _crc16(fw_table, line) == 0x030C


### PR DESCRIPTION
Draft — sensor-fw side of the drip-scan single-frame feature (companion to camera-fpga#8 and openmotion-sdk#167). **Do not merge until the matched set validates on the rig** — this firmware is compile + host-test verified only; the HIL suite is bench-gated.

## What this adds
- **`OW_CAMERA_IMAGE_MODE = 0x30`** (`if_commands.c`): reserved byte = enable 0/1, data[0] = camera bitmask; response is `image_mode_resp_t` (active/mask/per-camera gap counters) on every outcome.
- **Image-mode state machine** (`camera_manager.c`): enter suspends histogram streaming (saves+zeros `event_bits_enabled`, aborts in-flight histogram DMA, flushes the HISTO queue), arms a repeating 2408-B one-shot DMA per masked camera into the **existing** receive buffers (in place — cam1's SRAM4/BDMA slot unchanged). Exit restores histogram arming and discards the first post-session histogram frame (feature/5 garbage-frame caveat).
- **Data-paced receive** (`camera_manager.c`, `main.c`): `HAL_*_RxCpltCallback` build the 2424-B USB envelope in place around the DMA'd line and forward it on the HISTO endpoint as stream type **0x03** (envelope mirrors `send_histogram_data`: 6-B header + 4-B FSIN timestamp + SOH + cam_id + 2408-B line + EOH + CRC + EOF), then re-arm the DMA via a **software-pended LPTIM5 IRQ** (priority 7, below all camera IRQs) — required because the H7 HAL USART sets `State=READY` only *after* the RxCplt callback, so an in-callback re-arm is rejected.
- **Line-timeout watchdog** (`camera_manager.c`): main-loop DMA-progress check (`__HAL_DMA_GET_COUNTER`, covers both DMA-stream and BDMA) → a partial line stalled >~2 ms is aborted + re-armed + gap-counted (USART byte-slip resync).

## Histogram-path safety (the key regression concern)
When image mode is never entered, the firmware is behavior-identical: the RxCplt histogram branch sets the same event bit as before (`BIT_n == 1u<<n`, mapping unchanged), the `send_data()` discard hook is a guarded no-op (`histo_discard_next` static-false), and the error callbacks fall to the original abort+restart. Verified by reading + a clean full rebuild; the two-stage review specifically confirmed byte-identical histogram behavior.

## Verification
- `pytest tests/` → 37 passed / 19 skipped (wire-format + CRC-table tests pass; `test_image_mode_hil.py` collects and skips off-bench).
- Clean full `cmake --build build/Debug` on this branch (all 6 commits integrate; FLASH 75.8% of the app slot).
- The 2424-B envelope was cross-checked byte-for-byte against the SDK `parse_image_packet` (openmotion-sdk#167). During review an SDK/firmware envelope mismatch (SDK assumed 2420 B / no timestamp) was found and fixed SDK-side so both agree.

## Deferred to the bench (Task 9 / spec §5, cannot be done off-hardware)
`tests/test_image_mode_hil.py` (enter/exit + histogram resume, line-timeout via the histogram-envelope-chopping trick, and the sweep line-rate smoke against the feature/8 bitstream) must run on the rig, plus: deferred-re-arm timing, ISR budget under 8-camera data-paced load, and the `USBD_HISTO_SendData` copy-before-return assumption. Deploy is firmware-only (`scripts/deploy.py --device left --fw-only`).

Refs #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)