### PR TITLE
feat: camera telemetry v2 — log the full optical-black / black-level block

### DIFF
--- a/Core/Inc/camera_telemetry.h
+++ b/Core/Inc/camera_telemetry.h
@@ -8,7 +8,8 @@
  * OW_CAMERA_GET_TELEMETRY.
  *
  * Register basis: OX02C1S/OX02C1B DS 1.0 — voltage monitor §10.5.24/table
- * A-39, temperature §10.5.23, watchdog table A-40, frame counter §10.5.25.
+ * A-39, temperature §10.5.23, watchdog table A-40, frame counter §10.5.25,
+ * BLC / optical-black table A-25 (§3.5).
  * All values are returned as RAW register bytes assembled MSB-first; the SDK
  * owns conversion to engineering units (V = code*6/4096, °C = 8.8 format
  * with the >0xC000 negative rule, gains /16 and /1024).
@@ -26,7 +27,7 @@
 
 /* Wire-format version. Bump on ANY field change and update the SDK parser
  * (omotion/MotionSensor.py get_camera_telemetry()) in the same change. */
-#define CAM_TELEMETRY_VERSION 1u
+#define CAM_TELEMETRY_VERSION 2u
 
 /* Per-camera snapshot. Packed, little-endian (returned verbatim over COMMS).
  * "raw" fields hold the sensor's register bytes assembled MSB-first without
@@ -67,6 +68,41 @@ typedef struct __attribute__((packed)) {
 	uint8_t  isp_ctrl;       /* 0x5000 — 0x34 production / 0x30 raw mode (#89) */
 	uint8_t  i2c_err_count;  /* failed sweep transactions for this camera (saturating) */
 	uint8_t  sweep_count;    /* completed sweeps (wraps) — liveness/staleness check */
+
+	/* --- #103: optical-black / black-level block (DS table A-25) -------
+	 * The dark-row measurements plus the window/target/trigger context
+	 * that produced them — an average is not interpretable without
+	 * knowing which rows it averaged and what the servo was aiming at.
+	 * NOTE: the BLC servo only runs when 0x4001[0] blc_en is set. In raw
+	 * mode (#89 writes 0x4001 = 0x00) the offsets below are frozen at
+	 * whatever the servo last computed. */
+	uint16_t z_avg[4];        /* 0x40E0-0x40E7 — zero-line (dark row) averages for
+	                           * Bayer positions 00/01/10/11, 15-bit ({[6:0],[7:0]}).
+	                           * Mono sensor: all four sample the same physical dark
+	                           * rows, so they should agree; spread is a health metric. */
+	uint16_t blc_offset_z[4]; /* 0x40CD-0x40D4 — BLCoffset10000..10011, the second
+	                           * applied-offset bank (blc_offset[8] above is the first) */
+	uint16_t blc_thres;       /* 0x4061/62 — thres_l, the computed sample-discard
+	                           * threshold row averaging applies (0x4028[5] thres_en) */
+	uint16_t blk_lvl_target;  /* 0x4004/05 — blk_lvl_target_l, servo target pedestal
+	                           * (11-bit; base config programs 0x080 = 128) */
+	uint16_t zero_ln_num;     /* 0x4065/66 — zero_ln_num, zero-line count (10-bit) */
+	uint8_t  blc_trig_ctrl;   /* 0x4000 — [7] off_trig [6] exp_chg [5] gain_chg
+	                           * [4] fmt_chg [3] rst [2] man_trig [1] freeze [0] always */
+	uint8_t  bl_start;        /* 0x4008[5:0] — black-row window first row */
+	uint8_t  bl_end;          /* 0x4009[5:0] — black-row window last row */
+	uint8_t  blk_ln_num;      /* 0x4019 — black-row count */
+	uint8_t  blc_ln_mode;     /* 0x401A — [7] h_size_man_en [2] ln_num_man [1:0] byp_mode */
+	uint8_t  zl_start;        /* 0x4050 — zero-line window first row */
+	uint8_t  zl_end;          /* 0x4051 — zero-line window last row */
+	uint8_t  zavg_ctrl;       /* 0x40E8 — [5] dither_zbline_en [4] zl_win2_en
+	                           * [3] zl_off_en [2] zl_cal_dis [1:0] z_avg_sel */
+	uint8_t  zl_start2;       /* 0x40EA — second zero-line window first row */
+	uint8_t  zl_end2;         /* 0x40EB — second zero-line window last row */
+	uint8_t  blc_fault_latch; /* 0x40F1 — BLC fault_latch (mask at 0x40F0, default 0xFC) */
+	uint8_t  blc_fault_state; /* 0x40F2[0] — BLC fault_state */
+	uint8_t  dig_test_fail;   /* 0x40B3 — dig_test_fail_cnt_l, digital-test-row mismatches */
+	uint8_t  dtr_fault;       /* 0x40F8 — [1] dtr_fault_latched [0] dtr_fault_stat */
 } cam_telemetry_t;
 
 /* NOTE on frame counting: the OX02C1B's documented "32-bit frame counter"
@@ -88,8 +124,8 @@ typedef struct __attribute__((packed)) {
 	cam_telemetry_t cam[CAMERA_COUNT];
 } cam_telemetry_response_t;
 
-_Static_assert(sizeof(cam_telemetry_t) == 74u, "cam_telemetry_t wire size changed - bump CAM_TELEMETRY_VERSION and fix the SDK parser");
-_Static_assert(sizeof(cam_telemetry_response_t) == 12u + 8u * 74u, "cam_telemetry_response_t wire size changed");
+_Static_assert(sizeof(cam_telemetry_t) == 110u, "cam_telemetry_t wire size changed - bump CAM_TELEMETRY_VERSION and fix the SDK parser");
+_Static_assert(sizeof(cam_telemetry_response_t) == 12u + 8u * 110u, "cam_telemetry_response_t wire size changed");
 
 /* Advance the background sweep by one bounded chunk (<= ~1.3 ms of I2C).
  * Call from camera_i2c_service() only: hi2c1 work must stay in the main

--- a/Core/Inc/camera_telemetry.h
+++ b/Core/Inc/camera_telemetry.h
@@ -73,13 +73,24 @@ typedef struct __attribute__((packed)) {
 	 * The dark-row measurements plus the window/target/trigger context
 	 * that produced them — an average is not interpretable without
 	 * knowing which rows it averaged and what the servo was aiming at.
-	 * NOTE: the BLC servo only runs when 0x4001[0] blc_en is set. In raw
-	 * mode (#89 writes 0x4001 = 0x00) the offsets below are frozen at
-	 * whatever the servo last computed. */
+	 *
+	 * Bench-established 2026-07-20 (left sensor, all 8 cameras):
+	 *  - z_avg and blc_offset* update ONLY while the sensor is scanning
+	 *    rows. Idle (sc_state 6) they read 0; they populate within one
+	 *    sweep of stream-on. Judge them against sc_state, not updated_ms.
+	 *  - They are NOT gated by 0x4001[0] blc_en: in raw mode (#89 writes
+	 *    0x4001 = 0x00) both keep updating with unchanged values. The
+	 *    statistics engine runs independently of whether the correction
+	 *    is applied.
+	 *  - Scale: z_avg is fixed-point with 6 fractional bits, z_avg/64 =
+	 *    DN. Measured 7791/64 = 121.7 DN against the sensor's own
+	 *    raw-mode Yavg (0x4C13, no BLC subtraction) of 121. */
 	uint16_t z_avg[4];        /* 0x40E0-0x40E7 — zero-line (dark row) averages for
 	                           * Bayer positions 00/01/10/11, 15-bit ({[6:0],[7:0]}).
-	                           * Mono sensor: all four sample the same physical dark
-	                           * rows, so they should agree; spread is a health metric. */
+	                           * Mono sensor, so all four sample the same physical
+	                           * dark rows — but they do NOT agree: positions 10/11
+	                           * read ~60 LSB (~0.8 %) above 00/01, reproducibly, on
+	                           * every camera. The split is by row parity. */
 	uint16_t blc_offset_z[4]; /* 0x40CD-0x40D4 — BLCoffset10000..10011, the second
 	                           * applied-offset bank (blc_offset[8] above is the first) */
 	uint16_t blc_thres;       /* 0x4061/62 — thres_l, the computed sample-discard

--- a/Core/Src/camera_telemetry.c
+++ b/Core/Src/camera_telemetry.c
@@ -12,6 +12,10 @@
  * A failed transaction aborts the whole sweep: the published cache keeps the
  * camera's last completed snapshot (same last-known-good philosophy as
  * cam_temp[]) and i2c_err_count records the failure.
+ *
+ * #103 added the optical-black / black-level block (DS table A-25): the
+ * z_avg dark-row averages plus the window, target, trigger and fault context
+ * needed to interpret them. Read-only, like everything else here.
  */
 
 #include "camera_telemetry.h"
@@ -54,13 +58,27 @@ static const struct telem_op telem_ops[] = {
 	{ 0x350Au, 3u },  /* commanded digital gain (packed 14-bit) */
 	{ 0x3503u, 1u },  /* AEC/AGC mode */
 	{ 0x3A93u, 1u },  /* DCG (conversion gain) state */
-	{ 0x4001u, 1u },  /* BLC ctrl (#89 raw-mode contract) */
+	{ 0x4000u, 10u }, /* BLC trigger ctrl, BLC ctrl (#89 raw-mode contract),
+	                   * rsvd x2, black-level target, hwin_pad (skipped),
+	                   * black-row window start/end */
 	{ 0x5000u, 1u },  /* ISP ctrl (#89 raw-mode contract) */
 	{ 0x5052u, 8u },  /* ISP-latched real gain / dig gain / BLC / exposure */
 	{ 0x4072u, 30u }, /* applied BLC offsets ch0-7 ({MSB,LSB} at stride 4) */
+	/* #103 optical-black block. Read-only; ordered by address so the
+	 * bursts stay contiguous (DS table A-25). */
+	{ 0x4019u, 2u },  /* black-row count, line-number/bypass mode */
+	{ 0x4050u, 2u },  /* zero-line window start/end */
+	{ 0x4061u, 2u },  /* thres_l — computed sample-discard threshold */
+	{ 0x4065u, 2u },  /* zero_ln_num */
+	{ 0x40B3u, 1u },  /* digital-test-row fail count */
+	{ 0x40CDu, 8u },  /* BLCoffset10000..10011 (second offset bank, contiguous) */
+	{ 0x40E0u, 12u }, /* z_avg 00/01/10/11, zavg ctrl, 0x40E9 (skipped),
+	                   * second zero-line window start/end */
+	{ 0x40F1u, 2u },  /* BLC fault latch / fault state */
+	{ 0x40F8u, 1u },  /* digital-test-row fault status */
 };
 #define TELEM_N_OPS (sizeof(telem_ops) / sizeof(telem_ops[0]))
-#define TELEM_RAW_BYTES 81u
+#define TELEM_RAW_BYTES 122u
 
 /* Firmware-side FSIN pulse counter (main.c, incremented per frame trigger):
  * the frames-triggered ground truth for the response header — the sensor's
@@ -130,6 +148,7 @@ static void telem_publish(uint8_t cam_id, uint32_t now)
 	uint8_t prev_wd0 = t->wd[0], prev_wd1 = t->wd[1];
 	uint8_t prev_vml = t->vm_latched, prev_vmcpl = t->vm_cp_latched;
 	uint8_t prev_tpm = (uint8_t)(t->tpm_status & 0x0Fu);
+	uint8_t prev_blcf = t->blc_fault_latch;
 	_Bool was_valid = (telem_resp.valid_mask & (1u << cam_id)) != 0u;
 
 	t->avdd_raw = rd16(&p);
@@ -160,7 +179,15 @@ static void telem_publish(uint8_t cam_id, uint32_t now)
 	t->dgain_cmd |= rd8(&p);
 	t->aec_mode = rd8(&p);
 	t->dcg_state = rd8(&p);
+	/* 0x4000-0x4009 block: two reserved bytes and hwin_pad are read as part
+	 * of the burst but not published (nothing OB-relevant in them). */
+	t->blc_trig_ctrl = rd8(&p);
 	t->blc_ctrl = rd8(&p);
+	p += 2;                        /* 0x4002-0x4003 reserved */
+	t->blk_lvl_target = rd16(&p);
+	p += 2;                        /* 0x4006/07 hwin_pad */
+	t->bl_start = rd8(&p);
+	t->bl_end = rd8(&p);
 	t->isp_ctrl = rd8(&p);
 	t->isp_real_gain = rd16(&p);
 	t->isp_dig_gain = rd16(&p);
@@ -172,6 +199,28 @@ static void telem_publish(uint8_t cam_id, uint32_t now)
 		t->blc_offset[i] = (uint16_t)(((uint16_t)p[i * 4u] << 8) | p[i * 4u + 1u]);
 	}
 	p += 30;
+
+	/* #103 optical-black block, in telem_ops[] order. */
+	t->blk_ln_num = rd8(&p);
+	t->blc_ln_mode = rd8(&p);
+	t->zl_start = rd8(&p);
+	t->zl_end = rd8(&p);
+	t->blc_thres = rd16(&p);
+	t->zero_ln_num = rd16(&p);
+	t->dig_test_fail = rd8(&p);
+	for (uint8_t i = 0; i < 4u; i++) {   /* BLCoffset10000..10011, contiguous */
+		t->blc_offset_z[i] = rd16(&p);
+	}
+	for (uint8_t i = 0; i < 4u; i++) {   /* z_avg_00, _01, _10, _11 */
+		t->z_avg[i] = rd16(&p);
+	}
+	t->zavg_ctrl = rd8(&p);
+	p += 1;                              /* 0x40E9 row data-type selects */
+	t->zl_start2 = rd8(&p);
+	t->zl_end2 = rd8(&p);
+	t->blc_fault_latch = rd8(&p);
+	t->blc_fault_state = rd8(&p);
+	t->dtr_fault = rd8(&p);
 
 	if (p != &telem_staging[TELEM_RAW_BYTES]) {
 		/* Decode desynced from telem_ops[] — programming error, don't
@@ -191,10 +240,11 @@ static void telem_publish(uint8_t cam_id, uint32_t now)
 	if (was_valid &&
 	    (t->wd[0] != prev_wd0 || t->wd[1] != prev_wd1 ||
 	     t->vm_latched != prev_vml || t->vm_cp_latched != prev_vmcpl ||
-	     (uint8_t)(t->tpm_status & 0x0Fu) != prev_tpm)) {
-		printf("CAM%u TELEM fault change: wd=%02X/%02X vm=%02X cp=%02X tpm=%02X\r\n",
+	     (uint8_t)(t->tpm_status & 0x0Fu) != prev_tpm ||
+	     t->blc_fault_latch != prev_blcf)) {
+		printf("CAM%u TELEM fault change: wd=%02X/%02X vm=%02X cp=%02X tpm=%02X blc=%02X\r\n",
 		       cam_id + 1u, t->wd[0], t->wd[1], t->vm_latched,
-		       t->vm_cp_latched, t->tpm_status);
+		       t->vm_cp_latched, t->tpm_status, t->blc_fault_latch);
 	}
 }
 

--- a/tests/test_camera_telemetry_hil.py
+++ b/tests/test_camera_telemetry_hil.py
@@ -1,15 +1,19 @@
-"""HIL: continuous camera-sensor telemetry (#94, OW_CAMERA_GET_TELEMETRY).
+"""HIL: continuous camera-sensor telemetry (#94 + OB block #103).
 
 Brings up every present camera, lets the firmware's background sweep refresh
 the fleet (~1 s round-robin), then validates the cached snapshot end to end:
 
-- response framing: version 1, struct_size 78, valid bit per powered camera
+- response framing: version 2, struct_size 110, valid bit per powered camera
 - supply rails from the on-die voltage monitor sit inside the alarm windows
   the config table programs (AVDD [2.52, 3.08] V etc., V = code * 6 / 4096)
 - die temperatures are plausible (10-95 degC) and TPM cross-check alarm clear
 - no camera sits in safe mode (sc_state 5); no VM/watchdog fault latched
 - correction-state bytes match the production table (0x4001=0x23, 0x5000=0x34,
   AEC/AGC manual 0xA8) and commanded analog gain matches the per-slot ladder
+- the optical-black block's window/target/trigger context matches what the
+  config table programs (#103) — the dark-row averages themselves are printed,
+  not asserted, until a bench baseline exists (the watchdog bytes taught us
+  that an un-baselined "fault" byte is usually a configuration signature)
 - sweeps stay live (sweep_count advances between polls)
 - during a ~3 s stream_on + internal-FSIN burst, sweeps observe the probe
   camera actually producing frames: sc_state reads 0x9 (streaming) and the
@@ -62,6 +66,18 @@ PRODUCTION_ISP_CTRL = 0x34   # 0x5000 (raw mode #89 would read 0x30)
 AEC_AGC_MANUAL = 0xA8        # 0x3503
 EXPECTED_EXPO_ROWS = 0x0048  # 72 rows = 648 us (config table)
 SC_STATE_SAFE_MODE = 0x5
+
+# OB / black-level context the config table programs (#103). These are what
+# X02C1B_SENSOR_CONFIG writes, so a mismatch means the applied config drifted
+# — unlike the dark-row averages, they are safe to assert on the first run.
+EXPECTED_OB_CONTEXT = {
+    "blc_trig_ctrl": 0xF9,     # 0x4000
+    "blk_lvl_target": 0x080,   # 0x4004/05 — servo target pedestal 128
+    "bl_start": 0x04,          # 0x4008 — black-row window
+    "bl_end": 0x1B,            # 0x4009
+    "zl_start": 0x02,          # 0x4050 — zero-line window feeding z_avg
+    "zl_end": 0x0D,            # 0x4051
+}
 
 
 @pytest.fixture
@@ -132,7 +148,7 @@ def test_camera_telemetry_snapshot(interface):
 
         telem = sensor.get_camera_telemetry()
         assert telem is not None, f"[{side}] get_camera_telemetry returned None"
-        assert telem["version"] == 1, f"[{side}] unexpected telemetry version"
+        assert telem["version"] == 2, f"[{side}] unexpected telemetry version"
 
         print(f"\n=== Sensor [{side}] camera telemetry ===")
         print(f"{'cam':>3} | {'AVDD':>6} {'DOVDD':>6} {'DVDD':>6} | "
@@ -193,6 +209,43 @@ def test_camera_telemetry_snapshot(interface):
                 failures.append(
                     f"[{side}] cam {cam_id}: {c['i2c_err_count']} sweep I2C errors")
 
+            # OB block (#103): the window/target/trigger context is programmed
+            # by the config table, so assert it. The dark-row averages and the
+            # BLC fault byte have no bench baseline yet — report only.
+            for key, expected in EXPECTED_OB_CONTEXT.items():
+                if c[key] != expected:
+                    failures.append(
+                        f"[{side}] cam {cam_id}: {key} 0x{c[key]:02X} != "
+                        f"config-table 0x{expected:02X}")
+
+        # --- OB / black-level report (#103) -------------------------------
+        # z_avg_00/01/10/11 are the zero-line (dark row) averages per Bayer
+        # position. Mono sensor: all four sample the same physical dark rows,
+        # so spread should be ~0 and the mean is the dark pedestal. Printed
+        # for baselining; only structural context above is asserted.
+        print(f"\n--- Sensor [{side}] optical-black block ---")
+        print(f"{'cam':>3} | {'z_avg 00/01/10/11':>27} | {'mean':>7} {'spr':>4} | "
+              f"{'target':>6} | {'thres':>5} | {'blcflt':>6} | {'BLCoff_z':>19}")
+        print("-" * 96)
+        for cam_id in present:
+            c = telem["cameras"][cam_id]
+            if not c["valid"]:
+                continue
+            z = "/".join(f"{v:6d}" for v in c["z_avg"])
+            offz = "/".join(f"{v:4d}" for v in c["blc_offsets_z"])
+            print(f"{cam_id:>3} | {z:>27} | {c['z_avg_mean']:7.1f} "
+                  f"{c['z_avg_spread']:4d} | {c['blk_lvl_target']:6d} | "
+                  f"{c['blc_thres']:5d} | {c['blc_fault_latch']:02X}/"
+                  f"{c['blc_fault_state']:01X}  | {offz:>19}")
+        print(f"    zero-line window rows {telem['cameras'][present[0]]['zl_start']}"
+              f"-{telem['cameras'][present[0]]['zl_end']}, "
+              f"black-row window {telem['cameras'][present[0]]['bl_start']}"
+              f"-{telem['cameras'][present[0]]['bl_end']}, "
+              f"z_avg_sel={telem['cameras'][present[0]]['z_avg_sel']}, "
+              f"dtr_fault/dig_test_fail="
+              f"{telem['cameras'][present[0]]['dtr_fault']}/"
+              f"{telem['cameras'][present[0]]['dig_test_fail']}")
+
         # Liveness: sweeps keep advancing.
         probe_cam = present[0]
         first = telem["cameras"][probe_cam]["sweep_count"]
@@ -218,23 +271,29 @@ def test_camera_telemetry_snapshot(interface):
         while time.monotonic() < t_end:
             time.sleep(0.4)
             c = sensor.get_camera_telemetry()["cameras"][probe_cam]
-            samples.append((c["updated_ms"], c["tc_row"], c["sc_state"]))
+            samples.append((c["updated_ms"], c["tc_row"], c["sc_state"],
+                            tuple(c["z_avg"])))
         sensor.disable_aggregator_fsin()
         sensor._send(packetType=OW_CAMERA, command=OW_CAMERA_OFF)
         pc_after = sensor.get_camera_telemetry()["fsin_pulse_count"]
 
         fresh = {}
-        for upd, tc, sc in samples:
-            fresh[upd] = (tc, sc)
+        for upd, tc, sc, z in samples:
+            fresh[upd] = (tc, sc, z)
         print(f"burst sweeps for cam {probe_cam}: "
-              f"{[(u, t, hex(s)) for u, (t, s) in sorted(fresh.items())]} "
+              f"{[(u, t, hex(s)) for u, (t, s, _) in sorted(fresh.items())]} "
               f"(ext-FSIN pulse count {pc_before} -> {pc_after})")
+        # Open question this run answers: does z_avg track the dark rows while
+        # streaming, and does it move at all? Reported, not asserted.
+        z_seq = [z for _, (_, _, z) in sorted(fresh.items())]
+        print(f"  z_avg across burst sweeps: {z_seq}")
+        print(f"  z_avg changed during burst: {len(set(z_seq)) > 1}")
         if len(fresh) < 2:
             failures.append(
                 f"[{side}] only {len(fresh)} fresh sweep(s) during 3 s burst")
         else:
-            tc_vals = [t for t, _ in fresh.values()]
-            sc_vals = [s for _, s in fresh.values()]
+            tc_vals = [t for t, _, _ in fresh.values()]
+            sc_vals = [s for _, s, _ in fresh.values()]
             if 0x9 not in sc_vals:
                 failures.append(
                     f"[{side}] cam {probe_cam} never seen in streaming state "

--- a/tests/test_camera_telemetry_hil.py
+++ b/tests/test_camera_telemetry_hil.py
@@ -11,9 +11,12 @@ the fleet (~1 s round-robin), then validates the cached snapshot end to end:
 - correction-state bytes match the production table (0x4001=0x23, 0x5000=0x34,
   AEC/AGC manual 0xA8) and commanded analog gain matches the per-slot ladder
 - the optical-black block's window/target/trigger context matches what the
-  config table programs (#103) — the dark-row averages themselves are printed,
-  not asserted, until a bench baseline exists (the watchdog bytes taught us
-  that an un-baselined "fault" byte is usually a configuration signature)
+  config table programs (#103), and the dark-row averages track while the
+  sensor scans rows. Baselined on the left sensor 2026-07-20: z_avg reads 0
+  at idle, ~7790 LSB (/64 = 121.7 DN) while streaming, with Bayer positions
+  10/11 ~60 LSB above 00/01. blc_thres (2047), blc_fault_latch (0xFF with
+  fault_state 0) and dtr_fault (1) are configuration signatures, not faults —
+  same lesson as the watchdog bytes — so they are printed, never asserted.
 - sweeps stay live (sweep_count advances between polls)
 - during a ~3 s stream_on + internal-FSIN burst, sweeps observe the probe
   camera actually producing frames: sc_state reads 0x9 (streaming) and the
@@ -283,11 +286,35 @@ def test_camera_telemetry_snapshot(interface):
         print(f"burst sweeps for cam {probe_cam}: "
               f"{[(u, t, hex(s)) for u, (t, s, _) in sorted(fresh.items())]} "
               f"(ext-FSIN pulse count {pc_before} -> {pc_after})")
-        # Open question this run answers: does z_avg track the dark rows while
-        # streaming, and does it move at all? Reported, not asserted.
+        # OB dark rows (#103). Bench-established 2026-07-20: z_avg reads 0 at
+        # idle and populates while the sensor scans rows, so a streaming sweep
+        # with an all-zero z_avg means the statistic stopped tracking.
         z_seq = [z for _, (_, _, z) in sorted(fresh.items())]
+        streaming_z = [z for _, (_, sc, z) in sorted(fresh.items()) if sc == 0x9]
         print(f"  z_avg across burst sweeps: {z_seq}")
-        print(f"  z_avg changed during burst: {len(set(z_seq)) > 1}")
+        print(f"  z_avg while streaming: {streaming_z}")
+        if streaming_z:
+            for z in streaming_z:
+                if not any(z):
+                    failures.append(
+                        f"[{side}] cam {probe_cam}: z_avg all-zero on a "
+                        f"streaming sweep (dark-row statistic not tracking)")
+                    break
+            else:
+                # Row-parity split: positions 10/11 run ~60 LSB above 00/01 on
+                # every camera measured. Assert only the loose envelope — this
+                # is one bench, one sensor.
+                splits = [((z[2] + z[3]) - (z[0] + z[1])) / 2.0 for z in streaming_z]
+                dn = [sum(z) / 4.0 / 64.0 for z in streaming_z]   # 6 fractional bits
+                print(f"  row-parity split (10/11 - 00/01): "
+                      f"{[round(s, 1) for s in splits]} LSB; "
+                      f"dark level {[round(d, 1) for d in dn]} DN")
+                if max(abs(s) for s in splits) > 200:
+                    failures.append(
+                        f"[{side}] cam {probe_cam}: z_avg row-parity split "
+                        f"{max(splits):.0f} LSB far above the ~60 LSB baseline")
+        else:
+            print("  (no streaming sweep captured; z_avg checks skipped)")
         if len(fresh) < 2:
             failures.append(
                 f"[{side}] only {len(fresh)} fresh sweep(s) during 3 s burst")


### PR DESCRIPTION
Refs #103

## Why

From the laser engineer:

> also, AI seems to think that z_avg_00 through z_avg_11 are the means for the optically black pixels, in theory should be average of all 4 for our mono sensor

They are. OX02C1B DS 1.0 table A-25 sheet 11 puts the zero-line (dark row) averages for Bayer positions 00/01/10/11 at **0x40E0-0x40E7**, 15-bit each. A sweep of every `*avg*` register name in the DS appendix confirms these are the **only** readable dark-row statistic on the part (the other hit, `Yavg` 0x4C13, is the weighted *frame* mean and was already logged). On our mono sensor all four average the same physical dark rows, so their spread is a free per-camera health metric and their mean is the on-die dark pedestal.

## What

Wire version 1 -> 2. Beyond the four averages, this logs the context without which an average means nothing:

| Field | Register(s) |
|---|---|
| `z_avg[4]` | 0x40E0-0x40E7 |
| `blc_offset_z[4]` | 0x40CD-0x40D4 — second BLCoffset bank (v1 logged 8 of the 12) |
| `blc_thres` | 0x4061/62 — computed sample-discard threshold |
| `blk_lvl_target` | 0x4004/05 — servo target pedestal |
| `bl_start`/`bl_end`, `blk_ln_num`, `blc_ln_mode` | 0x4008/09, 0x4019/1A — black-row window |
| `zl_start`/`zl_end`, `zero_ln_num`, `zavg_ctrl`, `zl_start2`/`zl_end2` | 0x4050/51, 0x4065/66, 0x40E8, 0x40EA/EB — zero-line window + `z_avg_sel` |
| `blc_trig_ctrl` | 0x4000 — what re-triggers the servo |
| `blc_fault_latch`/`blc_fault_state`, `dig_test_fail`, `dtr_fault` | 0x40F1/F2, 0x40B3, 0x40F8 |

Read-only; the only write in the sweep is still the pre-existing `0x4E14` VM freeze.

## Cost

`cam_telemetry_t` 74 -> 110 B, response 604 -> 892 B (`COMMAND_MAX_SIZE` is 8192, no framing change). Sweep 21 -> 30 I2C ops / 122 raw bytes, unchanged 125 ms cadence and unchanged 6-op-per-pass budget — the 30-byte `0x4072` burst still dominates the worst pass, so the ~1.3 ms per-pass bound holds.

## Verification

- Builds clean; the `_Static_assert`s on `sizeof(cam_telemetry_t) == 110` and the response size are the layout proof.
- `telem_ops[]` and `telem_publish()` were walked against each other op by op; the runtime `p != &telem_staging[TELEM_RAW_BYTES]` guard remains as the desync backstop.
- Field-order cross-check against the SDK parser: 71 struct fields compared by byte offset, 0 mismatches, plus a distinct-value round trip so no two OB fields can be transposed.
- `pytest tests/` — 35 passed, 17 skipped (HIL, off bench).

## Not verified yet — needs the bench

1. **Does `z_avg` update at all, and does it track?** The HIL test now records `z_avg` across a streaming burst and prints whether it changed. In raw mode (#89 writes `0x4001 = 0x00`, `blc_en = 0`) the servo is off and `BLCoffset*` are frozen; whether the dark-row statistic keeps updating is undocumented.
2. **Baselines.** Per the watchdog lesson (`0x4F0A`=0x9E etc. turned out to be a configuration signature, not a fault), the test asserts only the config-table context — `blk_lvl_target`, the two window ranges, `blc_trig_ctrl` — and merely *reports* the averages, `blc_thres` and `blc_fault_latch` until a bench baseline exists.
3. **#96 interaction.** This raises per-sweep main-loop I2C occupancy ~40%. #96 (1 Hz telemetry polling wedges HISTO streaming) needs a re-check under streaming, not just a static read.

Host side: OpenwaterHealth/openmotion-sdk#169 — must ship together, or the parser rejects every snapshot on the version mismatch.