### PR TITLE
fix: recover the HISTO endpoint when a host reader dies mid-transfer

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -474,6 +474,7 @@ int main(void)
     camera_i2c_service();    /* Camera-bus work deferred from the frame ISRs (temp poll, mux disables) */
     logging_pump();          /* Flush USB log data buffered from ISR context */
     check_streaming();
+    USBD_HISTO_CheckTxStuck(); /* Recover the HISTO EP if an armed transfer stalls (dead host reader) */
     poll_mcu_temperature();  /* Print warning if MCU junction temp above threshold */
     USB_RecoveryCheck();     /* EFT/lock-up watchdog: rebuild USB stack if bus goes dead */
     system_monitor_poll();   /* ECC report drain + DMA error-flag scan */

--- a/USB/Class/HISTO/Inc/usbd_histo.h
+++ b/USB/Class/HISTO/Inc/usbd_histo.h
@@ -29,6 +29,12 @@ uint8_t  USBD_HISTO_SendData(USBD_HandleTypeDef *pdev, uint8_t *data, uint16_t l
 void USBD_HISTO_TxCpltCallback(uint8_t *Buf, uint32_t Len, uint8_t epnum);
 void USBD_HISTO_FlushQueue(const char *who);
 
+/* Stuck-TX watchdog -- call from the main loop. Recovers the HISTO IN
+ * endpoint when an armed multi-packet transfer stops making progress
+ * (host reader died mid-transfer), which otherwise wedges the endpoint
+ * until a power cycle. No-op unless a transfer is armed and stalled. */
+void USBD_HISTO_CheckTxStuck(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/USB/Class/HISTO/Src/usbd_histo.c
+++ b/USB/Class/HISTO/Src/usbd_histo.c
@@ -109,6 +109,12 @@ static volatile uint32_t histo_deq_count = 0;
 static volatile uint32_t histo_datain_count = 0;
 static volatile uint32_t histo_tx_fail_count = 0;
 
+/* Stuck-TX watchdog state (see USBD_HISTO_CheckTxStuck). Written from the
+ * main loop and from SetTxBuffer; read alongside histo_ep_data. */
+static volatile uint32_t histo_tx_armed_ms = 0;    /* tick when the in-flight transfer last progressed */
+static volatile uint32_t histo_tx_progress = 0;    /* histo_datain_count at that moment */
+static volatile uint32_t histo_tx_stuck_count = 0; /* watchdog recoveries (diagnostic) */
+
 #ifndef USB_RAM_D2
 #define USB_RAM_D2 __attribute__((section(".ram_d2")))
 #endif
@@ -140,6 +146,18 @@ static uint8_t USBD_Histo_Init(USBD_HandleTypeDef *pdev, uint8_t cfgidx)
     histo_queue_tail = 0;
     histo_queue_count = 0;
     histo_pdev = pdev;
+
+    /* Abandon any transfer the previous session left armed. A host reader
+     * that dies mid-transfer leaves histo_ep_data set with no DataIn ever
+     * coming; the flag used to survive this reconfigure, so every later
+     * SetTxBuffer returned BUSY, the 4-entry queue filled, and the
+     * endpoint stayed dead until a power cycle. A USB reset did not help
+     * either -- it runs this same DeInit/Init path. */
+    histo_ep_data = 0;
+    tx_histo_ptr = 0;
+    tx_histo_total_len = 0;
+    histo_tx_armed_ms = 0;
+    histo_tx_progress = 0;
 
     if (pdev->dev_speed == USBD_SPEED_HIGH)
     {
@@ -192,6 +210,14 @@ static uint8_t USBD_Histo_DeInit(USBD_HandleTypeDef *pdev, uint8_t cfgidx)
   histo_queue_tail = 0;
   histo_queue_count = 0;
   histo_pdev = NULL;
+
+  /* Same reason as Init: the in-flight marker must not outlive the
+   * session that armed it. */
+  histo_ep_data = 0;
+  tx_histo_ptr = 0;
+  tx_histo_total_len = 0;
+  histo_tx_armed_ms = 0;
+  histo_tx_progress = 0;
 #ifdef USE_USBD_COMPOSITE
   if (pdev->pClassDataCmsit[pdev->classId] != NULL)
   {
@@ -405,6 +431,15 @@ uint8_t USBD_HISTO_SendData(USBD_HandleTypeDef *pdev, uint8_t *data, uint16_t le
     histo_pdev = pdev;
   }
 
+  /* Do not push into a core that cannot move data. When the host
+   * selectively suspends the device the PHY clock is gated, and
+   * transmitting into it neither completes nor errors -- it just strands
+   * a transfer that DataIn will never finish. Drop the frame instead;
+   * histogram sends are already fire-and-forget. */
+  if (pdev->dev_state != USBD_STATE_CONFIGURED) {
+    return USBD_FAIL;
+  }
+
   /* If queue is empty and not currently sending, send directly */
   if (histo_queue_is_empty() && histo_ep_data == 0) {
     uint8_t ret = USBD_HISTO_SetTxBuffer(pdev, data, len);
@@ -451,6 +486,8 @@ void USBD_HISTO_FlushQueue(const char *who)
   histo_ep_data = 0;
   tx_histo_ptr = 0;
   tx_histo_total_len = 0;
+  histo_tx_armed_ms = 0;
+  histo_tx_progress = 0;
   if (histo_pdev != NULL && histo_ep_enabled != 0) {
     USBD_LL_FlushEP(histo_pdev, HISTOInEpAdd);
   }
@@ -463,6 +500,48 @@ void USBD_HISTO_FlushQueue(const char *who)
    *   e-d= enq-deq; this should EQUAL q. If e-d != q the count was corrupted by
    *        a cross-ISR race; if e-d == q > 0 the scan honestly left frames unsent. */
   printf("HISTO flush(%s): q=%u ep=%u e-d=%ld\r\n", who, pending, inflight, gap);
+}
+
+/* Stuck-TX watchdog. A multi-packet histogram transfer is chained by the
+ * DataIn completion interrupt: each 512-byte packet arms the next. If the
+ * host stops issuing IN tokens mid-chain -- a reader process dying, a
+ * cancelled transfer halting the pipe -- DataIn never fires again, so
+ * histo_ep_data stays 1 and histo_process_queue() returns BUSY forever.
+ * Nothing else in the class can break that cycle from inside a session.
+ *
+ * Call from the main loop. When a transfer has been armed for longer than
+ * HISTO_TX_STUCK_MS with no DataIn progress, abandon it: FlushQueue drops
+ * the EP FIFO, clears the in-flight marker and empties the queue, so the
+ * next frame starts a clean transfer.
+ *
+ * Deliberately keyed on lack of *progress*, not on elapsed time alone --
+ * a slow-but-advancing host must never be interrupted (the healthy path
+ * is what test_stream_resumes_within_one_session guards). */
+#define HISTO_TX_STUCK_MS 500u
+
+void USBD_HISTO_CheckTxStuck(void)
+{
+  if (histo_ep_data == 0 || histo_pdev == NULL || histo_ep_enabled == 0) {
+    return;
+  }
+
+  uint32_t datain_now = histo_datain_count;
+  if (datain_now != histo_tx_progress) {
+    /* Transfer is advancing -- re-arm the window and leave it alone. */
+    histo_tx_progress = datain_now;
+    histo_tx_armed_ms = HAL_GetTick();
+    return;
+  }
+
+  if ((HAL_GetTick() - histo_tx_armed_ms) < HISTO_TX_STUCK_MS) {
+    return;
+  }
+
+  histo_tx_stuck_count++;
+  /* FlushQueue clears histo_ep_data/tx bookkeeping under a critical
+   * section and prints its own one-line diagnostic, so the endpoint is
+   * usable again as soon as this returns. */
+  USBD_HISTO_FlushQueue("txstuck");
 }
 
 uint8_t  USBD_HISTO_SetTxBuffer(USBD_HandleTypeDef *pdev, uint8_t  *pbuff, uint16_t length)
@@ -490,6 +569,9 @@ uint8_t  USBD_HISTO_SetTxBuffer(USBD_HandleTypeDef *pdev, uint8_t  *pbuff, uint1
 		ret = USBD_LL_Transmit(pdev, HISTOInEpAdd, pTxHistoBuff, pkt_len);
 		if (ret == USBD_OK) {
 			histo_ep_data = 1;
+			/* Arm the stuck-TX watchdog against this transfer. */
+			histo_tx_armed_ms = HAL_GetTick();
+			histo_tx_progress = histo_datain_count;
 		} else {
 			histo_tx_fail_count++;
 			histo_ep_data = 0;

--- a/tests/_histo_wedge_reader.py
+++ b/tests/_histo_wedge_reader.py
@@ -1,0 +1,77 @@
+"""Child reader for test_histo_wedge_recovery_hil — meant to be hard-killed.
+
+Brings up two cameras, streams histograms, prints ``CHILD_STREAMING <bytes>``
+once frames are flowing, then reads until killed. It never tears anything
+down: the parent kills it with SIGKILL/taskkill, which is the only faithful
+way to produce "host reader process died mid-transfer".
+
+MotionInterface.stop() is NOT a substitute — ConnectionMonitor._teardown()
+drives every handle to DISCONNECTED so the transport releases cleanly, which
+is exactly the orderly shutdown this scenario must avoid.
+"""
+import queue
+import sys
+import time
+
+CAM_MASK = 0x03
+STREAM_TIMEOUT_S = 60.0
+
+
+def main():
+    side = sys.argv[1] if len(sys.argv) > 1 else "left"
+
+    from omotion import MotionInterface
+    from omotion.MotionProcessing import HISTOGRAM_BYTES
+
+    iface = MotionInterface()
+    iface.start(wait=False)
+    sensor = None
+    deadline = time.monotonic() + 25.0
+    while time.monotonic() < deadline and sensor is None:
+        sensor = next((s for s in iface.connected_sensors()
+                       if getattr(s, "side", None) == side), None)
+        time.sleep(0.3)
+    if sensor is None:
+        print("CHILD_FAIL no sensor", flush=True)
+        return 1
+
+    if not sensor.enable_camera_power(CAM_MASK):
+        print("CHILD_FAIL camera power", flush=True)
+        return 1
+    time.sleep(0.5)
+    if not sensor.program_fpga(camera_position=CAM_MASK, manual_process=False):
+        print("CHILD_FAIL program_fpga", flush=True)
+        return 1
+    time.sleep(0.1)
+    if not sensor.camera_configure_registers(CAM_MASK):
+        print("CHILD_FAIL configure", flush=True)
+        return 1
+
+    q = queue.Queue()
+    sensor.uart.histo.start_streaming(q, expected_size=HISTOGRAM_BYTES)
+    if not sensor.enable_camera(CAM_MASK) or not sensor.enable_aggregator_fsin():
+        print("CHILD_FAIL stream start", flush=True)
+        return 1
+
+    got = 0
+    announced = False
+    t_end = time.monotonic() + STREAM_TIMEOUT_S
+    while time.monotonic() < t_end:
+        try:
+            chunk = q.get(timeout=0.2)
+            if chunk:
+                got += len(chunk)
+        except queue.Empty:
+            pass
+        if not announced and got > 3 * HISTOGRAM_BYTES:
+            print(f"CHILD_STREAMING {got}", flush=True)
+            announced = True
+
+    # Only reached if the parent never killed us -- that is a test bug, and
+    # the parent treats it as one.
+    print("CHILD_NOT_KILLED", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_histo_wedge_recovery_hil.py
+++ b/tests/test_histo_wedge_recovery_hil.py
@@ -1,0 +1,321 @@
+"""HIL regression for the HISTO bulk IN endpoint wedge.
+
+Pre-fix firmware armed a multi-packet histogram transfer by setting
+histo_ep_data=1 in USBD_HISTO_SetTxBuffer, and only the DataIn complete
+callback ever cleared it. histo_ep_data also survived USB
+DeInit/Init untouched. So when a host reader process died mid-stream and
+a new one connected, the new session's SET_CONFIGURATION tore down the
+in-flight transfer (DataIn never fires) while histo_ep_data stayed 1:
+every later SetTxBuffer returned BUSY, the 4-entry histo_queue filled
+("HISTO enqueue fail: queue full ... deq=0"), and the endpoint was dead
+until power cycle. A USB device reset did not clear it either — reset
+runs the same DeInit/Init path that preserved the flag.
+
+Fixed by (a) clearing histo_ep_data and the TX bookkeeping in
+DeInit/Init, and (b) a stuck-TX watchdog serviced from the main loop: if
+a transfer has been armed for >500 ms with no DataIn progress, the
+firmware flushes the HISTO IN endpoint, clears histo_ep_data, and resets
+the frame queue.
+
+Two scenarios:
+
+* test_stream_resumes_within_one_session — the reader thread stops and
+  later resumes inside one USB session. This works even on pre-fix
+  firmware (the armed transfer simply completes once IN tokens return);
+  it guards against the watchdog breaking the healthy path.
+
+* test_new_session_streams_after_reader_died_mid_stream — the reader
+  session is torn down mid-stream without any firmware-side cleanup
+  (host process death) and a brand-new SDK session connects and reads.
+  On pre-fix firmware the new session gets 0 stream bytes.
+
+Run on a bench with a sensor attached (WinUSB via Zadig):
+
+    OPENMOTION_HIL=1 pytest tests/test_histo_wedge_recovery_hil.py
+    (PowerShell: $env:OPENMOTION_HIL = "1")
+
+Select the sensor side with OW_SENSOR_SIDE=left|right (default: right).
+
+Set OPENMOTION_POWER_CYCLE_CMD to a shell command (e.g. the bench Shelly
+script) and each test starts from a fresh boot, so a wedge left by a
+previous session can't fail the sanity phase:
+
+    OPENMOTION_POWER_CYCLE_CMD="python ...\\tests\\shelly.py cycle"
+"""
+import os
+import queue
+import subprocess
+import sys
+import threading
+import time
+
+import pytest
+
+requires_bench = pytest.mark.skipif(
+    os.environ.get("OPENMOTION_HIL") != "1",
+    reason="hardware-in-the-loop test; set OPENMOTION_HIL=1 on the bench",
+)
+
+CONNECT_TIMEOUT_S = 15.0
+
+# Same bring-up as the production ScanWorkflow: two cameras on the
+# aggregator.
+CAM_MASK = 0x03
+
+# One aggregated frame: 10-byte header (SOF, type, size, timestamp) +
+# per camera (SOH + cam_id + 4096 histogram + 4 temp + EOH) + CRC16 +
+# EOF — see send_histogram_data() in Core/Src/camera_manager.c.
+FRAME_BYTES = 10 + 2 * (1 + 1 + 4096 + 4 + 1) + 3
+
+# Each read phase lasts 5 s = 200 frames nominal at 40 Hz; demand a
+# quarter so USB hiccups don't flake the test while a dead stream (0
+# bytes on wedged firmware) still fails it loudly.
+PHASE_SECONDS = 5.0
+MIN_PHASE_BYTES = 50 * FRAME_BYTES
+
+# How long the firmware streams into the void with no host reader. Must
+# comfortably exceed the firmware's stuck-TX watchdog timeout (500 ms)
+# and be long enough that the histo_queue (4 entries, 25 ms cadence)
+# overflows many times over on pre-fix firmware.
+READER_DEAD_SECONDS = 3.0
+
+
+@pytest.fixture
+def bench_side():
+    """Power-cycle the bench sensor (if configured) and return its side."""
+    cycle_cmd = os.environ.get("OPENMOTION_POWER_CYCLE_CMD")
+    if cycle_cmd:
+        # Fresh boot so a wedge left by a prior session can't fail the
+        # sanity phase (see module docstring).
+        subprocess.run(cycle_cmd, shell=True, check=True, timeout=60)
+        time.sleep(8.0)  # re-enumeration settle
+    return os.environ.get("OW_SENSOR_SIDE", "right")
+
+
+# The SDK's Win32 hotplug provider registers its window class with the
+# first instance's ctypes wndproc thunk, and later MotionInterface
+# instances in the same process reuse that class (win32.py treats
+# ERROR_CLASS_ALREADY_EXISTS as "fine"). If the first instance is
+# garbage-collected, its thunk is freed and any later message dispatch —
+# e.g. DestroyWindow during stop() — faults natively and kills pytest.
+# This file creates several MotionInterface lifetimes per process, so
+# keep them all alive. SDK bug, tracked separately.
+_INTERFACE_KEEPALIVE = []
+
+
+def _connect(side):
+    """Start a fresh SDK session and return (interface, sensor handle)."""
+    from omotion import MotionInterface
+
+    interface = MotionInterface()
+    _INTERFACE_KEEPALIVE.append(interface)
+    interface.start(wait=False)
+    handle = interface.left if side == "left" else interface.right
+    deadline = time.monotonic() + CONNECT_TIMEOUT_S
+    while time.monotonic() < deadline and not handle.is_connected():
+        time.sleep(0.2)
+    if not handle.is_connected():
+        interface.stop()
+        pytest.fail(
+            f"{side} sensor not reachable in {CONNECT_TIMEOUT_S:.0f}s — "
+            "not plugged in, no WinUSB driver, or wedged from a previous "
+            "run (power-cycle it)."
+        )
+    return interface, handle
+
+
+def _bring_up(sensor):
+    """Power -> FPGA -> configure registers (matches ScanWorkflow)."""
+    assert sensor.enable_camera_power(CAM_MASK) is True
+    time.sleep(0.5)
+    assert sensor.program_fpga(camera_position=CAM_MASK, manual_process=False) is True
+    time.sleep(0.1)
+    assert sensor.camera_configure_registers(CAM_MASK) is True
+
+
+def _shut_down(sensor):
+    """Best-effort scan teardown; failures mean assertions already fired."""
+    try:
+        sensor.disable_aggregator_fsin()
+        sensor.disable_camera(CAM_MASK)
+        sensor.uart.histo.stop_streaming()
+        # NOTE: drain_final() used to run here to clear the host endpoint
+        # buffer, but it blocks forever in dev.read() after this scenario
+        # (bench-confirmed 2026-07-20, both sensors, every run) and hung
+        # the whole test in teardown. Tracked as an SDK bug; the fixture's
+        # power cycle already gives each test a clean endpoint.
+        sensor.disable_camera_power(CAM_MASK)
+    except Exception:
+        pass
+
+
+class _CountingReader:
+    """Host-side reader that tallies stream bytes off the packet queue."""
+
+    def __init__(self, histo, histogram_bytes):
+        self._histo = histo
+        self._histogram_bytes = histogram_bytes
+        self._queue = queue.Queue(maxsize=256)
+        self._stop_evt = threading.Event()
+        self.bytes_received = 0
+        self._thread = threading.Thread(target=self._drain, daemon=True)
+
+    def _drain(self):
+        while not self._stop_evt.is_set():
+            try:
+                chunk = self._queue.get(timeout=0.2)
+            except queue.Empty:
+                continue
+            if chunk:
+                self.bytes_received += len(chunk)
+
+    def start(self):
+        self._thread.start()
+        self._histo.start_streaming(
+            self._queue, expected_size=self._histogram_bytes
+        )
+
+    def stop(self) -> int:
+        self._histo.stop_streaming()
+        self._stop_evt.set()
+        self._thread.join(timeout=2.0)
+        return self.bytes_received
+
+
+def _counted_read(histo, histogram_bytes, seconds) -> int:
+    """One reader session: start, read for `seconds`, stop; return bytes."""
+    reader = _CountingReader(histo, histogram_bytes)
+    reader.start()
+    time.sleep(seconds)
+    return reader.stop()
+
+
+@requires_bench
+def test_stream_resumes_within_one_session(bench_side):
+    """Reader pauses and resumes inside one USB session: frames must flow
+    both before and after the pause. Passes on pre-fix firmware too (the
+    armed transfer completes once IN tokens return) — this guards the
+    healthy path against the stuck-TX watchdog itself (e.g. flushing an
+    endpoint the host is actively reading)."""
+    from omotion.MotionProcessing import HISTOGRAM_BYTES
+
+    interface, sensor = _connect(bench_side)
+    try:
+        assert sensor.ping() is True, "sensor not healthy before test"
+        _bring_up(sensor)
+        histo = sensor.uart.histo
+
+        histo.flush_stale_data(HISTOGRAM_BYTES)
+        reader = _CountingReader(histo, HISTOGRAM_BYTES)
+        reader.start()
+        assert sensor.enable_camera(CAM_MASK) is True
+        assert sensor.enable_aggregator_fsin() is True
+        time.sleep(PHASE_SECONDS)
+        phase1_bytes = reader.stop()
+        assert phase1_bytes >= MIN_PHASE_BYTES, (
+            f"stream never started: got {phase1_bytes} B in "
+            f"{PHASE_SECONDS:.0f}s, expected >= {MIN_PHASE_BYTES} B"
+        )
+
+        # Reader paused, firmware still streaming into the void.
+        time.sleep(READER_DEAD_SECONDS)
+
+        histo.flush_stale_data(HISTOGRAM_BYTES)
+        resumed_bytes = _counted_read(histo, HISTOGRAM_BYTES, PHASE_SECONDS)
+        assert resumed_bytes >= MIN_PHASE_BYTES, (
+            f"stream did not resume after in-session reader pause: got "
+            f"{resumed_bytes} B in {PHASE_SECONDS:.0f}s, expected >= "
+            f"{MIN_PHASE_BYTES} B"
+        )
+        assert sensor.ping() is True, "command interface unhealthy after resume"
+    finally:
+        _shut_down(sensor)
+        interface.stop()
+
+
+@requires_bench
+def test_new_session_streams_after_reader_died_mid_stream(bench_side):
+    """Host reader process dies mid-stream; a brand-new SDK session must
+    still receive frames.
+
+    Session A runs in a SEPARATE PROCESS that is hard-killed mid-stream —
+    no FSIN disable, no camera disable, no USB release, exactly what the
+    device sees when a host process dies. Session B then connects (its
+    SET_CONFIGURATION re-inits the USB classes mid-transfer) and reads.
+    On pre-fix firmware session B gets 0 stream bytes and only a power
+    cycle recovers the endpoint.
+
+    The kill has to be a real process kill. This test previously used
+    ``MotionInterface.stop()`` for session A, but
+    ``ConnectionMonitor._teardown()`` drives every handle to DISCONNECTED
+    so the transport releases cleanly — the orderly shutdown the scenario
+    must avoid. That made the test pass against firmware that was still
+    fully wedge-prone: bench-confirmed 2026-07-20 on one build, stop()
+    gave 401 frames while a hard kill gave 0 bytes. Do not "simplify" it
+    back to stop().
+    """
+    from omotion.MotionProcessing import HISTOGRAM_BYTES
+
+    side = bench_side
+
+    # --- session A: separate process, killed mid-stream ---
+    child = subprocess.Popen(
+        [sys.executable,
+         os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                      "_histo_wedge_reader.py"),
+         side],
+        stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True,
+    )
+    streaming_line = None
+    try:
+        deadline = time.monotonic() + 60.0
+        while time.monotonic() < deadline:
+            line = child.stdout.readline()
+            if not line:
+                break
+            line = line.strip()
+            if line.startswith("CHILD_STREAMING"):
+                streaming_line = line
+                break
+            if line.startswith("CHILD_FAIL"):
+                pytest.fail(f"session A could not stream: {line}")
+    finally:
+        # Hard kill: no teardown, no USB release. The firmware keeps
+        # producing frames into a transfer nobody will ever drain.
+        if sys.platform == "win32":
+            subprocess.run(["taskkill", "/F", "/T", "/PID", str(child.pid)],
+                           capture_output=True)
+        else:
+            child.kill()
+        try:
+            child.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            pass
+
+    assert streaming_line is not None, (
+        "session A never reached streaming state — bench problem (or "
+        "endpoint wedged by a previous run), not the regression under test"
+    )
+
+    time.sleep(READER_DEAD_SECONDS)
+
+    # --- session B: fresh process-equivalent connection must stream ---
+    interface_b, sensor_b = _connect(side)
+    try:
+        assert sensor_b.ping() is True, (
+            "command interface dead after reader death — worse than the "
+            "known HISTO wedge"
+        )
+        histo = sensor_b.uart.histo
+        histo.flush_stale_data(HISTOGRAM_BYTES)
+        session_b_bytes = _counted_read(histo, HISTOGRAM_BYTES, PHASE_SECONDS)
+        assert session_b_bytes >= MIN_PHASE_BYTES, (
+            f"HISTO endpoint wedged: new session after mid-stream reader "
+            f"death got {session_b_bytes} B in {PHASE_SECONDS:.0f}s, "
+            f"expected >= {MIN_PHASE_BYTES} B (power cycle required on "
+            "pre-fix firmware)"
+        )
+        assert sensor_b.ping() is True, "command interface unhealthy after recovery"
+    finally:
+        _shut_down(sensor_b)
+        interface_b.stop()


### PR DESCRIPTION
Refs #105 · host-side companion: OpenwaterHealth/openmotion-sdk#172

Resurrects work that was root-caused on 2026-06-11 and then lost — the branch was abandoned without ever taking a commit, so the firmware patch had to be rewritten from the notes. The HIL test survived as an untracked file and is included here.

## The bug

A histogram frame (32,837 B) ships as ~64 chained 512-byte packets, each armed by the previous packet's DataIn interrupt, with `histo_ep_data` marking "in flight". Only the DataIn completion path ever cleared that flag, and `Init`/`DeInit` reset the queue indices but **not** the flag.

So when a host reader process dies mid-chain, DataIn never fires again, `histo_ep_data` stays 1 forever, `histo_process_queue()` returns BUSY for every later frame, and the endpoint is dead until a power cycle. Reconnecting cannot clear it — a USB reset runs the same DeInit/Init path that preserved it.

## The fix

- Clear `histo_ep_data` + TX bookkeeping in **both** `Init` and `DeInit`, so an abandoned transfer cannot outlive the session that armed it.
- `USBD_HISTO_CheckTxStuck()`, serviced from the main loop: an armed transfer with no DataIn progress for 500 ms is abandoned via the existing `USBD_HISTO_FlushQueue()`. Keyed on lack of **progress**, not elapsed time, so a slow-but-advancing host is never interrupted.
- Drop sends when `dev_state != USBD_STATE_CONFIGURED`, so frames aren't pushed into a clock-gated core during selective suspend.

## Bench verification (left sensor)

Session A streams in a separate process, hard-killed (`taskkill /F`) mid-stream; session B then connects and reads for 5 s:

| Firmware | SDK | Session B |
|---|---|---|
| `next` (50afbf0) | EPIPE-patched | **0 B — wedged** |
| this PR | EPIPE-patched | 1,643,800 B (~401 frames) |
| this PR | stock | 1,643,800 B (~401 frames) |

The pre-fix row is the important one: with the patched SDK the host logs `pipe halted — clearing halt and resuming` and *still* receives nothing. Host-side recovery cannot fix this; the device has stopped sending.

Note this differs from the June finding that both halves were required. On current code the firmware fix alone is sufficient — the SDK PR stands on its own merits, not as a dependency.

## The test was lying

`test_histo_wedge_recovery_hil.py` already existed, and passed against fully wedge-prone firmware. It simulated reader death with `MotionInterface.stop()`, but `ConnectionMonitor._teardown()` drives every handle to DISCONNECTED and releases the transport **cleanly** — the orderly shutdown the scenario has to avoid. Same build, same day: `stop()` → 401 frames, hard kill → 0 bytes.

It now spawns a real child reader (`tests/_histo_wedge_reader.py`) and hard-kills it. Confirmed **failing on pre-fix firmware** (`got 0 B in 5s`) and **passing on this one** — the check that would have caught the rot, and which the previous version never performed.

`drain_final()` is out of the teardown path: it blocks forever against a dead endpoint and hung every run (OpenwaterHealth/openmotion-sdk#171).