### PR TITLE
Release 1.8.2 — dual boot-mode builds, camera telemetry, HISTO endpoint wedge fix

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -226,34 +226,81 @@ jobs:
           echo "Signed slot image: motion-sensor-fw-signed.bin (FwVersion=${{ steps.fwver.outputs.version }})"
 
       # ---------------------------
-      # Production image = bootloader (@0x08000000) + signed app (@0x08020000),
-      # merged into a single flashable image for factory programming.
+      # Production image = bootloader (@0x08000000) + signed app (@0x08020000)
+      # + camera FPGA bitstream (@0x081A0000), merged into a single flashable
+      # image for factory programming.
+      #
+      # The bitstream has to be in here. crosslink.c is compiled unconditionally
+      # (it is not behind BARE_METAL), so the slot application still programs the
+      # CrossLink from ADDR_CAMERA_BITSTREAM on every boot -- but the bootloader
+      # clamps its DFU window to the app slot, so nothing else can ever put a
+      # bitstream at 0x081A0000. Without it, a factory-fresh unit streams erased
+      # flash into the FPGA and comes up with no cameras. See issue #109.
       # ---------------------------
-      - name: Assemble production image (bootloader + signed app)
+      - name: Assemble production image (bootloader + signed app + FPGA bitstream)
         run: |
           set -euo pipefail
+          # Downloaded into the workspace by the bare-metal CMake configure above.
+          test -s fpga/openmotion-camera-fpga.bin
           python3 - <<'PY'
-          BL  = "_artifacts/openmotion-bl.bin"
-          APP = "_artifacts/motion-sensor-fw-signed.bin"
-          OUT = "_artifacts/motion-sensor-production.bin"
-          SLOT_OFFSET = 0x08020000 - 0x08000000   # 0x20000 (bootloader occupies sector 0)
-          bl  = open(BL, "rb").read()
-          app = open(APP, "rb").read()
+          import re
+
+          BL   = "_artifacts/openmotion-bl.bin"
+          APP  = "_artifacts/motion-sensor-fw-signed.bin"
+          FPGA = "fpga/openmotion-camera-fpga.bin"
+          OUT  = "_artifacts/motion-sensor-production.bin"
+
+          BASE        = 0x08000000
+          SLOT_OFFSET = 0x08020000 - BASE   # 0x20000  bootloader occupies sector 0
+          FPGA_OFFSET = 0x081A0000 - BASE   # 0x1A0000 bank 2 sectors 5-6
+          FPGA_LIMIT  = 0x081E0000 - BASE   # motion_config + serial sector starts here
+
+          bl   = open(BL, "rb").read()
+          app  = open(APP, "rb").read()
+          fpga = open(FPGA, "rb").read()
+
           if len(bl) > SLOT_OFFSET:
               raise SystemExit(f"bootloader ({len(bl)} B) overlaps app slot at 0x{SLOT_OFFSET:x}")
-          img = bytearray(b"\xff" * SLOT_OFFSET)
+          if SLOT_OFFSET + len(app) > FPGA_OFFSET:
+              raise SystemExit(f"signed app ({len(app)} B) overlaps FPGA bitstream at 0x{FPGA_OFFSET:x}")
+          if FPGA_OFFSET + len(fpga) > FPGA_LIMIT:
+              raise SystemExit(f"FPGA bitstream ({len(fpga)} B) overruns its region at 0x{FPGA_LIMIT:x}")
+
+          # crosslink.c streams a hardcoded byte count out of ADDR_CAMERA_BITSTREAM.
+          # A bitstream of any other size is sent truncated or over-read, and the
+          # failure only shows up as a dead FPGA on hardware -- catch it here.
+          src = open("Core/Src/crosslink.c").read()
+          m = re.search(r"ADDR_CAMERA_BITSTREAM\s*,\s*\(size_t\)\s*(\d+)\s*\)", src)
+          if not m:
+              raise SystemExit("could not find the bitstream length constant in Core/Src/crosslink.c")
+          if int(m.group(1)) != len(fpga):
+              raise SystemExit(
+                  f"bitstream is {len(fpga)} B but crosslink.c streams {m.group(1)} B "
+                  f"-- update the constant in Core/Src/crosslink.c")
+
+          img = bytearray(b"\xff" * FPGA_OFFSET)
           img[:len(bl)] = bl
-          img += app
+          img[SLOT_OFFSET:SLOT_OFFSET + len(app)] = app
+          img += fpga
           with open(OUT, "wb") as f:
               f.write(img)
-          print(f"production image: {len(img)} bytes (bootloader={len(bl)} B, signed app={len(app)} B)")
+          print(f"production image: {len(img)} bytes (bootloader={len(bl)} B, "
+                f"signed app={len(app)} B, fpga={len(fpga)} B)")
           PY
-          # Intel-HEX view of the same image at load base 0x08000000
+          # Intel-HEX view, built from the three pieces rather than converted from
+          # the padded .bin: a flat conversion would emit ~1.4 MB of 0xFF records
+          # for the gaps and make flashing take far longer than it needs to.
           docker run --rm \
             -v "$GITHUB_WORKSPACE":/workspace \
             -w /workspace \
             ghcr.io/openwaterhealth/stm32-build-env:latest \
-            bash -lc "arm-none-eabi-objcopy -I binary -O ihex --change-addresses=0x08000000 _artifacts/motion-sensor-production.bin _artifacts/motion-sensor-production.hex"
+            bash -lc 'set -e
+              arm-none-eabi-objcopy -I binary -O ihex --change-addresses=0x08000000 _artifacts/openmotion-bl.bin             _artifacts/_prod_bl.hex
+              arm-none-eabi-objcopy -I binary -O ihex --change-addresses=0x08020000 _artifacts/motion-sensor-fw-signed.bin  _artifacts/_prod_app.hex
+              arm-none-eabi-objcopy -I binary -O ihex --change-addresses=0x081A0000 fpga/openmotion-camera-fpga.bin         _artifacts/_prod_fpga.hex'
+          python3 merge_hex.py _artifacts/motion-sensor-production.hex \
+            _artifacts/_prod_bl.hex _artifacts/_prod_app.hex _artifacts/_prod_fpga.hex
+          rm -f _artifacts/_prod_bl.hex _artifacts/_prod_app.hex _artifacts/_prod_fpga.hex
           test -s _artifacts/motion-sensor-production.hex
 
       # Collect the two bare-metal images with unambiguous names (the bare-metal
@@ -275,7 +322,8 @@ jobs:
       #   - baremetal      : standalone app @0x08000000, no bootloader, no FPGA
       #   - baremetal-fpga : standalone app + FPGA bitstream, single flash image
       #   - signed         : app @0x08020400 signed for the bootloader slot
-      #   - production     : bootloader + signed app, single factory image
+      #   - production     : bootloader + signed app + FPGA bitstream, single
+      #                      factory image
       - name: Upload bare-metal (app only) artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -1,18 +1,45 @@
 name: Build firmware using published build image
 
 on:
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      bl_release:
+        description: "open-motion-sensor-bl release tag to bundle into the production image (default: latest)"
+        required: false
+        default: "latest"
   push:
     branches: [ "main", "next" ]
     tags:
       - "*.*.*"
       - "*.*.*-rc.*"
       - "*.*.*-dev.*"
-  release:
-    types: [created]
 
 permissions:
-  contents: write 
+  contents: write
+
+# ---------------------------------------------------------------------------
+# Required repository secrets (Settings -> Secrets and variables -> Actions):
+#
+#   FW_SIGNING_KEY     ECDSA P-256 *private* signing key, full PEM (multi-line).
+#                      MUST be the private half of the public key embedded in the
+#                      open-motion-sensor-bl bootloader (SECoreBin). Used to sign
+#                      the slot image so the bootloader will accept it. This is the
+#                      SENSOR key — it is NOT the console key. NEVER commit this.
+#
+#   SECOREBIN_AES_KEY  AES-128 key as base64 of the raw 16 bytes. Same value as the
+#                      open-motion-sensor-bl secret of the same name. The CBC crypto
+#                      scheme's sign step requires it (sign_firmware.py --aes-key).
+#
+#   BL_REPO_TOKEN      PAT / fine-grained token with *read* access to
+#                      OpenwaterHealth/open-motion-sensor-bl (contents + releases).
+#                      Needed only because that repo is private: used to check out
+#                      py-tools/sign_firmware.py and to download the bootloader
+#                      release binary. Falls back to GITHUB_TOKEN if the bl repo is
+#                      made public.
+#
+# The AES + ECDSA keypair MUST match what is embedded in open-motion-sensor-bl.
+# A mismatch silently produces a bootloader that rejects this firmware.
+# ---------------------------------------------------------------------------
 
 jobs:
   build:
@@ -22,8 +49,30 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0        # full history so git-describe works
-          fetch-tags: true       # ensure all tags are present
+          fetch-depth: 0
+          fetch-tags: true
+
+      # Fail fast (before the minutes-long builds) with a clear message if any
+      # signing/bootloader secret is missing, instead of the cryptic
+      # "set the GH_TOKEN environment variable" error deep in the run.
+      - name: Check required secrets
+        env:
+          FW_SIGNING_KEY: ${{ secrets.FW_SIGNING_KEY }}
+          SECOREBIN_AES_KEY: ${{ secrets.SECOREBIN_AES_KEY }}
+          BL_REPO_TOKEN: ${{ secrets.BL_REPO_TOKEN }}
+        run: |
+          missing=0
+          for v in FW_SIGNING_KEY SECOREBIN_AES_KEY BL_REPO_TOKEN; do
+            if [ -z "${!v}" ]; then
+              echo "::error::Required secret '$v' is not set. Add it under" \
+                   "Settings -> Secrets and variables -> Actions. BL_REPO_TOKEN" \
+                   "must be a PAT with read access to OpenwaterHealth/open-motion-sensor-bl."
+              missing=1
+            fi
+          done
+          [ "$missing" = "0" ] || exit 1
+          echo "All required secrets present."
+
       # ---------------------------
       # Determine build config from the ref:
       #   *-dev.* tag            -> Debug   (development pre-release)
@@ -50,75 +99,240 @@ jobs:
           echo "ref='$GITHUB_REF' event='$GITHUB_EVENT_NAME' tag='$TAG_NAME' -> build config: $CONFIG"
 
       # ---------------------------
-      # Build Firmware
+      # FwVersion is a uint16 consumed by the bootloader's monotonic anti-rollback
+      # floor. Derive it from a release tag X.Y.Z as X*10000 + Y*100 + Z (supports
+      # up to 6.55.35); non-release builds sign as version 1.
+      # WARNING: anti-rollback means a unit that has booted version N will REFUSE
+      # any image < N until re-flashed. Keep release versions monotonic. Revisit
+      # this mapping if the versioning policy changes.
       # ---------------------------
+      - name: Compute signing FW version
+        id: fwver
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if [[ "$GITHUB_REF" == refs/tags/* && "$TAG" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+            V=$(( ${BASH_REMATCH[1]}*10000 + ${BASH_REMATCH[2]}*100 + ${BASH_REMATCH[3]} ))
+            [ "$V" -lt 1 ] && V=1
+            [ "$V" -gt 65535 ] && V=65535
+          else
+            V=1
+          fi
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+          echo "Signing FwVersion: $V"
+
       - name: Pull build image
         run: docker pull ghcr.io/openwaterhealth/stm32-build-env:latest
 
-      - name: Build inside container
+      # Slot image: runs under the custom bootloader from the active slot
+      # (linked at 0x08020400). App-only, no FPGA merge -> directly signable.
+      # This is the image that gets signed.
+      - name: Build slot image (@0x08020400)
         run: |
           docker run --rm \
             -v "$GITHUB_WORKSPACE":/workspace \
             -w /workspace \
-            --workdir /workspace \
             ghcr.io/openwaterhealth/stm32-build-env:latest \
-            bash -lc "git config --global --add safe.directory /workspace || true; cmake --preset ${{ steps.cfg.outputs.config }} && cmake --build build/${{ steps.cfg.outputs.config }} --config ${{ steps.cfg.outputs.config }} --target all -j 10"
+            bash -lc "git config --global --add safe.directory /workspace && cmake --preset ${{ steps.cfg.outputs.config }} && cmake --build build/${{ steps.cfg.outputs.config }} --config ${{ steps.cfg.outputs.config }} --target all -j 10"
+
+      # Bare-metal image: standalone at 0x08000000, no bootloader (BARE_METAL=ON).
+      # This build emits BOTH:
+      #   motion-sensor-fw-raw.{bin,hex}  = app only (no FPGA)
+      #   motion-sensor-fw.{bin,hex}      = app + FPGA bitstream merged @0x081A0000
+      - name: Build bare-metal image (@0x08000000)
+        run: |
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE":/workspace \
+            -w /workspace \
+            ghcr.io/openwaterhealth/stm32-build-env:latest \
+            bash -lc "git config --global --add safe.directory /workspace && cmake --preset ${{ steps.cfg.outputs.config }}-BareMetal && cmake --build build/${{ steps.cfg.outputs.config }}-BareMetal --config ${{ steps.cfg.outputs.config }} --target all -j 10"
 
       # ---------------------------
-      # Upload Firmware
+      # Resolve which open-motion-sensor-bl release to bundle. Uses the
+      # workflow_dispatch input when given, otherwise the latest published
+      # bootloader release.
       # ---------------------------
-      - name: Upload firmware artifact
+      - name: Resolve open-motion-sensor-bl release tag
+        id: bl
+        env:
+          GH_TOKEN: ${{ secrets.BL_REPO_TOKEN }}
+        run: |
+          set -euo pipefail
+          REQ="${{ github.event.inputs.bl_release }}"
+          if [ -z "$REQ" ] || [ "$REQ" = "latest" ]; then
+            TAG=$(gh release view --repo OpenwaterHealth/open-motion-sensor-bl --json tagName --jq .tagName)
+          else
+            TAG="$REQ"
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "Bundling open-motion-sensor-bl @ $TAG"
+
+      # Pull the signing tool + public key from the SAME pinned bootloader version
+      # so the signing format always matches the bootloader that will verify it.
+      - name: Fetch signing tool from open-motion-sensor-bl
+        uses: actions/checkout@v4
+        with:
+          repository: OpenwaterHealth/open-motion-sensor-bl
+          ref: ${{ steps.bl.outputs.tag }}
+          token: ${{ secrets.BL_REPO_TOKEN }}
+          path: _bl
+          sparse-checkout: py-tools
+
+      - name: Download bootloader binary from open-motion-sensor-bl release
+        env:
+          GH_TOKEN: ${{ secrets.BL_REPO_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p _artifacts
+          gh release download "${{ steps.bl.outputs.tag }}" \
+            --repo OpenwaterHealth/open-motion-sensor-bl \
+            --pattern 'openmotion-bl.bin' \
+            --dir _artifacts --clobber
+          test -s _artifacts/openmotion-bl.bin
+
+      # ---------------------------
+      # Sign the slot image with the ECDSA private key (+ AES key) from secrets.
+      # The slot build's motion-sensor-fw.bin is already app-only (FPGA is merged
+      # only in bare-metal builds), so it is signed directly. Keys are materialised
+      # only into a tmp dir and removed after use; never written into the repo tree.
+      # ---------------------------
+      - name: Sign the slot image
+        env:
+          FW_SIGNING_KEY: ${{ secrets.FW_SIGNING_KEY }}
+          SECOREBIN_AES_KEY: ${{ secrets.SECOREBIN_AES_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "$FW_SIGNING_KEY" ] || [ -z "$SECOREBIN_AES_KEY" ]; then
+            echo "::error::FW_SIGNING_KEY and SECOREBIN_AES_KEY secrets must be set to sign the slot image." >&2
+            exit 1
+          fi
+          python3 -m pip install --quiet 'cryptography>=41'
+          KD="$(mktemp -d)"
+          trap 'rm -rf "$KD"' EXIT
+          printf '%s\n' "$FW_SIGNING_KEY" > "$KD/ecdsa_private.pem"
+          printf '%s' "$SECOREBIN_AES_KEY" | base64 -d > "$KD/aes128.bin"
+          if [ "$(wc -c < "$KD/aes128.bin")" -ne 16 ]; then
+            echo "::error::Decoded AES key is not 16 bytes — check SECOREBIN_AES_KEY." >&2
+            exit 1
+          fi
+          APP="build/${{ steps.cfg.outputs.config }}/motion-sensor-fw.bin"
+          test -s "$APP"
+          python3 _bl/py-tools/sign_firmware.py \
+            --firmware "$APP" \
+            --private-key "$KD/ecdsa_private.pem" \
+            --aes-key "$KD/aes128.bin" \
+            --version "${{ steps.fwver.outputs.version }}" \
+            --output _artifacts/motion-sensor-fw-signed.bin
+          test -s _artifacts/motion-sensor-fw-signed.bin
+          echo "Signed slot image: motion-sensor-fw-signed.bin (FwVersion=${{ steps.fwver.outputs.version }})"
+
+      # ---------------------------
+      # Production image = bootloader (@0x08000000) + signed app (@0x08020000),
+      # merged into a single flashable image for factory programming.
+      # ---------------------------
+      - name: Assemble production image (bootloader + signed app)
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          BL  = "_artifacts/openmotion-bl.bin"
+          APP = "_artifacts/motion-sensor-fw-signed.bin"
+          OUT = "_artifacts/motion-sensor-production.bin"
+          SLOT_OFFSET = 0x08020000 - 0x08000000   # 0x20000 (bootloader occupies sector 0)
+          bl  = open(BL, "rb").read()
+          app = open(APP, "rb").read()
+          if len(bl) > SLOT_OFFSET:
+              raise SystemExit(f"bootloader ({len(bl)} B) overlaps app slot at 0x{SLOT_OFFSET:x}")
+          img = bytearray(b"\xff" * SLOT_OFFSET)
+          img[:len(bl)] = bl
+          img += app
+          with open(OUT, "wb") as f:
+              f.write(img)
+          print(f"production image: {len(img)} bytes (bootloader={len(bl)} B, signed app={len(app)} B)")
+          PY
+          # Intel-HEX view of the same image at load base 0x08000000
+          docker run --rm \
+            -v "$GITHUB_WORKSPACE":/workspace \
+            -w /workspace \
+            ghcr.io/openwaterhealth/stm32-build-env:latest \
+            bash -lc "arm-none-eabi-objcopy -I binary -O ihex --change-addresses=0x08000000 _artifacts/motion-sensor-production.bin _artifacts/motion-sensor-production.hex"
+          test -s _artifacts/motion-sensor-production.hex
+
+      # Collect the two bare-metal images with unambiguous names (the bare-metal
+      # build emits both an app-only -raw image and an FPGA-merged image sharing
+      # the motion-sensor-fw.* basename).
+      - name: Collect bare-metal artifacts
+        run: |
+          set -euo pipefail
+          BM="build/${{ steps.cfg.outputs.config }}-BareMetal"
+          # app only (no FPGA)
+          cp "$BM/motion-sensor-fw-raw.bin" _artifacts/motion-sensor-fw-baremetal.bin
+          cp "$BM/motion-sensor-fw-raw.hex" _artifacts/motion-sensor-fw-baremetal.hex
+          # app + FPGA bitstream merged
+          cp "$BM/motion-sensor-fw.bin" _artifacts/motion-sensor-fw-baremetal-fpga.bin
+          cp "$BM/motion-sensor-fw.hex" _artifacts/motion-sensor-fw-baremetal-fpga.hex
+
+      # Upload as four separate, clearly-named artifacts (each shows as its own
+      # row) rather than one opaque bundle:
+      #   - baremetal      : standalone app @0x08000000, no bootloader, no FPGA
+      #   - baremetal-fpga : standalone app + FPGA bitstream, single flash image
+      #   - signed         : app @0x08020400 signed for the bootloader slot
+      #   - production     : bootloader + signed app, single factory image
+      - name: Upload bare-metal (app only) artifact
         uses: actions/upload-artifact@v4
         with:
-          name: motion-sensor-fw
+          name: motion-sensor-fw-baremetal
+          if-no-files-found: error
           path: |
-            build/${{ steps.cfg.outputs.config }}/*.hex
-            build/${{ steps.cfg.outputs.config }}/*.bin
+            _artifacts/motion-sensor-fw-baremetal.bin
+            _artifacts/motion-sensor-fw-baremetal.hex
 
+      - name: Upload bare-metal (app + FPGA) artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: motion-sensor-fw-baremetal-fpga
+          if-no-files-found: error
+          path: |
+            _artifacts/motion-sensor-fw-baremetal-fpga.bin
+            _artifacts/motion-sensor-fw-baremetal-fpga.hex
 
-      # ---------------------------
-      # Create GitHub Release (tags only)
-      # ---------------------------
+      - name: Upload signed slot artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: motion-sensor-fw-signed
+          if-no-files-found: error
+          path: _artifacts/motion-sensor-fw-signed.bin
+
+      - name: Upload production artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: motion-sensor-production
+          if-no-files-found: error
+          path: |
+            _artifacts/motion-sensor-production.bin
+            _artifacts/motion-sensor-production.hex
+
       - name: Detect release type
         id: reltype
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
-          if [ "$GITHUB_EVENT_NAME" = "release" ]; then
-            TAG_NAME=$(python3 -c "import json,sys;print(json.load(open('$GITHUB_EVENT_PATH'))['release']['tag_name'])")
+          TAG_NAME="${GITHUB_REF_NAME}"
+
+          if [[ "$TAG_NAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+-(rc|dev)\.[0-9]+$ ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$TAG_NAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
           else
-            TAG_NAME="${GITHUB_REF_NAME}"
+            echo "Unrecognized tag format: $TAG_NAME" >&2
+            exit 1
           fi
 
-          echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
-
-          if [[ "$TAG_NAME" == *"-rc."* ]] || [[ "$TAG_NAME" == *"-dev."* ]]; then
-            echo "prerelease=true" >> $GITHUB_OUTPUT
-          else
-            echo "prerelease=false" >> $GITHUB_OUTPUT
-          fi
-          # Compute release display name:
-          if [[ "$TAG_NAME" == pre-* ]]; then
-            BASE=${TAG_NAME#pre-}
-            if [[ "$BASE" == v* ]]; then
-              RELEASE_NAME="pre-${BASE}"
-            else
-              RELEASE_NAME="pre-v${BASE}"
-            fi
-          elif [[ "$TAG_NAME" == v* ]]; then
-            RELEASE_NAME="$TAG_NAME"
-          else
-            RELEASE_NAME="v${TAG_NAME}"
-          fi
-
-          echo "release_name=$RELEASE_NAME" >> $GITHUB_OUTPUT
-          
       - name: Capture build metadata
         id: buildmeta
         run: |
-          echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          echo "datetime=$(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_OUTPUT
+          echo "sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "datetime=$(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> "$GITHUB_OUTPUT"
 
       - name: Generate release notes
-        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'release'
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           : > notes.md
 
@@ -127,31 +341,38 @@ jobs:
             echo "" >> notes.md
           fi
 
-          PREV_TAG=$(git tag --sort=-creatordate | sed -n '2p')
+          PREV_TAG=$(git tag --sort=-creatordate | grep -v "^${GITHUB_REF_NAME}$" | head -n 1)
 
           if [ -z "$PREV_TAG" ]; then
             git log --pretty=format:"- %s" >> notes.md
           else
-            git log ${PREV_TAG}..HEAD --pretty=format:"- %s" >> notes.md
+            git log "$PREV_TAG"..HEAD --pretty=format:"- %s" >> notes.md
           fi
 
+          echo "" >> notes.md
           echo "" >> notes.md
           echo "---" >> notes.md
           echo "**Build SHA:** \`${{ steps.buildmeta.outputs.sha }}\`" >> notes.md
           echo "**Build Time:** ${{ steps.buildmeta.outputs.datetime }}" >> notes.md
           echo "**Build Config:** ${{ steps.cfg.outputs.config }}" >> notes.md
+          echo "**Bundled bootloader:** \`${{ steps.bl.outputs.tag }}\`" >> notes.md
+          echo "**Signed FwVersion:** \`${{ steps.fwver.outputs.version }}\`" >> notes.md
 
       - name: Create GitHub Release
-        if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'release'
+        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v2
         with:
-          draft: false
-          prerelease: ${{ steps.reltype.outputs.prerelease }}
-          allow_updates: ${{ steps.reltype.outputs.prerelease }}
-          replace_existing_artifacts: ${{ steps.reltype.outputs.prerelease }}
+          tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
+          prerelease: ${{ steps.reltype.outputs.prerelease }}
           body_path: notes.md
+          overwrite_files: true
+          make_latest: ${{ steps.reltype.outputs.prerelease == 'false' }}
           files: |
-            build/${{ steps.cfg.outputs.config }}/*.hex
-            build/${{ steps.cfg.outputs.config }}/*.bin
-
+            _artifacts/motion-sensor-fw-baremetal.bin
+            _artifacts/motion-sensor-fw-baremetal.hex
+            _artifacts/motion-sensor-fw-baremetal-fpga.bin
+            _artifacts/motion-sensor-fw-baremetal-fpga.hex
+            _artifacts/motion-sensor-fw-signed.bin
+            _artifacts/motion-sensor-production.bin
+            _artifacts/motion-sensor-production.hex

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # openmotion-sensor-fw — Claude guide
 
-Firmware for the sensor-module MCU (STM32H743VIH6). Drives 8 OV2312 cameras through a Lattice CrossLink FPGA, exposes a composite USB device (three bulk interfaces: COMMS, HISTO, IMU) to the host, and ships a `.hex` that merges the firmware + the FPGA bitstream into one programmable image.
+Firmware for the sensor-module MCU (STM32H743VIH6). Drives 8 OX02C1B cameras through a Lattice CrossLink FPGA, exposes a composite USB device (three bulk interfaces: COMMS, HISTO, IMU) to the host, and ships a `.hex` that merges the firmware + the FPGA bitstream into one programmable image.
 
 Cross-repo context + shared protocol: [../CLAUDE.md](../CLAUDE.md). Authoritative protocol spec lives in [../openmotion-console-fw/CommandHandling.md](../openmotion-console-fw/CommandHandling.md).
 
@@ -108,7 +108,7 @@ Note: the parent CLAUDE.md historically claimed 384 KB for the FPGA region — t
 | `Core/Src/main.c` | Init, event loop, USB setup, GPIO / IRQ handlers. |
 | `Core/Src/if_commands.c` | Command dispatcher — handlers in `app_handle_uartframe()`. |
 | `Core/Src/camera_manager.c` | 8-camera orchestration, histogram streaming. SPI6 read from FPGA → `frame_buffer` → USB HISTO. |
-| `Core/Src/0X02C1B.c` | OV2312 image-sensor register config (the file is literally named after the part). |
+| `Core/Src/0X02C1B.c` | OX02C1B image-sensor register config (the file is named after the part). |
 | `Core/Src/crosslink.c` | Lattice CrossLink FPGA — I2C activation, IDCODE check, SRAM erase/program, status verify. Bitstream size hardcoded as `163489`. |
 | `Core/Src/ICM20948.c` | 6-DOF IMU + magnetometer driver. |
 | `Core/Src/uart_comms.c` | UART packet framing with CRC-16. |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,11 +71,43 @@ message("Build type: " ${CMAKE_BUILD_TYPE})
 # Enable CMake support for ASM and C languages
 enable_language(C ASM)
 
+# ---------------------------------------------------------------------------
+# Boot mode: run under the custom secure bootloader (default) or bare-metal.
+#   OFF (default): image runs from the bootloader's active slot (linked at
+#                  0x08020400, VTOR relocated there). A DFU request hands control
+#                  back to the custom bootloader via the RTC->BKP7R magic.
+#   ON           : bare-metal image at 0x08000000 with NO bootloader. A DFU
+#                  request jumps to the STM32 system-memory ROM bootloader
+#                  (0x1FF09800). Matches openmotion-console-fw.
+# ---------------------------------------------------------------------------
+option(BARE_METAL "Build a bare-metal image (no custom bootloader; runs at 0x08000000)" OFF)
+
 # Create an executable object type
 add_executable(${CMAKE_PROJECT_NAME})
 
+# Select the linker script based on the BARE_METAL option. The matching
+# BARE_METAL_BUILD compile definition is applied to the stm32cubemx interface
+# library below so the STM32 drivers — notably system_stm32h7xx.c, which owns the
+# VTOR base address and the ROM-bootloader jump — pick it up alongside the app.
+if(BARE_METAL)
+    set(LINKER_SCRIPT "${CMAKE_SOURCE_DIR}/STM32H743XX_FLASH_BARE.ld")
+    message(STATUS "Boot mode    : BARE METAL (0x08000000, DFU -> ROM bootloader)")
+else()
+    set(LINKER_SCRIPT "${CMAKE_SOURCE_DIR}/STM32H743XX_FLASH.ld")
+    message(STATUS "Boot mode    : custom bootloader slot (0x08020400)")
+endif()
+target_link_options(${CMAKE_PROJECT_NAME} PRIVATE -T "${LINKER_SCRIPT}")
+set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES LINK_DEPENDS "${LINKER_SCRIPT}")
+
 # Add STM32CubeMX generated sources
 add_subdirectory(cmake/stm32cubemx)
+
+# Propagate the boot-mode define to every translation unit (application sources
+# and the STM32 drivers), so system_stm32h7xx.c relocates VTOR and gates the
+# ROM-bootloader jump correctly.
+if(BARE_METAL)
+    target_compile_definitions(stm32cubemx INTERFACE BARE_METAL_BUILD=1)
+endif()
 
 # Link directories setup
 target_link_directories(${CMAKE_PROJECT_NAME} PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,6 +123,7 @@ target_sources(${CMAKE_PROJECT_NAME} PRIVATE
     USB/Class/IMU/Src/usbd_imu.c
     Core/Src/0X02C1B.c
     Core/Src/camera_manager.c
+    Core/Src/camera_telemetry.c
     Core/Src/crosslink.c
     Core/Src/histo_fake.c
     Core/Src/i2c_protocol.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,11 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
     # Add user defined libraries
 )
 
+# FPGA bitstream: only needed for the BARE-METAL image, where it is merged into
+# the flashed .hex/.bin. In bootloader-slot mode the app is signed app-only and
+# the FPGA is flashed separately at 0x081A0000, so the download + merge are
+# skipped entirely (and the slot .hex/.bin are the plain, directly-signable app).
+if(BARE_METAL)
 # FPGA bitstream binary (always fetch latest from GitHub releases)
 set(FPGA_BITSTREAM_BIN ${CMAKE_SOURCE_DIR}/fpga/openmotion-camera-fpga.bin)
 set(FPGA_BITSTREAM_URL "https://github.com/OpenwaterHealth/openmotion-camera-fpga/releases/latest/download/openmotion-camera-fpga.bin")
@@ -195,6 +200,7 @@ if(NOT FPGA_DOWNLOAD_ERROR EQUAL 0)
     message(FATAL_ERROR "Failed to download FPGA bitstream: ${FPGA_DOWNLOAD_MSG}")
 endif()
 message(STATUS "FPGA bitstream downloaded to ${FPGA_BITSTREAM_BIN}")
+endif()
 
 # Locate a Python interpreter for build-time scripts (e.g. merge_hex.py).
 # Prefer python3, fall back to python (Windows installers often ship only "python").
@@ -205,32 +211,45 @@ if(NOT PYTHON_EXECUTABLE)
 endif()
 message(STATUS "Using Python interpreter: ${PYTHON_EXECUTABLE}")
 
-# Generate hex and bin files after build
-add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
-    # Generate firmware hex and bin
-    COMMAND ${CMAKE_OBJCOPY} -O ihex $<TARGET_FILE:${CMAKE_PROJECT_NAME}> ${CMAKE_PROJECT_NAME}-raw.hex
-    COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:${CMAKE_PROJECT_NAME}> ${CMAKE_PROJECT_NAME}-raw.bin
+# Generate hex and bin files after build.
+if(BARE_METAL)
+    # Bare-metal: merge the FPGA bitstream into the flashed image so a single
+    # .hex/.bin flashed at 0x08000000 brings up both the app and the FPGA.
+    add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
+        # Generate firmware hex and bin
+        COMMAND ${CMAKE_OBJCOPY} -O ihex $<TARGET_FILE:${CMAKE_PROJECT_NAME}> ${CMAKE_PROJECT_NAME}-raw.hex
+        COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:${CMAKE_PROJECT_NAME}> ${CMAKE_PROJECT_NAME}-raw.bin
 
-    # Convert FPGA bitstream to hex at the target flash address
-    COMMAND ${CMAKE_OBJCOPY} -I binary -O ihex
-        --change-addresses ${FPGA_BITSTREAM_ADDR}
-        ${FPGA_BITSTREAM_BIN}
-        openmotion-camera-fpga.hex
+        # Convert FPGA bitstream to hex at the target flash address
+        COMMAND ${CMAKE_OBJCOPY} -I binary -O ihex
+            --change-addresses ${FPGA_BITSTREAM_ADDR}
+            ${FPGA_BITSTREAM_BIN}
+            openmotion-camera-fpga.hex
 
-    # Merge firmware + FPGA bitstream into a single hex file
-    COMMAND ${CMAKE_COMMAND} -E echo "Merging firmware + FPGA bitstream hex files..."
-    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/merge_hex.py
-        ${CMAKE_PROJECT_NAME}.hex
-        ${CMAKE_PROJECT_NAME}-raw.hex
-        openmotion-camera-fpga.hex
+        # Merge firmware + FPGA bitstream into a single hex file
+        COMMAND ${CMAKE_COMMAND} -E echo "Merging firmware + FPGA bitstream hex files..."
+        COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/merge_hex.py
+            ${CMAKE_PROJECT_NAME}.hex
+            ${CMAKE_PROJECT_NAME}-raw.hex
+            openmotion-camera-fpga.hex
 
-    # Generate combined bin from merged hex (for DFU flashing)
-    COMMAND ${CMAKE_OBJCOPY} -I ihex -O binary
-        ${CMAKE_PROJECT_NAME}.hex
-        ${CMAKE_PROJECT_NAME}.bin
+        # Generate combined bin from merged hex (for direct flashing)
+        COMMAND ${CMAKE_OBJCOPY} -I ihex -O binary
+            ${CMAKE_PROJECT_NAME}.hex
+            ${CMAKE_PROJECT_NAME}.bin
 
-    COMMENT "Generating .hex/.bin and merging FPGA bitstream at ${FPGA_BITSTREAM_ADDR}"
-)
+        COMMENT "Generating .hex/.bin and merging FPGA bitstream at ${FPGA_BITSTREAM_ADDR}"
+    )
+else()
+    # Bootloader-slot: plain application image, NO FPGA merge. motion-sensor-fw.bin
+    # is the app-only image that gets signed for the bootloader; the FPGA bitstream
+    # is flashed separately at 0x081A0000.
+    add_custom_command(TARGET ${CMAKE_PROJECT_NAME} POST_BUILD
+        COMMAND ${CMAKE_OBJCOPY} -O ihex   $<TARGET_FILE:${CMAKE_PROJECT_NAME}> ${CMAKE_PROJECT_NAME}.hex
+        COMMAND ${CMAKE_OBJCOPY} -O binary $<TARGET_FILE:${CMAKE_PROJECT_NAME}> ${CMAKE_PROJECT_NAME}.bin
+        COMMENT "Generating .hex/.bin (bootloader slot; app-only, FPGA flashed separately)"
+    )
+endif()
 
 # Build + DFU-flash targets, one per sensor side. Invokes scripts/deploy.py.
 # `--device` is required by the script, so we expose two separate targets.

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -23,6 +23,22 @@
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release"
             }
+        },
+        {
+            "name": "Debug-BareMetal",
+            "inherits": "default",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "BARE_METAL": "ON"
+            }
+        },
+        {
+            "name": "Release-BareMetal",
+            "inherits": "default",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "BARE_METAL": "ON"
+            }
         }
     ],
     "buildPresets": [
@@ -33,6 +49,14 @@
         {
             "name": "Release",
             "configurePreset": "Release"
+        },
+        {
+            "name": "Debug-BareMetal",
+            "configurePreset": "Debug-BareMetal"
+        },
+        {
+            "name": "Release-BareMetal",
+            "configurePreset": "Release-BareMetal"
         }
     ]
 }

--- a/Core/Inc/camera_manager.h
+++ b/Core/Inc/camera_manager.h
@@ -51,7 +51,7 @@ typedef struct {
 
 #define CAMERA_COUNT	8
 /* How long a dead camera's rail is held off so the camera-module PCB power
- * regulator (supplies both the CrossLink FPGA and the OV2312) can cool and
+ * regulator (supplies both the CrossLink FPGA and the OX02C1B) can cool and
  * clear its thermal-shutdown latch. */
 #define CAMERA_RECOVERY_OFF_MS	10000
 #define HISTOGRAM_DATA_SIZE	4100

--- a/Core/Inc/camera_manager.h
+++ b/Core/Inc/camera_manager.h
@@ -90,6 +90,7 @@ _Bool enter_sram_prog_fpga(uint8_t cam_id);
 _Bool exit_sram_prog_fpga(uint8_t cam_id);
 _Bool erase_sram_fpga(uint8_t cam_id);
 _Bool program_fpga(uint8_t cam_id, _Bool force_update);
+_Bool camera_nvcm_boot_probe(uint8_t cam_id, _Bool *booted);
 _Bool configure_camera_sensor(uint8_t cam_id);
 _Bool configure_camera_testpattern(uint8_t cam_id, uint8_t test_pattern);
 _Bool capture_single_histogram(uint8_t cam_id);

--- a/Core/Inc/camera_telemetry.h
+++ b/Core/Inc/camera_telemetry.h
@@ -8,7 +8,8 @@
  * OW_CAMERA_GET_TELEMETRY.
  *
  * Register basis: OX02C1S/OX02C1B DS 1.0 — voltage monitor §10.5.24/table
- * A-39, temperature §10.5.23, watchdog table A-40, frame counter §10.5.25.
+ * A-39, temperature §10.5.23, watchdog table A-40, frame counter §10.5.25,
+ * BLC / optical-black table A-25 (§3.5).
  * All values are returned as RAW register bytes assembled MSB-first; the SDK
  * owns conversion to engineering units (V = code*6/4096, °C = 8.8 format
  * with the >0xC000 negative rule, gains /16 and /1024).
@@ -26,7 +27,7 @@
 
 /* Wire-format version. Bump on ANY field change and update the SDK parser
  * (omotion/MotionSensor.py get_camera_telemetry()) in the same change. */
-#define CAM_TELEMETRY_VERSION 1u
+#define CAM_TELEMETRY_VERSION 2u
 
 /* Per-camera snapshot. Packed, little-endian (returned verbatim over COMMS).
  * "raw" fields hold the sensor's register bytes assembled MSB-first without
@@ -67,6 +68,41 @@ typedef struct __attribute__((packed)) {
 	uint8_t  isp_ctrl;       /* 0x5000 — 0x34 production / 0x30 raw mode (#89) */
 	uint8_t  i2c_err_count;  /* failed sweep transactions for this camera (saturating) */
 	uint8_t  sweep_count;    /* completed sweeps (wraps) — liveness/staleness check */
+
+	/* --- #103: optical-black / black-level block (DS table A-25) -------
+	 * The dark-row measurements plus the window/target/trigger context
+	 * that produced them — an average is not interpretable without
+	 * knowing which rows it averaged and what the servo was aiming at.
+	 * NOTE: the BLC servo only runs when 0x4001[0] blc_en is set. In raw
+	 * mode (#89 writes 0x4001 = 0x00) the offsets below are frozen at
+	 * whatever the servo last computed. */
+	uint16_t z_avg[4];        /* 0x40E0-0x40E7 — zero-line (dark row) averages for
+	                           * Bayer positions 00/01/10/11, 15-bit ({[6:0],[7:0]}).
+	                           * Mono sensor: all four sample the same physical dark
+	                           * rows, so they should agree; spread is a health metric. */
+	uint16_t blc_offset_z[4]; /* 0x40CD-0x40D4 — BLCoffset10000..10011, the second
+	                           * applied-offset bank (blc_offset[8] above is the first) */
+	uint16_t blc_thres;       /* 0x4061/62 — thres_l, the computed sample-discard
+	                           * threshold row averaging applies (0x4028[5] thres_en) */
+	uint16_t blk_lvl_target;  /* 0x4004/05 — blk_lvl_target_l, servo target pedestal
+	                           * (11-bit; base config programs 0x080 = 128) */
+	uint16_t zero_ln_num;     /* 0x4065/66 — zero_ln_num, zero-line count (10-bit) */
+	uint8_t  blc_trig_ctrl;   /* 0x4000 — [7] off_trig [6] exp_chg [5] gain_chg
+	                           * [4] fmt_chg [3] rst [2] man_trig [1] freeze [0] always */
+	uint8_t  bl_start;        /* 0x4008[5:0] — black-row window first row */
+	uint8_t  bl_end;          /* 0x4009[5:0] — black-row window last row */
+	uint8_t  blk_ln_num;      /* 0x4019 — black-row count */
+	uint8_t  blc_ln_mode;     /* 0x401A — [7] h_size_man_en [2] ln_num_man [1:0] byp_mode */
+	uint8_t  zl_start;        /* 0x4050 — zero-line window first row */
+	uint8_t  zl_end;          /* 0x4051 — zero-line window last row */
+	uint8_t  zavg_ctrl;       /* 0x40E8 — [5] dither_zbline_en [4] zl_win2_en
+	                           * [3] zl_off_en [2] zl_cal_dis [1:0] z_avg_sel */
+	uint8_t  zl_start2;       /* 0x40EA — second zero-line window first row */
+	uint8_t  zl_end2;         /* 0x40EB — second zero-line window last row */
+	uint8_t  blc_fault_latch; /* 0x40F1 — BLC fault_latch (mask at 0x40F0, default 0xFC) */
+	uint8_t  blc_fault_state; /* 0x40F2[0] — BLC fault_state */
+	uint8_t  dig_test_fail;   /* 0x40B3 — dig_test_fail_cnt_l, digital-test-row mismatches */
+	uint8_t  dtr_fault;       /* 0x40F8 — [1] dtr_fault_latched [0] dtr_fault_stat */
 } cam_telemetry_t;
 
 /* NOTE on frame counting: the OX02C1B's documented "32-bit frame counter"
@@ -88,8 +124,8 @@ typedef struct __attribute__((packed)) {
 	cam_telemetry_t cam[CAMERA_COUNT];
 } cam_telemetry_response_t;
 
-_Static_assert(sizeof(cam_telemetry_t) == 74u, "cam_telemetry_t wire size changed - bump CAM_TELEMETRY_VERSION and fix the SDK parser");
-_Static_assert(sizeof(cam_telemetry_response_t) == 12u + 8u * 74u, "cam_telemetry_response_t wire size changed");
+_Static_assert(sizeof(cam_telemetry_t) == 110u, "cam_telemetry_t wire size changed - bump CAM_TELEMETRY_VERSION and fix the SDK parser");
+_Static_assert(sizeof(cam_telemetry_response_t) == 12u + 8u * 110u, "cam_telemetry_response_t wire size changed");
 
 /* Advance the background sweep by one bounded chunk (<= ~1.3 ms of I2C).
  * Call from camera_i2c_service() only: hi2c1 work must stay in the main

--- a/Core/Inc/camera_telemetry.h
+++ b/Core/Inc/camera_telemetry.h
@@ -1,0 +1,91 @@
+/*
+ * camera_telemetry.h
+ *
+ * #94: continuous OX02C1B condition telemetry — supply rails, die temps,
+ * fault/integrity state, frame/trigger counters and applied-configuration
+ * truth for all 8 cameras, collected by a background sweep in the main loop
+ * (camera_i2c_service()) and served to the host as one cached snapshot via
+ * OW_CAMERA_GET_TELEMETRY.
+ *
+ * Register basis: OX02C1S/OX02C1B DS 1.0 — voltage monitor §10.5.24/table
+ * A-39, temperature §10.5.23, watchdog table A-40, frame counter §10.5.25.
+ * All values are returned as RAW register bytes assembled MSB-first; the SDK
+ * owns conversion to engineering units (V = code*6/4096, °C = 8.8 format
+ * with the >0xC000 negative rule, gains /16 and /1024).
+ */
+
+#ifndef INC_CAMERA_TELEMETRY_H_
+#define INC_CAMERA_TELEMETRY_H_
+
+#include <stdint.h>
+#include "camera_manager.h"
+
+/* Sweep cadence: one camera sweep is started per interval, round-robin over
+ * powered cameras -> full-fleet refresh in CAMERA_COUNT * interval (~1 s). */
+#define CAM_TELEM_SWEEP_INTERVAL_MS  125u
+
+/* Wire-format version. Bump on ANY field change and update the SDK parser
+ * (omotion/MotionSensor.py get_camera_telemetry()) in the same change. */
+#define CAM_TELEMETRY_VERSION 1u
+
+/* Per-camera snapshot. Packed, little-endian (returned verbatim over COMMS).
+ * "raw" fields hold the sensor's register bytes assembled MSB-first without
+ * masking reserved bits — mask/convert host-side. */
+typedef struct __attribute__((packed)) {
+	uint32_t updated_ms;     /* HAL_GetTick() at sweep completion; 0 = never swept */
+	uint32_t frame_counter;  /* 0x4900-0x4903, MIPI SOF count (byte order verified on HW via increment check) */
+	uint32_t dgain_cmd;      /* 0x350A-0x350C raw bytes (b0<<16|b1<<8|b2); 14-bit gain/1024 packed per DS */
+	uint16_t avdd_raw;       /* 0x4E20/21 — V = (raw & 0xFFF) * 6 / 4096 */
+	uint16_t dovdd_raw;      /* 0x4E22/23 */
+	uint16_t dvdd_raw;       /* 0x4E24/25 */
+	uint16_t tpm_avg_raw;    /* 0x4D2A/2B — 8.8 °C, >0xC000 = negative (see X02C1B_read_temp) */
+	uint16_t tpm0_raw;       /* 0x4D56/57 */
+	uint16_t tpm1_raw;       /* 0x4D58/59 */
+	uint16_t tc_row;         /* 0x3890/91 — timing-counter row readback */
+	uint16_t expo_cmd;       /* 0x3501/02 — commanded coarse exposure (rows) */
+	uint16_t expo_applied;   /* 0x350E/0F — applied coarse exposure (rows) */
+	uint16_t again_cmd;      /* 0x3508/09 — commanded analog gain, code/16 = x */
+	uint16_t isp_real_gain;  /* 0x5052/53 — gain the ISP latched for the frame */
+	uint16_t isp_dig_gain;   /* 0x5054/55 */
+	uint16_t isp_blc;        /* 0x5056/57 — BLC value the ISP latched */
+	uint16_t isp_expo;       /* 0x5058/59 */
+	uint16_t blc_offset[8];  /* 0x4072..0x408F stride 4 — applied per-channel BLC offsets (15-bit) */
+	uint8_t  tpm_status;     /* 0x4D28 — [3] out_of_range [2] alarm_cel [1] alarm [0] failed */
+	uint8_t  vm_live;        /* 0x4E32 — [5:3] BIST fail, [2:0] rail out-of-range (DVDD/DOVDD/AVDD) */
+	uint8_t  vm_cp;          /* 0x4E33 — charge-pump comparator faults */
+	uint8_t  vm_latched;     /* 0x4E34 — [6] fault state, [5:3]/[2:0] latched BIST/rail faults */
+	uint8_t  vm_cp_latched;  /* 0x4E35 */
+	uint8_t  wd[6];          /* 0x4F0A-0x4F0F — watchdog fault roll-up A/B, sticky, tpm_readout, state */
+	uint8_t  sc_state;       /* 0x0108[3:0] — 5 = safe mode, 9 = streaming, 6/7 = standby/stream-off */
+	uint8_t  otp_crc[2];     /* 0x3DA7/A8 — OTP CRC check status (per-die cal loaded?) */
+	uint8_t  trig_error;     /* 0x3897 — FSIN trigger-mode read error flags */
+	uint8_t  yavg;           /* 0x4C13 — on-chip weighted frame mean */
+	uint8_t  aec_mode;       /* 0x3503 — expect 0xA8 (AEC+AGC manual) */
+	uint8_t  dcg_state;      /* 0x3A93 — expect 0x40 (manual LCG, no auto-DCG) */
+	uint8_t  blc_ctrl;       /* 0x4001 — 0x23 production / 0x00 raw mode (#89) */
+	uint8_t  isp_ctrl;       /* 0x5000 — 0x34 production / 0x30 raw mode (#89) */
+	uint8_t  i2c_err_count;  /* failed sweep transactions for this camera (saturating) */
+	uint8_t  sweep_count;    /* completed sweeps (wraps) — liveness/staleness check */
+} cam_telemetry_t;
+
+typedef struct __attribute__((packed)) {
+	uint8_t version;      /* = CAM_TELEMETRY_VERSION */
+	uint8_t valid_mask;   /* bit n: camera n has >=1 completed sweep (never cleared; check updated_ms for staleness) */
+	uint8_t struct_size;  /* = sizeof(cam_telemetry_t), parser sanity check */
+	uint8_t reserved;
+	cam_telemetry_t cam[CAMERA_COUNT];
+} cam_telemetry_response_t;
+
+_Static_assert(sizeof(cam_telemetry_t) == 78u, "cam_telemetry_t wire size changed - bump CAM_TELEMETRY_VERSION and fix the SDK parser");
+_Static_assert(sizeof(cam_telemetry_response_t) == 4u + 8u * 78u, "cam_telemetry_response_t wire size changed");
+
+/* Advance the background sweep by one bounded chunk (<= ~1.3 ms of I2C).
+ * Call from camera_i2c_service() only: hi2c1 work must stay in the main
+ * loop's serialization domain (see camera_manager.c). */
+void camera_telemetry_service(void);
+
+/* Cached snapshot for OW_CAMERA_GET_TELEMETRY. Always valid to return
+ * verbatim; never-swept cameras are all-zero with their valid bit clear. */
+const cam_telemetry_response_t *camera_telemetry_get(void);
+
+#endif /* INC_CAMERA_TELEMETRY_H_ */

--- a/Core/Inc/camera_telemetry.h
+++ b/Core/Inc/camera_telemetry.h
@@ -73,13 +73,24 @@ typedef struct __attribute__((packed)) {
 	 * The dark-row measurements plus the window/target/trigger context
 	 * that produced them — an average is not interpretable without
 	 * knowing which rows it averaged and what the servo was aiming at.
-	 * NOTE: the BLC servo only runs when 0x4001[0] blc_en is set. In raw
-	 * mode (#89 writes 0x4001 = 0x00) the offsets below are frozen at
-	 * whatever the servo last computed. */
+	 *
+	 * Bench-established 2026-07-20 (left sensor, all 8 cameras):
+	 *  - z_avg and blc_offset* update ONLY while the sensor is scanning
+	 *    rows. Idle (sc_state 6) they read 0; they populate within one
+	 *    sweep of stream-on. Judge them against sc_state, not updated_ms.
+	 *  - They are NOT gated by 0x4001[0] blc_en: in raw mode (#89 writes
+	 *    0x4001 = 0x00) both keep updating with unchanged values. The
+	 *    statistics engine runs independently of whether the correction
+	 *    is applied.
+	 *  - Scale: z_avg is fixed-point with 6 fractional bits, z_avg/64 =
+	 *    DN. Measured 7791/64 = 121.7 DN against the sensor's own
+	 *    raw-mode Yavg (0x4C13, no BLC subtraction) of 121. */
 	uint16_t z_avg[4];        /* 0x40E0-0x40E7 — zero-line (dark row) averages for
 	                           * Bayer positions 00/01/10/11, 15-bit ({[6:0],[7:0]}).
-	                           * Mono sensor: all four sample the same physical dark
-	                           * rows, so they should agree; spread is a health metric. */
+	                           * Mono sensor, so all four sample the same physical
+	                           * dark rows — but they do NOT agree: positions 10/11
+	                           * read ~60 LSB (~0.8 %) above 00/01, reproducibly, on
+	                           * every camera. The split is by row parity. */
 	uint16_t blc_offset_z[4]; /* 0x40CD-0x40D4 — BLCoffset10000..10011, the second
 	                           * applied-offset bank (blc_offset[8] above is the first) */
 	uint16_t blc_thres;       /* 0x4061/62 — thres_l, the computed sample-discard

--- a/Core/Inc/camera_telemetry.h
+++ b/Core/Inc/camera_telemetry.h
@@ -33,7 +33,6 @@
  * masking reserved bits — mask/convert host-side. */
 typedef struct __attribute__((packed)) {
 	uint32_t updated_ms;     /* HAL_GetTick() at sweep completion; 0 = never swept */
-	uint32_t frame_counter;  /* 0x4900-0x4903, MIPI SOF count (byte order verified on HW via increment check) */
 	uint32_t dgain_cmd;      /* 0x350A-0x350C raw bytes (b0<<16|b1<<8|b2); 14-bit gain/1024 packed per DS */
 	uint16_t avdd_raw;       /* 0x4E20/21 — V = (raw & 0xFFF) * 6 / 4096 */
 	uint16_t dovdd_raw;      /* 0x4E22/23 */
@@ -41,7 +40,9 @@ typedef struct __attribute__((packed)) {
 	uint16_t tpm_avg_raw;    /* 0x4D2A/2B — 8.8 °C, >0xC000 = negative (see X02C1B_read_temp) */
 	uint16_t tpm0_raw;       /* 0x4D56/57 */
 	uint16_t tpm1_raw;       /* 0x4D58/59 */
-	uint16_t tc_row;         /* 0x3890/91 — timing-counter row readback */
+	uint16_t tc_row;         /* 0x3892/93 — LIVE timing-counter row readback (bench-verified moving
+	                          * while streaming; 0x3890/91 read constant 0). Nonzero/changing =
+	                          * the sensor is actually scanning rows. */
 	uint16_t expo_cmd;       /* 0x3501/02 — commanded coarse exposure (rows) */
 	uint16_t expo_applied;   /* 0x350E/0F — applied coarse exposure (rows) */
 	uint16_t again_cmd;      /* 0x3508/09 — commanded analog gain, code/16 = x */
@@ -68,16 +69,27 @@ typedef struct __attribute__((packed)) {
 	uint8_t  sweep_count;    /* completed sweeps (wraps) — liveness/staleness check */
 } cam_telemetry_t;
 
+/* NOTE on frame counting: the OX02C1B's documented "32-bit frame counter"
+ * (DS §10.5.25) has NO readable value register in the DS 1.0 SCCB map —
+ * 0x4900-0x4903 are the FC *control* bytes (bench-verified static 08 00 00 81
+ * while streaming) and the value is only emitted via embedded-data rows. The
+ * frames-triggered ground truth here is therefore firmware-side: the FSIN
+ * pulse counter in the response header below. */
 typedef struct __attribute__((packed)) {
 	uint8_t version;      /* = CAM_TELEMETRY_VERSION */
 	uint8_t valid_mask;   /* bit n: camera n has >=1 completed sweep (never cleared; check updated_ms for staleness) */
 	uint8_t struct_size;  /* = sizeof(cam_telemetry_t), parser sanity check */
 	uint8_t reserved;
+	uint32_t fsin_pulse_count;  /* firmware FSIN pulse counter (u16 zero-extended), sampled at query
+	                             * time. Counts EXTERNAL FSIN edges (EXTI pin 13) — i.e. console-driven
+	                             * scan frames. The internal TIM4 FSIN generator does NOT increment it
+	                             * (bench-verified 2026-07-17). */
+	uint32_t uptime_ms;         /* HAL_GetTick() at query time — reference for the per-camera updated_ms staleness */
 	cam_telemetry_t cam[CAMERA_COUNT];
 } cam_telemetry_response_t;
 
-_Static_assert(sizeof(cam_telemetry_t) == 78u, "cam_telemetry_t wire size changed - bump CAM_TELEMETRY_VERSION and fix the SDK parser");
-_Static_assert(sizeof(cam_telemetry_response_t) == 4u + 8u * 78u, "cam_telemetry_response_t wire size changed");
+_Static_assert(sizeof(cam_telemetry_t) == 74u, "cam_telemetry_t wire size changed - bump CAM_TELEMETRY_VERSION and fix the SDK parser");
+_Static_assert(sizeof(cam_telemetry_response_t) == 12u + 8u * 74u, "cam_telemetry_response_t wire size changed");
 
 /* Advance the background sweep by one bounded chunk (<= ~1.3 ms of I2C).
  * Call from camera_i2c_service() only: hi2c1 work must stay in the main

--- a/Core/Inc/common.h
+++ b/Core/Inc/common.h
@@ -34,6 +34,8 @@
 #define DEBUG_FLAG_SEND_DEFER (1u << 7)  /* #68: FSIN ISR only flips send_data_flag; main loop runs send_data() */
 #define DEBUG_FLAG_HISTO_STALL (1u << 8) /* #75: stop sending histogram frames after HISTO_STALL_TRIGGER_FRAMES;
                                           * cameras/SPI/USB stay alive — deterministic host-visible stall repro */
+#define DEBUG_FLAG_CAMERA_CROP (1u << 9) /* #86: crop camera output to 1720x1280 (drop right 200 columns) when
+                                          * cameras are (re)configured — misaligned-optic A/B test. See 0X02C1B.c */
 
 
 #define I2C_IRQ_PRIORITY 0

--- a/Core/Inc/common.h
+++ b/Core/Inc/common.h
@@ -170,7 +170,6 @@ typedef enum {
 	OW_FACTORY_I2C_WR = 0x6A,
 	OW_FACTORY_I2C_WRRD = 0x6B,
 	OW_FACTORY_NVCM_CHECK = 0x6C,
-	OW_FACTORY_NVCM_BOOT = 0x6D,
 } MotionFactoryCommands;
 
 typedef enum {

--- a/Core/Inc/common.h
+++ b/Core/Inc/common.h
@@ -163,6 +163,7 @@ typedef enum {
 	OW_CAMERA_POWER_OFF = 0x51,
 	OW_CAMERA_POWER_STATUS = 0x52,
 	OW_CAMERA_READ_SECURITY_UID = 0x53,
+	OW_CAMERA_GET_TELEMETRY = 0x54,  /* #94: cached cam_telemetry_response_t snapshot (camera_telemetry.h) */
 
 } MotionCameraCommands;
 

--- a/Core/Inc/common.h
+++ b/Core/Inc/common.h
@@ -105,6 +105,7 @@ typedef enum {
 	OW_CMD_I2C_BROADCAST = 0x06,
 	OW_CMD_SERIAL = 0x07,
 	OW_CMD_I2C_REG_READ = 0x08,
+	OW_CMD_BOOT_INFO = 0x09,   /* report runtime SCB->VTOR so a host can tell bare-metal from bootloader-slot */
 	OW_CMD_USR_CFG = 0x0A,
 	OW_CMD_I2C_STATUS = 0x0B,
 	OW_CMD_DEBUG_FLAGS = 0x0C,

--- a/Core/Inc/common.h
+++ b/Core/Inc/common.h
@@ -36,6 +36,9 @@
                                           * cameras/SPI/USB stay alive — deterministic host-visible stall repro */
 #define DEBUG_FLAG_CAMERA_CROP (1u << 9) /* #86: crop camera output to 1720x1280 (drop right 200 columns) when
                                           * cameras are (re)configured — misaligned-optic A/B test. See 0X02C1B.c */
+#define DEBUG_FLAG_CAMERA_RAW (1u << 10) /* #89: raw "scientific sensor" mode — disable every on-sensor pixel
+                                          * correction (BLC/DC-BLC/dither/OTP-DPC) when cameras are
+                                          * (re)configured. See X02C1B_raw_sensor in 0X02C1B.c */
 
 
 #define I2C_IRQ_PRIORITY 0

--- a/Core/Inc/common.h
+++ b/Core/Inc/common.h
@@ -170,6 +170,7 @@ typedef enum {
 	OW_FACTORY_I2C_WR = 0x6A,
 	OW_FACTORY_I2C_WRRD = 0x6B,
 	OW_FACTORY_NVCM_CHECK = 0x6C,
+	OW_FACTORY_NVCM_BOOT = 0x6D,
 } MotionFactoryCommands;
 
 typedef enum {

--- a/Core/Inc/i2c_health.h
+++ b/Core/Inc/i2c_health.h
@@ -21,7 +21,7 @@ typedef struct __attribute__((packed)) {
 	uint8_t version;          /* = I2C_HEALTH_VERSION */
 	uint8_t mux_present;      /* TCA9548A 0x70 ACK on the main bus */
 	uint8_t imu_present;      /* ICM-20948 0x68 ACK on the main bus */
-	uint8_t camera_present;   /* bit i = OV2312 (0x36) found on mux channel i */
+	uint8_t camera_present;   /* bit i = OX02C1B (0x36) found on mux channel i */
 	uint8_t fpga_present;     /* bit i = CrossLink (0x40) found on mux channel i */
 	uint8_t cameras_expected; /* = 0xFF (all 8 — both sensors fully connected) */
 	uint8_t all_present;      /* 1 iff mux & imu & camera==0xFF & fpga==0xFF */

--- a/Core/Src/0X02C1B.c
+++ b/Core/Src/0X02C1B.c
@@ -6,8 +6,24 @@
  */
 #include "0X02C1B.h"
 #include "X02C1B_Sensor_Config.h"
+#include "logging.h"
 #include "utils.h"
 #include <stdio.h>
+
+/*
+ * #86 debug crop: shrink horizontal output from 1920 to 1720, dropping the
+ * rightmost 200 columns of the active region (misaligned-optic A/B test).
+ * The output window is left-anchored (ISP X offset 0x3811 = 8), so only
+ * X_OUTPUT_SIZE (0x3808/0x3809) changes: 0x0780 (1920) -> 0x06B8 (1720).
+ * Left edge, height (1280), framerate and line timing are all untouched.
+ * Applied after the base config table (which always programs 1920), so
+ * clearing DEBUG_FLAG_CAMERA_CROP and reconfiguring reverts to full frame.
+ */
+#define X02C1B_CROP_WIDTH 1720u
+static const struct regval_list X02C1B_crop_1720[] = {
+    {0x3808, (X02C1B_CROP_WIDTH >> 8) & 0xff},
+    {0x3809, X02C1B_CROP_WIDTH & 0xff},
+};
 
 static volatile _Bool ext_fsin_enabled = false;
 #define I2C_TIMEOUT 1000 // Set an appropriate timeout for I2C transactions
@@ -100,6 +116,17 @@ int X02C1B_configure_sensor(CameraDevice *cam) {
 		printf("Camera %d Failed to stop streaming\r\n", cam->id+1);
 		return ret;
 	}
+
+    /* #86: optional debug crop to 1720x1280 (drop rightmost 200 columns). */
+    if ((logging_get_debug_flags() & DEBUG_FLAG_CAMERA_CROP) != 0u) {
+        ret = X02C1B_write_array(cam->pI2c, X02C1B_crop_1720, ARRAY_SIZE(X02C1B_crop_1720));
+        if (ret < 0) {
+            printf("Camera %d crop override failed\r\n", cam->id+1);
+            return ret;
+        }
+        printf("Camera %d cropped to %ux1280 (right %u cols dropped)\r\n",
+               cam->id+1, X02C1B_CROP_WIDTH, 1920u - X02C1B_CROP_WIDTH);
+    }
 
 	delay_ms(100);
     return 0;

--- a/Core/Src/0X02C1B.c
+++ b/Core/Src/0X02C1B.c
@@ -25,6 +25,41 @@ static const struct regval_list X02C1B_crop_1720[] = {
     {0x3809, X02C1B_CROP_WIDTH & 0xff},
 };
 
+/*
+ * #89 raw "scientific sensor" mode: strip every on-sensor pixel correction so
+ * the output is the bare ADC codes (analog gain/exposure are signal chain, not
+ * processing, and keep their per-camera values). Register basis: OX02C1B DS 1.0
+ * + OVT AE thread (see issue #89 for the full proposal table).
+ *
+ * Functional changes vs the base table:
+ *   0x4001 0x23 -> 0x00  BLC block off ([0] blc_en, [1] dc_blc_en, [5] dither).
+ *                        No OB-row servo subtraction: the raw per-channel
+ *                        pedestal (~255 DN @1x, ~495 DN @16x gain) stays in the
+ *                        data and eats headroom on high-gain cameras.
+ *   0x5000 0x34 -> 0x30  [2] OTP static defect-pixel correction off — the last
+ *                        pixel modifier still enabled in production; defect
+ *                        pixels become visible. [3] DPC, [1] WB, [0] pre-ISP
+ *                        were already 0; [5] ISP + [4] window stay 1 so output
+ *                        geometry/timing are unchanged.
+ * The rest re-asserts states the base table already establishes (test pattern
+ * off, digital gain 1x, ISP manual overrides off, AEC/AGC manual): runtime
+ * register writes survive OW_CAMERA_SET_CONFIG (it skips already-configured
+ * cameras), so the flag must guarantee the raw contract, not assume it.
+ * The base table always programs the corrected values, so clearing the flag
+ * and reconfiguring (after a camera power-cycle) reverts. Test patterns rewrite
+ * 0x5000 (X02C1B_set_test_pattern) — don't combine them with raw mode.
+ */
+static const struct regval_list X02C1B_raw_sensor[] = {
+    {0x4001, 0x00},  /* BLC / DC-BLC / dither off            (was 0x23) */
+    {0x5000, 0x30},  /* OTP DPC off; window + ISP kept       (was 0x34) */
+    {0x5100, 0x00},  /* assert: test patterns off */
+    {0x350a, 0x01},  /* assert: digital gain 1.000x */
+    {0x350b, 0x00},
+    {0x350c, 0x00},
+    {0x5006, 0x00},  /* assert: ISP manual-override paths disabled */
+    {0x3503, 0xa8},  /* assert: AEC + AGC manual */
+};
+
 static volatile _Bool ext_fsin_enabled = false;
 #define I2C_TIMEOUT 1000 // Set an appropriate timeout for I2C transactions
 
@@ -126,6 +161,16 @@ int X02C1B_configure_sensor(CameraDevice *cam) {
         }
         printf("Camera %d cropped to %ux1280 (right %u cols dropped)\r\n",
                cam->id+1, X02C1B_CROP_WIDTH, 1920u - X02C1B_CROP_WIDTH);
+    }
+
+    /* #89: optional raw "scientific sensor" mode — no on-sensor corrections. */
+    if ((logging_get_debug_flags() & DEBUG_FLAG_CAMERA_RAW) != 0u) {
+        ret = X02C1B_write_array(cam->pI2c, X02C1B_raw_sensor, ARRAY_SIZE(X02C1B_raw_sensor));
+        if (ret < 0) {
+            printf("Camera %d raw-mode override failed\r\n", cam->id+1);
+            return ret;
+        }
+        printf("Camera %d RAW mode: BLC/DC-BLC/dither/OTP-DPC off\r\n", cam->id+1);
     }
 
 	delay_ms(100);

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -1174,7 +1174,7 @@ static void poll_camera_temperatures(void)
                     {
                         /* Keep last-known-good on failed reads: read_temp
                          * returns a negative error code on I2C failure, and
-                         * a live OV2312 die never legitimately reads <= 0 °C
+                         * a live OX02C1B die never legitimately reads <= 0 °C
                          * (self-heating), so treat non-positive as failure. */
                         float t = X02C1B_read_temp(pCam);
                         if (t > 0.0f) {
@@ -1251,7 +1251,7 @@ static void camera_death_isolate(uint8_t cam_id)
 }
 
 /* Re-power a dead camera's rail once its cool-off has elapsed, keeping
- * CRESETB low: the FPGA stays unbooted and quiet, while the OV2312 (direct
+ * CRESETB low: the FPGA stays unbooted and quiet, while the OX02C1B (direct
  * I2C behind the mux) comes back up so temperature telemetry resumes.
  * needs_recovery stays set until program_fpga() completes the real
  * bring-up at the next scan. Main-loop only. */
@@ -1471,7 +1471,7 @@ static void check_camera_failures(void) {
 						/* Mark dead via needs_recovery — NOT isPresent, which keeps
 						 * the presence determination from scan start. The likely
 						 * cause is the camera PCB's power regulator hitting thermal
-						 * shutdown (kills both FPGA and OV2312), so the camera
+						 * shutdown (kills both FPGA and OX02C1B), so the camera
 						 * needs a timed rail cycle, done from the main loop. */
 						cam_array[cam_id].needs_recovery = true;
 						printf("Camera %d has stopped posting data\r\n", cam_id + 1);

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -9,6 +9,7 @@
 #include "logging.h"
 #include "crosslink.h"
 #include "0X02C1B.h"
+#include "camera_telemetry.h"
 #include "i2c_master.h"
 #include "uart_comms.h"
 #include "utils.h"
@@ -1301,6 +1302,11 @@ void camera_i2c_service(void)
     }
 
     camera_recovery_tick();  /* Re-power dead cameras whose cool-off elapsed */
+
+    /* #94: advance the background telemetry sweep by one bounded chunk.
+     * Unlike the temp poll it self-schedules on HAL_GetTick(), so telemetry
+     * keeps refreshing while idle (no frames driving cam_temp_poll_due). */
+    camera_telemetry_service();
 }
 /* -------- END CAMERA I2C FUNCTIONS -------- */
 

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -139,14 +139,18 @@ static bool camera_request_is_valid(uint8_t cam_id) {
 
 
 /**
- * Detect whether a CrossLink FPGA has been permanently programmed via NVCM.
+ * Detect whether a CrossLink FPGA boots a working design from NVCM.
  *
- * Method: enter forced slave config mode (activation key + CRESETB), read the
- * STATUS register Done bit.  Done=1 means NVCM was fully programmed (the Done
- * bit is the last step burned during NVCM programming and gates auto-boot).
+ * Method: release CRESETB without the activation key (auto-boot window),
+ * then check that the booted user design is driving this camera's bus
+ * clk/data pins low. This is behavioral — it detects a *bootable* image,
+ * not just a burned Done fuse: a part with the Done fuse programmed but a
+ * non-booting image correctly reads "no boot" here even though the 0x6C
+ * probe's STATUS bit 19 (the SDM Enable fuse mirror) reads "programmed"
+ * (openmotion-test-app#44, 2026-07-17).
  *
- * The slave I2C config port at 0x40 requires the activation key to become
- * active — without it, 0x40 never responds regardless of NVCM state.
+ * Leaves the design running (CRESETB high) when it booted, or the FPGA
+ * held in reset (CRESETB low, SRAM cleared) when it did not.
  */
 static bool fpga_detect_nvcm(CameraDevice *cam)
 {
@@ -202,6 +206,28 @@ static bool fpga_detect_nvcm(CameraDevice *cam)
 
 	HAL_GPIO_WritePin(cam->cresetb_port, cam->cresetb_pin, GPIO_PIN_RESET);
 	return false;
+}
+
+/* Host-facing wrapper for the pin-drive NVCM boot probe (#91, factory
+ * command OW_FACTORY_NVCM_BOOT). Read-only with respect to flash and cached
+ * camera state: no SRAM write, no isProgrammed/isConfigured mutation — but
+ * it does reset the FPGA, so a previously SRAM-configured blank part is left
+ * unconfigured until the next program_fpga(). Returns false (probe refused)
+ * for an out-of-range index or an unpowered camera, whose floating pins
+ * would fake a "booted" reading. */
+_Bool camera_nvcm_boot_probe(uint8_t cam_id, _Bool *booted)
+{
+	if (cam_id >= CAMERA_COUNT || booted == NULL) {
+		return false;
+	}
+	CameraDevice *cam = &cam_array[cam_id];
+	if (!cam->isPowered) {
+		printf("C%d: NVCM boot probe refused - camera not powered\r\n",
+		       cam_id + 1);
+		return false;
+	}
+	*booted = fpga_detect_nvcm(cam);
+	return true;
 }
 
 static void init_camera(CameraDevice *cam){

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -208,9 +208,10 @@ static bool fpga_detect_nvcm(CameraDevice *cam)
 	return false;
 }
 
-/* Host-facing wrapper for the pin-drive NVCM boot probe (#91, factory
- * command OW_FACTORY_NVCM_BOOT). Read-only with respect to flash and cached
- * camera state: no SRAM write, no isProgrammed/isConfigured mutation — but
+/* Host-facing wrapper for the pin-drive NVCM boot probe (#91 — verdict byte
+ * appended to the OW_FACTORY_NVCM_CHECK blob). Read-only with respect to
+ * flash and cached camera state: no SRAM write, no isProgrammed/isConfigured
+ * mutation — but
  * it does reset the FPGA, so a previously SRAM-configured blank part is left
  * unconfigured until the next program_fpga(). Returns false (probe refused)
  * for an out-of-range index or an unpowered camera, whose floating pins

--- a/Core/Src/camera_telemetry.c
+++ b/Core/Src/camera_telemetry.c
@@ -1,0 +1,279 @@
+/*
+ * camera_telemetry.c
+ *
+ * #94: background OX02C1B condition sweep. One camera sweep per
+ * CAM_TELEM_SWEEP_INTERVAL_MS, round-robin over powered cameras, executed in
+ * bounded chunks from camera_i2c_service() so streaming-time main-loop
+ * latency stays comparable to the temperature poll. Mux discipline per
+ * chunk mirrors poll_camera_temperatures(): select the swept camera's
+ * TCA9548A channel, do the reads with mux_channel=0xFF (pre-selected), then
+ * restore the active camera's channel.
+ *
+ * A failed transaction aborts the whole sweep: the published cache keeps the
+ * camera's last completed snapshot (same last-known-good philosophy as
+ * cam_temp[]) and i2c_err_count records the failure.
+ */
+
+#include "camera_telemetry.h"
+#include "main.h"
+#include "i2c_master.h"
+#include "0X02C1B.h"
+#include <stdio.h>
+#include <string.h>
+
+/* I2C transactions per service() pass. 6 keeps a chunk under ~1.3 ms at
+ * 400 kHz including the two mux selects (compression-budget scale, #70). */
+#define TELEM_OPS_PER_PASS 6u
+
+#define TELEM_MUX_ADDR        0x70u
+#define TELEM_I2C_TIMEOUT_MS  25u
+
+/* One burst read: `len` bytes starting at `reg` (SCCB sub-address
+ * auto-increment). Order is the decode order in telem_publish() — the two
+ * must change together (TELEM_RAW_BYTES asserts the total). */
+struct telem_op {
+	uint16_t reg;
+	uint8_t len;
+};
+
+static const struct telem_op telem_ops[] = {
+	{ 0x4E20u, 6u },  /* VM results: AVDD, DOVDD, DVDD (table A-39) */
+	{ 0x4E32u, 4u },  /* VM faults: live, CP, latched, CP-latched */
+	{ 0x4D2Au, 2u },  /* TPM average (8.8 degC) */
+	{ 0x4D56u, 4u },  /* TPM0, TPM1 */
+	{ 0x4D28u, 1u },  /* TPM status/alarm */
+	{ 0x4F0Au, 6u },  /* watchdog 0x4F0A-0x4F0F */
+	{ 0x0108u, 1u },  /* sc_state */
+	{ 0x3DA7u, 2u },  /* OTP CRC status */
+	{ 0x4900u, 4u },  /* frame counter (MIPI SOF) */
+	{ 0x3890u, 2u },  /* timing-counter row readback */
+	{ 0x3897u, 1u },  /* trigger-mode error flags */
+	{ 0x4C13u, 1u },  /* Yavg on-chip frame mean */
+	{ 0x3501u, 2u },  /* commanded coarse exposure */
+	{ 0x350Eu, 2u },  /* applied coarse exposure */
+	{ 0x3508u, 2u },  /* commanded analog gain */
+	{ 0x350Au, 3u },  /* commanded digital gain (packed 14-bit) */
+	{ 0x3503u, 1u },  /* AEC/AGC mode */
+	{ 0x3A93u, 1u },  /* DCG (conversion gain) state */
+	{ 0x4001u, 1u },  /* BLC ctrl (#89 raw-mode contract) */
+	{ 0x5000u, 1u },  /* ISP ctrl (#89 raw-mode contract) */
+	{ 0x5052u, 8u },  /* ISP-latched real gain / dig gain / BLC / exposure */
+	{ 0x4072u, 30u }, /* applied BLC offsets ch0-7 ({MSB,LSB} at stride 4) */
+};
+#define TELEM_N_OPS (sizeof(telem_ops) / sizeof(telem_ops[0]))
+#define TELEM_RAW_BYTES 85u
+
+static cam_telemetry_response_t telem_resp = {
+	.version = CAM_TELEMETRY_VERSION,
+	.valid_mask = 0u,
+	.struct_size = (uint8_t)sizeof(cam_telemetry_t),
+	.reserved = 0u,
+};
+
+/* Sweep state machine (main-loop only, so no locking). */
+static uint32_t telem_next_ms = 0;
+static uint8_t  telem_rr_idx = 0;          /* round-robin cursor */
+static int8_t   telem_active = -1;         /* camera mid-sweep, -1 = idle */
+static uint8_t  telem_op_idx = 0;
+static uint8_t  telem_staging_off = 0;
+static _Bool    telem_wrote_setup = false; /* 0x4E14 stop_update written this sweep */
+static uint8_t  telem_staging[TELEM_RAW_BYTES];
+
+const cam_telemetry_response_t *camera_telemetry_get(void)
+{
+	return &telem_resp;
+}
+
+static HAL_StatusTypeDef telem_write_reg(uint16_t reg, uint8_t val)
+{
+	uint8_t buf[3] = { (uint8_t)(reg >> 8), (uint8_t)(reg & 0xFFu), val };
+	return HAL_I2C_Master_Transmit(&hi2c1, (uint16_t)(X02C1B_ADDRESS << 1),
+	                               buf, 3, TELEM_I2C_TIMEOUT_MS);
+}
+
+/* Cursor readers: staging bytes are the sensor's MSB-first register order. */
+static uint8_t rd8(const uint8_t **p)
+{
+	uint8_t v = (*p)[0];
+	*p += 1;
+	return v;
+}
+
+static uint16_t rd16(const uint8_t **p)
+{
+	uint16_t v = (uint16_t)(((uint16_t)(*p)[0] << 8) | (*p)[1]);
+	*p += 2;
+	return v;
+}
+
+static void telem_fail(uint8_t cam_id)
+{
+	cam_telemetry_t *t = &telem_resp.cam[cam_id];
+	if (t->i2c_err_count < 0xFFu) {
+		t->i2c_err_count++;
+	}
+	telem_active = -1;
+}
+
+static void telem_publish(uint8_t cam_id, uint32_t now)
+{
+	cam_telemetry_t *t = &telem_resp.cam[cam_id];
+	const uint8_t *p = telem_staging;
+
+	/* Fault-relevant previous state, for the change notice below. */
+	uint8_t prev_wd0 = t->wd[0], prev_wd1 = t->wd[1];
+	uint8_t prev_vml = t->vm_latched, prev_vmcpl = t->vm_cp_latched;
+	uint8_t prev_tpm = (uint8_t)(t->tpm_status & 0x0Fu);
+	_Bool was_valid = (telem_resp.valid_mask & (1u << cam_id)) != 0u;
+
+	t->avdd_raw = rd16(&p);
+	t->dovdd_raw = rd16(&p);
+	t->dvdd_raw = rd16(&p);
+	t->vm_live = rd8(&p);
+	t->vm_cp = rd8(&p);
+	t->vm_latched = rd8(&p);
+	t->vm_cp_latched = rd8(&p);
+	t->tpm_avg_raw = rd16(&p);
+	t->tpm0_raw = rd16(&p);
+	t->tpm1_raw = rd16(&p);
+	t->tpm_status = rd8(&p);
+	for (uint8_t i = 0; i < 6u; i++) {
+		t->wd[i] = rd8(&p);
+	}
+	t->sc_state = rd8(&p);
+	t->otp_crc[0] = rd8(&p);
+	t->otp_crc[1] = rd8(&p);
+	t->frame_counter = ((uint32_t)rd16(&p) << 16);
+	t->frame_counter |= rd16(&p);
+	t->tc_row = rd16(&p);
+	t->trig_error = rd8(&p);
+	t->yavg = rd8(&p);
+	t->expo_cmd = rd16(&p);
+	t->expo_applied = rd16(&p);
+	t->again_cmd = rd16(&p);
+	t->dgain_cmd = ((uint32_t)rd8(&p) << 16);
+	t->dgain_cmd |= ((uint32_t)rd8(&p) << 8);
+	t->dgain_cmd |= rd8(&p);
+	t->aec_mode = rd8(&p);
+	t->dcg_state = rd8(&p);
+	t->blc_ctrl = rd8(&p);
+	t->isp_ctrl = rd8(&p);
+	t->isp_real_gain = rd16(&p);
+	t->isp_dig_gain = rd16(&p);
+	t->isp_blc = rd16(&p);
+	t->isp_expo = rd16(&p);
+	/* BLC applied offsets: 30-byte block, {MSB,LSB} pairs at stride 4
+	 * (0x4072/73, 0x4076/77, ... 0x408E/8F — see DS table A-25 §1.7). */
+	for (uint8_t i = 0; i < 8u; i++) {
+		t->blc_offset[i] = (uint16_t)(((uint16_t)p[i * 4u] << 8) | p[i * 4u + 1u]);
+	}
+	p += 30;
+
+	if (p != &telem_staging[TELEM_RAW_BYTES]) {
+		/* Decode desynced from telem_ops[] — programming error, don't
+		 * publish garbage. (Unreachable when the tables match.) */
+		printf("CAM%u TELEM decode length mismatch\r\n", cam_id + 1u);
+		telem_active = -1;
+		return;
+	}
+
+	t->updated_ms = now;
+	t->sweep_count++;
+	telem_resp.valid_mask |= (uint8_t)(1u << cam_id);
+	telem_active = -1;
+
+	/* One-line notice on fault-latch changes — rare by construction. The
+	 * watchdog sticky bit preserves one-shot events between sweeps. */
+	if (was_valid &&
+	    (t->wd[0] != prev_wd0 || t->wd[1] != prev_wd1 ||
+	     t->vm_latched != prev_vml || t->vm_cp_latched != prev_vmcpl ||
+	     (uint8_t)(t->tpm_status & 0x0Fu) != prev_tpm)) {
+		printf("CAM%u TELEM fault change: wd=%02X/%02X vm=%02X cp=%02X tpm=%02X\r\n",
+		       cam_id + 1u, t->wd[0], t->wd[1], t->vm_latched,
+		       t->vm_cp_latched, t->tpm_status);
+	}
+}
+
+void camera_telemetry_service(void)
+{
+	uint32_t now = HAL_GetTick();  /* wrap-safe cadence, same rationale as the temp poll (#73) */
+
+	if (telem_active < 0) {
+		if ((int32_t)(now - telem_next_ms) < 0) {
+			return;
+		}
+		telem_next_ms = now + CAM_TELEM_SWEEP_INTERVAL_MS;
+
+		/* Pick the next powered camera (dead-camera rails are off during
+		 * cool-off; their mux channel is disconnected — skip, like the
+		 * temperature poll). */
+		for (uint8_t i = 0; i < CAMERA_COUNT; i++) {
+			uint8_t cam = telem_rr_idx;
+			telem_rr_idx = (uint8_t)((telem_rr_idx + 1u) % CAMERA_COUNT);
+			CameraDevice *p = get_camera_byID(cam);
+			if (p != NULL && p->isPresent && p->isPowered) {
+				telem_active = (int8_t)cam;
+				telem_op_idx = 0;
+				telem_staging_off = 0;
+				telem_wrote_setup = false;
+				break;
+			}
+		}
+		if (telem_active < 0) {
+			return;  /* nothing powered */
+		}
+	}
+
+	uint8_t cam_id = (uint8_t)telem_active;
+	CameraDevice *cam = get_camera_byID(cam_id);
+	if (cam == NULL || !cam->isPowered) {
+		/* Camera died mid-sweep (death isolation) — drop the sweep without
+		 * counting an I2C error against it. */
+		telem_active = -1;
+		return;
+	}
+
+	if (TCA9548A_SelectChannel(&hi2c1, TELEM_MUX_ADDR, cam->i2c_target) != HAL_OK) {
+		telem_fail(cam_id);
+	} else {
+		uint8_t ops_done = 0;
+
+		/* Sweep setup: freeze VM result updates during SCCB reads so the
+		 * 12-bit MSB/LSB pairs can't tear (0x4E14[0], table A-39). Written
+		 * every sweep — self-healing after a camera power cycle resets it. */
+		if (!telem_wrote_setup) {
+			if (telem_write_reg(0x4E14u, 0x01u) != HAL_OK) {
+				telem_fail(cam_id);
+				ops_done = TELEM_OPS_PER_PASS;  /* skip the read loop */
+			} else {
+				telem_wrote_setup = true;
+				ops_done++;
+			}
+		}
+
+		while (ops_done < TELEM_OPS_PER_PASS && telem_active >= 0 &&
+		       telem_op_idx < TELEM_N_OPS) {
+			const struct telem_op *op = &telem_ops[telem_op_idx];
+			if (i2c_mem_read(&hi2c1, X02C1B_ADDRESS, op->reg, 2u,
+			                 &telem_staging[telem_staging_off], op->len,
+			                 0xFFu) != HAL_OK) {
+				telem_fail(cam_id);
+				break;
+			}
+			telem_staging_off += op->len;
+			telem_op_idx++;
+			ops_done++;
+		}
+
+		if (telem_active >= 0 && telem_op_idx >= TELEM_N_OPS) {
+			telem_publish(cam_id, now);
+		}
+	}
+
+	/* Restore the active camera's channel, exactly like the temperature
+	 * poll — command handlers assume their selection is still in effect. */
+	CameraDevice *active = get_active_cam();
+	if (active != NULL) {
+		(void)TCA9548A_SelectChannel(&hi2c1, TELEM_MUX_ADDR, active->i2c_target);
+	}
+}

--- a/Core/Src/camera_telemetry.c
+++ b/Core/Src/camera_telemetry.c
@@ -45,8 +45,7 @@ static const struct telem_op telem_ops[] = {
 	{ 0x4F0Au, 6u },  /* watchdog 0x4F0A-0x4F0F */
 	{ 0x0108u, 1u },  /* sc_state */
 	{ 0x3DA7u, 2u },  /* OTP CRC status */
-	{ 0x4900u, 4u },  /* frame counter (MIPI SOF) */
-	{ 0x3890u, 2u },  /* timing-counter row readback */
+	{ 0x3892u, 2u },  /* LIVE row counter (0x3890/91 are constant-0; bench-verified) */
 	{ 0x3897u, 1u },  /* trigger-mode error flags */
 	{ 0x4C13u, 1u },  /* Yavg on-chip frame mean */
 	{ 0x3501u, 2u },  /* commanded coarse exposure */
@@ -61,7 +60,12 @@ static const struct telem_op telem_ops[] = {
 	{ 0x4072u, 30u }, /* applied BLC offsets ch0-7 ({MSB,LSB} at stride 4) */
 };
 #define TELEM_N_OPS (sizeof(telem_ops) / sizeof(telem_ops[0]))
-#define TELEM_RAW_BYTES 85u
+#define TELEM_RAW_BYTES 81u
+
+/* Firmware-side FSIN pulse counter (main.c, incremented per frame trigger):
+ * the frames-triggered ground truth for the response header — the sensor's
+ * own frame counter has no readable SCCB value register (see header note). */
+extern volatile uint16_t pulse_count;
 
 static cam_telemetry_response_t telem_resp = {
 	.version = CAM_TELEMETRY_VERSION,
@@ -81,6 +85,8 @@ static uint8_t  telem_staging[TELEM_RAW_BYTES];
 
 const cam_telemetry_response_t *camera_telemetry_get(void)
 {
+	telem_resp.fsin_pulse_count = (uint32_t)pulse_count;
+	telem_resp.uptime_ms = HAL_GetTick();
 	return &telem_resp;
 }
 
@@ -143,8 +149,6 @@ static void telem_publish(uint8_t cam_id, uint32_t now)
 	t->sc_state = rd8(&p);
 	t->otp_crc[0] = rd8(&p);
 	t->otp_crc[1] = rd8(&p);
-	t->frame_counter = ((uint32_t)rd16(&p) << 16);
-	t->frame_counter |= rd16(&p);
 	t->tc_row = rd16(&p);
 	t->trig_error = rd8(&p);
 	t->yavg = rd8(&p);

--- a/Core/Src/camera_telemetry.c
+++ b/Core/Src/camera_telemetry.c
@@ -12,6 +12,10 @@
  * A failed transaction aborts the whole sweep: the published cache keeps the
  * camera's last completed snapshot (same last-known-good philosophy as
  * cam_temp[]) and i2c_err_count records the failure.
+ *
+ * #103 added the optical-black / black-level block (DS table A-25): the
+ * z_avg dark-row averages plus the window, target, trigger and fault context
+ * needed to interpret them. Read-only, like everything else here.
  */
 
 #include "camera_telemetry.h"
@@ -54,13 +58,27 @@ static const struct telem_op telem_ops[] = {
 	{ 0x350Au, 3u },  /* commanded digital gain (packed 14-bit) */
 	{ 0x3503u, 1u },  /* AEC/AGC mode */
 	{ 0x3A93u, 1u },  /* DCG (conversion gain) state */
-	{ 0x4001u, 1u },  /* BLC ctrl (#89 raw-mode contract) */
+	{ 0x4000u, 10u }, /* BLC trigger ctrl, BLC ctrl (#89 raw-mode contract),
+	                   * rsvd x2, black-level target, hwin_pad (skipped),
+	                   * black-row window start/end */
 	{ 0x5000u, 1u },  /* ISP ctrl (#89 raw-mode contract) */
 	{ 0x5052u, 8u },  /* ISP-latched real gain / dig gain / BLC / exposure */
 	{ 0x4072u, 30u }, /* applied BLC offsets ch0-7 ({MSB,LSB} at stride 4) */
+	/* #103 optical-black block. Read-only; ordered by address so the
+	 * bursts stay contiguous (DS table A-25). */
+	{ 0x4019u, 2u },  /* black-row count, line-number/bypass mode */
+	{ 0x4050u, 2u },  /* zero-line window start/end */
+	{ 0x4061u, 2u },  /* thres_l — computed sample-discard threshold */
+	{ 0x4065u, 2u },  /* zero_ln_num */
+	{ 0x40B3u, 1u },  /* digital-test-row fail count */
+	{ 0x40CDu, 8u },  /* BLCoffset10000..10011 (second offset bank, contiguous) */
+	{ 0x40E0u, 12u }, /* z_avg 00/01/10/11, zavg ctrl, 0x40E9 (skipped),
+	                   * second zero-line window start/end */
+	{ 0x40F1u, 2u },  /* BLC fault latch / fault state */
+	{ 0x40F8u, 1u },  /* digital-test-row fault status */
 };
 #define TELEM_N_OPS (sizeof(telem_ops) / sizeof(telem_ops[0]))
-#define TELEM_RAW_BYTES 81u
+#define TELEM_RAW_BYTES 122u
 
 /* Firmware-side FSIN pulse counter (main.c, incremented per frame trigger):
  * the frames-triggered ground truth for the response header — the sensor's
@@ -130,6 +148,7 @@ static void telem_publish(uint8_t cam_id, uint32_t now)
 	uint8_t prev_wd0 = t->wd[0], prev_wd1 = t->wd[1];
 	uint8_t prev_vml = t->vm_latched, prev_vmcpl = t->vm_cp_latched;
 	uint8_t prev_tpm = (uint8_t)(t->tpm_status & 0x0Fu);
+	uint8_t prev_blcf = t->blc_fault_latch;
 	_Bool was_valid = (telem_resp.valid_mask & (1u << cam_id)) != 0u;
 
 	t->avdd_raw = rd16(&p);
@@ -160,7 +179,15 @@ static void telem_publish(uint8_t cam_id, uint32_t now)
 	t->dgain_cmd |= rd8(&p);
 	t->aec_mode = rd8(&p);
 	t->dcg_state = rd8(&p);
+	/* 0x4000-0x4009 block: two reserved bytes and hwin_pad are read as part
+	 * of the burst but not published (nothing OB-relevant in them). */
+	t->blc_trig_ctrl = rd8(&p);
 	t->blc_ctrl = rd8(&p);
+	p += 2;                        /* 0x4002-0x4003 reserved */
+	t->blk_lvl_target = rd16(&p);
+	p += 2;                        /* 0x4006/07 hwin_pad */
+	t->bl_start = rd8(&p);
+	t->bl_end = rd8(&p);
 	t->isp_ctrl = rd8(&p);
 	t->isp_real_gain = rd16(&p);
 	t->isp_dig_gain = rd16(&p);
@@ -172,6 +199,28 @@ static void telem_publish(uint8_t cam_id, uint32_t now)
 		t->blc_offset[i] = (uint16_t)(((uint16_t)p[i * 4u] << 8) | p[i * 4u + 1u]);
 	}
 	p += 30;
+
+	/* #103 optical-black block, in telem_ops[] order. */
+	t->blk_ln_num = rd8(&p);
+	t->blc_ln_mode = rd8(&p);
+	t->zl_start = rd8(&p);
+	t->zl_end = rd8(&p);
+	t->blc_thres = rd16(&p);
+	t->zero_ln_num = rd16(&p);
+	t->dig_test_fail = rd8(&p);
+	for (uint8_t i = 0; i < 4u; i++) {   /* BLCoffset10000..10011, contiguous */
+		t->blc_offset_z[i] = rd16(&p);
+	}
+	for (uint8_t i = 0; i < 4u; i++) {   /* z_avg_00, _01, _10, _11 */
+		t->z_avg[i] = rd16(&p);
+	}
+	t->zavg_ctrl = rd8(&p);
+	p += 1;                              /* 0x40E9 row data-type selects */
+	t->zl_start2 = rd8(&p);
+	t->zl_end2 = rd8(&p);
+	t->blc_fault_latch = rd8(&p);
+	t->blc_fault_state = rd8(&p);
+	t->dtr_fault = rd8(&p);
 
 	if (p != &telem_staging[TELEM_RAW_BYTES]) {
 		/* Decode desynced from telem_ops[] — programming error, don't
@@ -191,10 +240,11 @@ static void telem_publish(uint8_t cam_id, uint32_t now)
 	if (was_valid &&
 	    (t->wd[0] != prev_wd0 || t->wd[1] != prev_wd1 ||
 	     t->vm_latched != prev_vml || t->vm_cp_latched != prev_vmcpl ||
-	     (uint8_t)(t->tpm_status & 0x0Fu) != prev_tpm)) {
-		printf("CAM%u TELEM fault change: wd=%02X/%02X vm=%02X cp=%02X tpm=%02X\r\n",
+	     (uint8_t)(t->tpm_status & 0x0Fu) != prev_tpm ||
+	     t->blc_fault_latch != prev_blcf)) {
+		printf("CAM%u TELEM fault change: wd=%02X/%02X vm=%02X cp=%02X tpm=%02X blc=%02X\r\n",
 		       cam_id + 1u, t->wd[0], t->wd[1], t->vm_latched,
-		       t->vm_cp_latched, t->tpm_status);
+		       t->vm_cp_latched, t->tpm_status, t->blc_fault_latch);
 	}
 }
 

--- a/Core/Src/i2c_health.c
+++ b/Core/Src/i2c_health.c
@@ -22,7 +22,7 @@ extern IWDG_HandleTypeDef hiwdg1;
 
 #define MUX_I2C_ADDR        0x70u  /* TCA9548A */
 #define IMU_I2C_ADDR        0x68u  /* ICM-20948, AD0=0 */
-#define CAM_SENSOR_I2C_ADDR 0x36u  /* OV2312 */
+#define CAM_SENSOR_I2C_ADDR 0x36u  /* OX02C1B */
 
 /* HAL_I2C_IsDeviceReady tuning: a couple of trials, short bounded timeout so a
  * missing/wedged device can't stall the boot scan. */
@@ -39,7 +39,7 @@ static bool ping(uint8_t addr7)
 }
 
 /*
- * Probe one camera slot.  The OV2312 (0x36) and the CrossLink config port
+ * Probe one camera slot.  The OX02C1B (0x36) and the CrossLink config port
  * (0x40) are reachable in MUTUALLY-EXCLUSIVE FPGA states, so each is checked in
  * its own state within a single power cycle:
  *   - FPGA: rail on with CRESETB held low (forced slave-config) + activation

--- a/Core/Src/if_commands.c
+++ b/Core/Src/if_commands.c
@@ -16,6 +16,7 @@
 #include "i2c_protocol.h"
 #include "ICM20948.h"
 #include "0X02C1B.h"
+#include "camera_telemetry.h"
 #include "histo_fake.h"
 #include "usbd_histo.h"
 #include "motion_config.h"
@@ -940,6 +941,16 @@ static void process_camera_commands(UartPacket *uartResp, UartPacket cmd)
 				uartResp->data = (uint8_t *)&cam_temp; // Point to the static temp variable
 			}
 		}
+		break;
+	case OW_CAMERA_GET_TELEMETRY:
+		/* #94: background-collected per-camera condition snapshot (rails,
+		 * temps, faults, counters). No I2C here — returns the cache that
+		 * camera_telemetry_service() maintains from the main loop. */
+		VERBOSE_CMD("[CMD] OW_CAMERA_GET_TELEMETRY\r\n");
+		uartResp->command = OW_CAMERA_GET_TELEMETRY;
+		uartResp->packet_type = OW_RESP;
+		uartResp->data_len = sizeof(cam_telemetry_response_t);
+		uartResp->data = (uint8_t *)camera_telemetry_get();
 		break;
 	case OW_CAMERA_FSIN_EXTERNAL:
 		VERBOSE_CMD("[CMD] OW_CAMERA_FSIN_EXTERNAL reserved=%u (%s)\r\n", cmd.reserved, cmd.reserved == 0 ? "disable" : "enable");

--- a/Core/Src/if_commands.c
+++ b/Core/Src/if_commands.c
@@ -35,6 +35,19 @@ extern volatile uint8_t event_bits_enabled;
 } while(0)
 
 static uint32_t id_words[4] = {0};  /* 3 UID words + 1 zero-pad: HWID reply is 16B, so [3] would over-read 4B past the array */
+
+/* OW_CMD_BOOT_INFO reply. Reports the RUNTIME vector-table base (SCB->VTOR),
+ * not the compile-time BARE_METAL_BUILD flag, so the device evidences where it
+ * is actually executing: 0x08000000 => bare-metal, 0x08020400 => bootloader
+ * slot. The host derives the boot mode. Packed, little-endian on the wire. */
+typedef struct __attribute__((packed)) {
+	uint8_t  struct_version;   /* 1 */
+	uint8_t  reserved[3];
+	uint32_t vtor;             /* SCB->VTOR */
+	uint32_t flash_base;       /* image link base (same as vtor sans the 0x400 header offset in slot builds) */
+} boot_info_t;
+static boot_info_t boot_info = {0};
+
 static uint8_t camera_status[8] = {0};
 static uint8_t i2c_reg_read_buf[I2C_REG_READ_MAX_LEN] = {0};
 static uint8_t camera_power_status = 0;
@@ -87,6 +100,22 @@ static void process_basic_command(UartPacket *uartResp, UartPacket cmd)
 		id_words[2] = HAL_GetUIDw2();
 		uartResp->data_len = 16;
 		uartResp->data = (uint8_t *)&id_words;
+		break;
+	case OW_CMD_BOOT_INFO:
+		VERBOSE_CMD("[CMD] OW_CMD_BOOT_INFO\r\n");
+		uartResp->command = OW_CMD_BOOT_INFO;
+		uartResp->packet_type = OW_RESP;
+		boot_info.struct_version = 1u;
+		boot_info.reserved[0] = 0u;
+		boot_info.reserved[1] = 0u;
+		boot_info.reserved[2] = 0u;
+		boot_info.vtor       = SCB->VTOR;
+		/* Link base = VTOR. In slot builds the vectors sit at slot+0x400; the
+		 * host only needs VTOR to classify (0x08000000 bare-metal vs 0x08020400
+		 * slot), so we report it directly rather than reconstructing a base. */
+		boot_info.flash_base = SCB->VTOR;
+		uartResp->data_len = sizeof(boot_info);
+		uartResp->data = (uint8_t *)&boot_info;
 		break;
 	case OW_CMD_I2C_REG_READ:
 	{

--- a/Core/Src/if_factory_prog.c
+++ b/Core/Src/if_factory_prog.c
@@ -237,7 +237,8 @@ _Bool process_factory_command(UartPacket *response, UartPacket *cmd)
                      *  [6..9] status, [10..17] feature_row, [18..19] feabits,
                      *  [20..23] usercode, [24] boot_probe_done,
                      *  [25] boot_0x40_responds, [26] num_rows_read,
-                     *  [27..] rows(16B each) */
+                     *  [27..] rows(16B each),
+                     *  [27+16*rows] pin-drive boot verdict (#91, see below) */
                     uint16_t n = 0;
                     memcpy(&i2c_read_buf[n], nvcm_probe.idcode, 4);       n += 4;
                     i2c_read_buf[n++] = nvcm_probe.idcode_ok;
@@ -255,30 +256,26 @@ _Bool process_factory_command(UartPacket *response, UartPacket *cmd)
                         memcpy(&i2c_read_buf[n], nvcm_probe.nvcm_rows, rb);
                         n += rb;
                     }
-                    response->data_len = n;
-                    response->data = i2c_read_buf;
-                    break;
-                }
-                case OW_FACTORY_NVCM_BOOT:
-                {
-                    /* Fast read-only NVCM bootability probe (#91): runs the
-                     * same pin-drive boot test the program paths use.
-                     * Params: data[0] = camera index 0-7 (mux-independent —
-                     * the probe is GPIO-only, no active-cam state needed).
-                     * Response: 1 byte, 1 = NVCM design booted, 0 = no boot.
-                     * OW_ERROR for a bad index or an unpowered camera. */
-                    response->command = OW_FACTORY_NVCM_BOOT;
-                    _Bool booted = 0;
-                    if (cmd->data_len < 1 ||
-                        !camera_nvcm_boot_probe(cmd->data[0], &booted))
+                    /* #91: append the behavioral pin-drive boot verdict so
+                     * this command answers the actual "is it programmed"
+                     * question (does a design boot?), which the register
+                     * reads above cannot — STATUS bit 19 only mirrors the
+                     * Done fuse (openmotion-test-app#44). Trailing byte:
+                     * 1 = NVCM design booted, 0 = no boot, 0xFF = probe
+                     * refused (camera not powered). Old hosts ignore the
+                     * extra byte; new hosts detect pre-#91 firmware by its
+                     * absence. */
+                    _Bool nvcm_booted = 0;
+                    if (camera_nvcm_boot_probe(_active_cam->id, &nvcm_booted))
                     {
-                        response->packet_type = OW_ERROR;
-                        response->data_len = 0;
-                        response->data = NULL;
-                        break;
+                        i2c_read_buf[n++] = nvcm_booted ? 1 : 0;
                     }
-                    i2c_read_buf[0] = booted ? 1 : 0;
-                    response->data_len = 1;
+                    else
+                    {
+                        i2c_read_buf[n++] = 0xFF;
+                    }
+
+                    response->data_len = n;
                     response->data = i2c_read_buf;
                     break;
                 }

--- a/Core/Src/if_factory_prog.c
+++ b/Core/Src/if_factory_prog.c
@@ -259,6 +259,29 @@ _Bool process_factory_command(UartPacket *response, UartPacket *cmd)
                     response->data = i2c_read_buf;
                     break;
                 }
+                case OW_FACTORY_NVCM_BOOT:
+                {
+                    /* Fast read-only NVCM bootability probe (#91): runs the
+                     * same pin-drive boot test the program paths use.
+                     * Params: data[0] = camera index 0-7 (mux-independent —
+                     * the probe is GPIO-only, no active-cam state needed).
+                     * Response: 1 byte, 1 = NVCM design booted, 0 = no boot.
+                     * OW_ERROR for a bad index or an unpowered camera. */
+                    response->command = OW_FACTORY_NVCM_BOOT;
+                    _Bool booted = 0;
+                    if (cmd->data_len < 1 ||
+                        !camera_nvcm_boot_probe(cmd->data[0], &booted))
+                    {
+                        response->packet_type = OW_ERROR;
+                        response->data_len = 0;
+                        response->data = NULL;
+                        break;
+                    }
+                    i2c_read_buf[0] = booted ? 1 : 0;
+                    response->data_len = 1;
+                    response->data = i2c_read_buf;
+                    break;
+                }
                 default:
                     response->packet_type = OW_UNKNOWN;
                     response->data_len = 0;

--- a/Core/Src/logging.c
+++ b/Core/Src/logging.c
@@ -102,14 +102,15 @@ void logging_set_debug_flags(uint32_t flags) {
 	uint32_t prev_flags = debug_flags;
 	debug_flags = flags;
 	if (prev_flags != debug_flags) {
-		printf("Debug flags changed: 0x%08lX -> 0x%08lX%s%s%s%s%s\r\n",
+		printf("Debug flags changed: 0x%08lX -> 0x%08lX%s%s%s%s%s%s\r\n",
 		       (unsigned long)prev_flags,
 		       (unsigned long)debug_flags,
 		       (debug_flags & DEBUG_FLAG_USB_PRINTF) ? " (USB printf ON)" : " (USB printf OFF)",
 		       (debug_flags & DEBUG_FLAG_HISTO_SPARSE) ? " (HISTO sparse ON)" : "",
 		       (debug_flags & DEBUG_FLAG_COMM_VERBOSE) ? " (comm verbose ON)" : "",
 		       (debug_flags & DEBUG_FLAG_CMD_VERBOSE) ? " (verbose cmd ON)" : "",
-		       (debug_flags & DEBUG_FLAG_HISTO_CMP) ? " (histo compress ON)" : "");
+		       (debug_flags & DEBUG_FLAG_HISTO_CMP) ? " (histo compress ON)" : "",
+		       (debug_flags & DEBUG_FLAG_CAMERA_CROP) ? " (camera crop 1720 ON)" : "");
 	}
 	if ((debug_flags & DEBUG_FLAG_USB_PRINTF) == 0u) {
 		// Drop any buffered log data so it doesn't flush later.

--- a/Core/Src/logging.c
+++ b/Core/Src/logging.c
@@ -102,7 +102,7 @@ void logging_set_debug_flags(uint32_t flags) {
 	uint32_t prev_flags = debug_flags;
 	debug_flags = flags;
 	if (prev_flags != debug_flags) {
-		printf("Debug flags changed: 0x%08lX -> 0x%08lX%s%s%s%s%s%s\r\n",
+		printf("Debug flags changed: 0x%08lX -> 0x%08lX%s%s%s%s%s%s%s\r\n",
 		       (unsigned long)prev_flags,
 		       (unsigned long)debug_flags,
 		       (debug_flags & DEBUG_FLAG_USB_PRINTF) ? " (USB printf ON)" : " (USB printf OFF)",
@@ -110,7 +110,8 @@ void logging_set_debug_flags(uint32_t flags) {
 		       (debug_flags & DEBUG_FLAG_COMM_VERBOSE) ? " (comm verbose ON)" : "",
 		       (debug_flags & DEBUG_FLAG_CMD_VERBOSE) ? " (verbose cmd ON)" : "",
 		       (debug_flags & DEBUG_FLAG_HISTO_CMP) ? " (histo compress ON)" : "",
-		       (debug_flags & DEBUG_FLAG_CAMERA_CROP) ? " (camera crop 1720 ON)" : "");
+		       (debug_flags & DEBUG_FLAG_CAMERA_CROP) ? " (camera crop 1720 ON)" : "",
+		       (debug_flags & DEBUG_FLAG_CAMERA_RAW) ? " (camera RAW ON)" : "");
 	}
 	if ((debug_flags & DEBUG_FLAG_USB_PRINTF) == 0u) {
 		// Drop any buffered log data so it doesn't flush later.

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -474,6 +474,7 @@ int main(void)
     camera_i2c_service();    /* Camera-bus work deferred from the frame ISRs (temp poll, mux disables) */
     logging_pump();          /* Flush USB log data buffered from ISR context */
     check_streaming();
+    USBD_HISTO_CheckTxStuck(); /* Recover the HISTO EP if an armed transfer stalls (dead host reader) */
     poll_mcu_temperature();  /* Print warning if MCU junction temp above threshold */
     USB_RecoveryCheck();     /* EFT/lock-up watchdog: rebuild USB stack if bus goes dead */
     system_monitor_poll();   /* ECC report drain + DMA error-flag scan */

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -195,6 +195,30 @@ static void imu_service(void);
 
 /* Private user code ---------------------------------------------------------*/
 /* USER CODE BEGIN 0 */
+/*
+ * Clear the custom secure bootloader's failsafe boot counter (RTC->BKP6R).
+ * The bootloader increments BKP6R on every launch attempt; after
+ * BL_BOOT_FAIL_MAX consecutive attempts that do not clear it, it enters USB DFU
+ * instead of launching us. Calling this early in boot signals a successful
+ * launch so the next normal reset starts from a clean count. No-op in bare-metal
+ * (no bootloader). HAL RTC module is not enabled, so use CMSIS directly. */
+#if !defined(BARE_METAL_BUILD)
+static void clear_boot_counter(void)
+{
+  PWR->CR1     |= PWR_CR1_DBP;            /* disable backup-domain write protect  */
+  RCC->APB4ENR |= RCC_APB4ENR_RTCAPBEN;  /* RTC register APB interface clock      */
+  RCC->CSR     |= RCC_CSR_LSION;          /* LSI on (RTC kernel clock source)      */
+  { uint32_t to = 0U;
+    while (((RCC->CSR & RCC_CSR_LSIRDY) == 0U) && (++to < 0x00100000U)) { } }
+  if ((RCC->BDCR & RCC_BDCR_RTCSEL) == 0U) {
+    RCC->BDCR = (RCC->BDCR & ~RCC_BDCR_RTCSEL) | RCC_BDCR_RTCSEL_1; /* LSI */
+  }
+  RCC->BDCR |= RCC_BDCR_RTCEN;            /* enable RTC                            */
+  RTC->BKP6R = 0U;                        /* successful boot: reset the attempt count */
+  __DSB();
+}
+#endif /* !BARE_METAL_BUILD */
+
 /* Print last reset cause - helps diagnose thermal/brownout (BOR) or watchdog (IWDG) */
 static void print_reset_cause(void)
 {
@@ -366,6 +390,13 @@ int main(void)
   system_monitor_ecc_enable();
   HAL_PWREx_EnableMonitoring();  /* Enable junction temp (TEMPH/TEMPL) monitoring */
   printf("Initializing, please wait ...\r\n");
+
+#if !defined(BARE_METAL_BUILD)
+  /* Signal a successful launch to the custom bootloader (clears its failsafe
+   * boot counter) early, before the camera/FPGA bring-up below, so a stalled
+   * FPGA init (e.g. bitstream not yet flashed) does not trip the DFU fallback. */
+  clear_boot_counter();
+#endif
 
   // enable HS USB MUX
   HAL_GPIO_WritePin(USB_MUX_GPIO_Port, USB_MUX_Pin, GPIO_PIN_RESET);
@@ -2212,7 +2243,32 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
   if (htim->Instance == TIM15) {
     HAL_TIM_Base_Stop_IT(htim);
     if(_enter_dfu) {
-      *((uint32_t *)0x38000000) = 0xDEADBEEF; 
+#if defined(BARE_METAL_BUILD)
+      /* Bare-metal build: no custom bootloader. Arm the RAM magic that
+       * CheckBootloaderFlag() (system_stm32h7xx.c) reads after the reset below;
+       * it then jumps to the STM32 system-memory ROM DFU loader. D3 SRAM
+       * survives the software reset. */
+      *((uint32_t *)0x38000000) = 0xDEADBEEFU;
+      __DSB();
+#else
+      /* Custom-bootloader build: request DFU from our secure bootloader (NOT the
+       * STM32 ROM loader). It reads RTC->BKP7R on the next reset and, when it
+       * holds the magic, enters USB DFU instead of launching the app. The backup
+       * register lives in the VBAT/backup domain and survives the reset below.
+       * Direct CMSIS access (HAL RTC module not enabled): unlock backup domain
+       * (DBP), clock the RTC APB interface + kernel (LSI), then arm the magic. */
+      PWR->CR1     |= PWR_CR1_DBP;
+      RCC->APB4ENR |= RCC_APB4ENR_RTCAPBEN;
+      RCC->CSR     |= RCC_CSR_LSION;
+      { uint32_t to = 0U;
+        while (((RCC->CSR & RCC_CSR_LSIRDY) == 0U) && (++to < 0x00100000U)) { } }
+      if ((RCC->BDCR & RCC_BDCR_RTCSEL) == 0U) {
+        RCC->BDCR = (RCC->BDCR & ~RCC_BDCR_RTCSEL) | RCC_BDCR_RTCSEL_1; /* LSI */
+      }
+      RCC->BDCR |= RCC_BDCR_RTCEN;
+      RTC->BKP7R = 0xB007C0DEU;   /* BL_FORCE_DFU_MAGIC */
+      __DSB();
+#endif
     }
 
 

--- a/Core/Src/system_stm32h7xx.c
+++ b/Core/Src/system_stm32h7xx.c
@@ -85,7 +85,9 @@
 /*!< Uncomment the following line if you need to relocate the vector table
      anywhere in FLASH BANK1 or AXI SRAM, else the vector table is kept at the automatic
      remap of boot address selected */
-/* #define USER_VECT_TAB_ADDRESS */
+/* Relocate the vector table: the boot mode (bare-metal @0x08000000 vs custom
+ * bootloader slot @0x08020400) is resolved below via BARE_METAL_BUILD. */
+#define USER_VECT_TAB_ADDRESS
 
 #if defined(USER_VECT_TAB_ADDRESS)
 #if defined(DUAL_CORE) && defined(CORE_CM4)
@@ -112,11 +114,14 @@
                                                        This value must be a multiple of 0x400. */
 #define VECT_TAB_OFFSET         0x00000000U       /*!< Vector Table base offset field.
                                                        This value must be a multiple of 0x400. */
+#elif defined(BARE_METAL_BUILD)
+#define VECT_TAB_BASE_ADDRESS   0x08000000U       /*!< Bare-metal image at flash base
+                                                       (no bootloader). Multiple of 0x400. */
+#define VECT_TAB_OFFSET         0x00000000U       /*!< Multiple of 0x400. */
 #else
-#define VECT_TAB_BASE_ADDRESS   FLASH_BANK1_BASE  /*!< Vector Table base address field.
-                                                       This value must be a multiple of 0x400. */
-#define VECT_TAB_OFFSET         0x00000000U       /*!< Vector Table base offset field.
-                                                       This value must be a multiple of 0x400. */
+#define VECT_TAB_BASE_ADDRESS   0x08020400U       /*!< Custom bootloader active slot
+                                                       (0x08020000) + image offset (0x400). */
+#define VECT_TAB_OFFSET         0x00000000U       /*!< Multiple of 0x400. */
 #endif /* VECT_TAB_SRAM */
 #endif /* DUAL_CORE && CORE_CM4 */
 #endif /* USER_VECT_TAB_ADDRESS */
@@ -165,6 +170,13 @@
   * @{
   */
 
+/* Bare-metal build only: honour a DFU request by jumping to the STM32
+ * system-memory ROM DFU loader (0x1FF09800 on H743). The application writes
+ * 0xDEADBEEF to D3 SRAM (0x38000000) and resets; that RAM survives the reset and
+ * is checked first thing in SystemInit. In the custom-bootloader build the
+ * bootloader runs first and reads its own RTC backup-register magic, so this is
+ * compiled out and SystemInit boots straight into the slot image. */
+#if defined(BARE_METAL_BUILD)
 void CheckBootloaderFlag(void) {
     if (*((uint32_t *)0x38000000) == 0xDEADBEEF) {
         *((uint32_t *)0x38000000) = 0; // Clear flag
@@ -212,6 +224,7 @@ void CheckBootloaderFlag(void) {
         pJump();
     }
 }
+#endif /* BARE_METAL_BUILD */
 
 /**
   * @brief  Setup the microcontroller system
@@ -222,7 +235,9 @@ void CheckBootloaderFlag(void) {
   */
 void SystemInit (void)
 {
+#if defined(BARE_METAL_BUILD)
   CheckBootloaderFlag();
+#endif
 #if defined (DATA_IN_D2_SRAM)
  __IO uint32_t tmpreg;
 #endif /* DATA_IN_D2_SRAM */

--- a/STM32H743XX_FLASH.ld
+++ b/STM32H743XX_FLASH.ld
@@ -1,12 +1,11 @@
 /*
 ******************************************************************************
 **
-
 **  File        : LinkerScript.ld
 **
-**  Author		: STM32CubeMX
+**  Author      : STM32CubeIDE
 **
-**  Abstract    : Linker script for STM32H743VIHx series
+**  Abstract    : Linker script for STM32H7 series
 **                2048Kbytes FLASH and 1056Kbytes RAM
 **
 **                Set heap size, stack size and stack location according
@@ -16,58 +15,45 @@
 **
 **  Target      : STMicroelectronics STM32
 **
-**  Distribution: The file is distributed “as is,” without any warranty
+**  Distribution: The file is distributed as is, without any warranty
 **                of any kind.
 **
 *****************************************************************************
 ** @attention
 **
-** <h2><center>&copy; COPYRIGHT(c) 2025 STMicroelectronics</center></h2>
+** Copyright (c) 2025 STMicroelectronics.
+** All rights reserved.
 **
-** Redistribution and use in source and binary forms, with or without modification,
-** are permitted provided that the following conditions are met:
-**   1. Redistributions of source code must retain the above copyright notice,
-**      this list of conditions and the following disclaimer.
-**   2. Redistributions in binary form must reproduce the above copyright notice,
-**      this list of conditions and the following disclaimer in the documentation
-**      and/or other materials provided with the distribution.
-**   3. Neither the name of STMicroelectronics nor the names of its contributors
-**      may be used to endorse or promote products derived from this software
-**      without specific prior written permission.
+** This software is licensed under terms that can be found in the LICENSE file
+** in the root directory of this software component.
+** If no LICENSE file comes with this software, it is provided AS-IS.
 **
-** THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-** AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-** IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-** DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-** FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-** DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-** SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-** CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-** OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-** OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-**
-*****************************************************************************
+****************************************************************************
 */
 
 /* Entry Point */
 ENTRY(Reset_Handler)
 
-/* Specify the memory areas */
-MEMORY
-{
-DTCMRAM (xrw)      : ORIGIN = 0x20000000, LENGTH = 128K
-RAM (xrw)      : ORIGIN = 0x24000000, LENGTH = 512K
-RAM_D2 (xrw)      : ORIGIN = 0x30000000, LENGTH = 288K
-RAM_D3 (xrw)      : ORIGIN = 0x38000000, LENGTH = 64K
-ITCMRAM (xrw)      : ORIGIN = 0x00000000, LENGTH = 64K
-FLASH (rx)      : ORIGIN = 0x8000000, LENGTH = 2048K
-}
-
 /* Highest address of the user mode stack */
-_estack = ORIGIN(DTCMRAM) + LENGTH(DTCMRAM);    /* end of RAM */
+_estack = ORIGIN(RAM_D1) + LENGTH(RAM_D1);    /* end of RAM */
 /* Generate a link error if heap and stack don't fit into RAM */
 _Min_Heap_Size = 0x400;      /* required amount of heap  */
 _Min_Stack_Size = 0x800; /* required amount of stack */
+
+/* Specify the memory areas */
+MEMORY
+{
+  /* Custom bootloader active slot 1: 0x08020000 + 0x400 image header offset,
+     512 KB slot (ends 0x0809FFFF). The ~307 KB sensor application fits with room.
+     The FPGA bitstream (0x081A0000), anti-rollback floor (0x081C0000) and config
+     (0x081E0000) sit above the slot and are flashed / managed separately. */
+  FLASH (rx)     : ORIGIN = 0x08020400, LENGTH = 511K
+  DTCMRAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 128K
+  RAM_D1 (xrw)   : ORIGIN = 0x24000000, LENGTH = 512K
+  RAM_D2 (xrw)   : ORIGIN = 0x30000000, LENGTH = 288K
+  SRAM4   (xrw)  : ORIGIN = 0x38000000, LENGTH = 64K  /* <-- add if missing */
+  ITCMRAM (xrw)  : ORIGIN = 0x00000000, LENGTH = 64K
+}
 
 /* Define output sections */
 SECTIONS
@@ -106,49 +92,38 @@ SECTIONS
     . = ALIGN(4);
   } >FLASH
 
-  .ARM.extab (READONLY) : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  .ARM.extab (READONLY) : /* The READONLY keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
   {
-    . = ALIGN(4);
     *(.ARM.extab* .gnu.linkonce.armextab.*)
-    . = ALIGN(4);
   } >FLASH
-
-  .ARM (READONLY) : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  .ARM (READONLY) : /* The READONLY keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
   {
-    . = ALIGN(4);
     __exidx_start = .;
     *(.ARM.exidx*)
     __exidx_end = .;
-    . = ALIGN(4);
   } >FLASH
 
-  .preinit_array (READONLY) : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  .preinit_array (READONLY) : /* The READONLY keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
   {
-    . = ALIGN(4);
     PROVIDE_HIDDEN (__preinit_array_start = .);
     KEEP (*(.preinit_array*))
     PROVIDE_HIDDEN (__preinit_array_end = .);
-    . = ALIGN(4);
   } >FLASH
 
-  .init_array (READONLY) : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  .init_array (READONLY) : /* The READONLY keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
   {
-    . = ALIGN(4);
     PROVIDE_HIDDEN (__init_array_start = .);
     KEEP (*(SORT(.init_array.*)))
     KEEP (*(.init_array*))
     PROVIDE_HIDDEN (__init_array_end = .);
-    . = ALIGN(4);
   } >FLASH
 
-  .fini_array (READONLY) : /* The "READONLY" keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  .fini_array (READONLY) : /* The READONLY keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
   {
-    . = ALIGN(4);
     PROVIDE_HIDDEN (__fini_array_start = .);
     KEEP (*(SORT(.fini_array.*)))
     KEEP (*(.fini_array*))
     PROVIDE_HIDDEN (__fini_array_end = .);
-    . = ALIGN(4);
   } >FLASH
 
   /* used by the startup to initialize data */
@@ -165,72 +140,36 @@ SECTIONS
     *(.RamFunc*)       /* .RamFunc* sections */
 
     . = ALIGN(4);
-  } >DTCMRAM AT> FLASH
-
- /* Initialized TLS data section */
-  .tdata : ALIGN(4)
-  {
-    *(.tdata .tdata.* .gnu.linkonce.td.*)
-    . = ALIGN(4);
     _edata = .;        /* define a global symbol at data end */
-    PROVIDE(__data_end = .);
-    PROVIDE(__tdata_end = .);
-  } >DTCMRAM AT> FLASH
+  } >RAM_D1 AT> FLASH
 
-  PROVIDE( __tdata_start = ADDR(.tdata) );
-  PROVIDE( __tdata_size = __tdata_end - __tdata_start );
-
-  PROVIDE( __data_start = ADDR(.data) );
-  PROVIDE( __data_size = __data_end - __data_start );
-
-  PROVIDE( __tdata_source = LOADADDR(.tdata) );
-  PROVIDE( __tdata_source_end = LOADADDR(.tdata) + SIZEOF(.tdata) );
-  PROVIDE( __tdata_source_size = __tdata_source_end - __tdata_source );
-
-  PROVIDE( __data_source = LOADADDR(.data) );
-  PROVIDE( __data_source_end = __tdata_source_end );
-  PROVIDE( __data_source_size = __data_source_end - __data_source );
   /* Uninitialized data section */
-  .tbss (NOLOAD) : ALIGN(4)
+  . = ALIGN(4);
+  .bss :
   {
-     /* This is used by the startup in order to initialize the .bss secion */
+    /* This is used by the startup in order to initialize the .bss section */
     _sbss = .;         /* define a global symbol at bss start */
     __bss_start__ = _sbss;
-    *(.tbss .tbss.*)
-    . = ALIGN(4);
-    PROVIDE( __tbss_end = . );
-  } >DTCMRAM
-
-  PROVIDE( __tbss_start = ADDR(.tbss) );
-  PROVIDE( __tbss_size = __tbss_end - __tbss_start );
-  PROVIDE( __tbss_offset = ADDR(.tbss) - ADDR(.tdata) );
-
-  PROVIDE( __tls_base = __tdata_start );
-  PROVIDE( __tls_end = __tbss_end );
-  PROVIDE( __tls_size = __tls_end - __tls_base );
-  PROVIDE( __tls_align = MAX(ALIGNOF(.tdata), ALIGNOF(.tbss)) );
-  PROVIDE( __tls_size_align = (__tls_size + __tls_align - 1) & ~(__tls_align - 1) );
-  PROVIDE( __arm32_tls_tcb_offset = MAX(8, __tls_align) );
-  PROVIDE( __arm64_tls_tcb_offset = MAX(16, __tls_align) );
-
-  .bss (NOLOAD) : ALIGN(4)
-  {
     *(.bss)
     *(.bss*)
     *(COMMON)
 
-      . = ALIGN(4);
+    . = ALIGN(4);
     _ebss = .;         /* define a global symbol at bss end */
     __bss_end__ = _ebss;
-      PROVIDE( __bss_end = .);
-  } >DTCMRAM
-  PROVIDE( __non_tls_bss_start = ADDR(.bss) );
+  } >RAM_D1
 
-  PROVIDE( __bss_start = __tbss_start );
-  PROVIDE( __bss_size = __bss_end - __bss_start );
+  /* Persistent across soft/IWDG reset; not zeroed by startup */
+  .noinit (NOLOAD) :
+  {
+    . = ALIGN(4);
+    *(.noinit)
+    *(.noinit*)
+    . = ALIGN(4);
+  } >RAM_D1
 
   /* User_heap_stack section, used to check that there is enough RAM left */
-  ._user_heap_stack (NOLOAD) :
+  ._user_heap_stack :
   {
     . = ALIGN(8);
     PROVIDE ( end = . );
@@ -238,16 +177,33 @@ SECTIONS
     . = . + _Min_Heap_Size;
     . = . + _Min_Stack_Size;
     . = ALIGN(8);
-  } >DTCMRAM
+  } >RAM_D1
 
-
+/* Place USB buffers in RAM_D2 */
+.ram_d2 (NOLOAD) :
+{
+  . = ALIGN(4);
+  *(.ram_d2)
+  . = ALIGN(4);
+} >RAM_D2
 
   /* Remove information from the standard libraries */
   /DISCARD/ :
   {
-    libc.a:* ( * )
-    libm.a:* ( * )
-    libgcc.a:* ( * )
+    libc.a ( * )
+    libm.a ( * )
+    libgcc.a ( * )
   }
 
+  .ARM.attributes 0 : { *(.ARM.attributes) }
+
+/* Place BDMA-safe buffers in SRAM4 */
+.sram4 (NOLOAD) :
+{
+  . = ALIGN(4);
+  *(.sram4)
+  . = ALIGN(4);
+} >SRAM4
 }
+
+

--- a/STM32H743XX_FLASH_BARE.ld
+++ b/STM32H743XX_FLASH_BARE.ld
@@ -1,0 +1,205 @@
+/*
+******************************************************************************
+**
+**  File        : LinkerScript.ld
+**
+**  Author      : STM32CubeIDE
+**
+**  Abstract    : Linker script for STM32H7 series
+**                2048Kbytes FLASH and 1056Kbytes RAM
+**
+**                Set heap size, stack size and stack location according
+**                to application requirements.
+**
+**                Set memory bank area and size if external memory is used.
+**
+**  Target      : STMicroelectronics STM32
+**
+**  Distribution: The file is distributed as is, without any warranty
+**                of any kind.
+**
+*****************************************************************************
+** @attention
+**
+** Copyright (c) 2025 STMicroelectronics.
+** All rights reserved.
+**
+** This software is licensed under terms that can be found in the LICENSE file
+** in the root directory of this software component.
+** If no LICENSE file comes with this software, it is provided AS-IS.
+**
+****************************************************************************
+*/
+
+/* Entry Point */
+ENTRY(Reset_Handler)
+
+/* Highest address of the user mode stack */
+_estack = ORIGIN(RAM_D1) + LENGTH(RAM_D1);    /* end of RAM */
+/* Generate a link error if heap and stack don't fit into RAM */
+_Min_Heap_Size = 0x400;      /* required amount of heap  */
+_Min_Stack_Size = 0x800; /* required amount of stack */
+
+/* Specify the memory areas */
+MEMORY
+{
+  FLASH (rx)     : ORIGIN = 0x08000000, LENGTH = 1024K
+  DTCMRAM (xrw)  : ORIGIN = 0x20000000, LENGTH = 128K
+  RAM_D1 (xrw)   : ORIGIN = 0x24000000, LENGTH = 512K
+  RAM_D2 (xrw)   : ORIGIN = 0x30000000, LENGTH = 288K
+  SRAM4   (xrw)  : ORIGIN = 0x38000000, LENGTH = 64K  /* <-- add if missing */
+  ITCMRAM (xrw)  : ORIGIN = 0x00000000, LENGTH = 64K
+}
+
+/* Define output sections */
+SECTIONS
+{
+  /* The startup code goes first into FLASH */
+  .isr_vector :
+  {
+    . = ALIGN(4);
+    KEEP(*(.isr_vector)) /* Startup code */
+    . = ALIGN(4);
+  } >FLASH
+
+  /* The program code and other data goes into FLASH */
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)           /* .text sections (code) */
+    *(.text*)          /* .text* sections (code) */
+    *(.glue_7)         /* glue arm to thumb code */
+    *(.glue_7t)        /* glue thumb to arm code */
+    *(.eh_frame)
+
+    KEEP (*(.init))
+    KEEP (*(.fini))
+
+    . = ALIGN(4);
+    _etext = .;        /* define a global symbols at end of code */
+  } >FLASH
+
+  /* Constant data goes into FLASH */
+  .rodata :
+  {
+    . = ALIGN(4);
+    *(.rodata)         /* .rodata sections (constants, strings, etc.) */
+    *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
+    . = ALIGN(4);
+  } >FLASH
+
+  .ARM.extab (READONLY) : /* The READONLY keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  {
+    *(.ARM.extab* .gnu.linkonce.armextab.*)
+  } >FLASH
+  .ARM (READONLY) : /* The READONLY keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  {
+    __exidx_start = .;
+    *(.ARM.exidx*)
+    __exidx_end = .;
+  } >FLASH
+
+  .preinit_array (READONLY) : /* The READONLY keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  {
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array*))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+  } >FLASH
+
+  .init_array (READONLY) : /* The READONLY keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  {
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)))
+    KEEP (*(.init_array*))
+    PROVIDE_HIDDEN (__init_array_end = .);
+  } >FLASH
+
+  .fini_array (READONLY) : /* The READONLY keyword is only supported in GCC11 and later, remove it if using GCC10 or earlier. */
+  {
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT(.fini_array.*)))
+    KEEP (*(.fini_array*))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+  } >FLASH
+
+  /* used by the startup to initialize data */
+  _sidata = LOADADDR(.data);
+
+  /* Initialized data sections goes into RAM, load LMA copy after code */
+  .data :
+  {
+    . = ALIGN(4);
+    _sdata = .;        /* create a global symbol at data start */
+    *(.data)           /* .data sections */
+    *(.data*)          /* .data* sections */
+    *(.RamFunc)        /* .RamFunc sections */
+    *(.RamFunc*)       /* .RamFunc* sections */
+
+    . = ALIGN(4);
+    _edata = .;        /* define a global symbol at data end */
+  } >RAM_D1 AT> FLASH
+
+  /* Uninitialized data section */
+  . = ALIGN(4);
+  .bss :
+  {
+    /* This is used by the startup in order to initialize the .bss section */
+    _sbss = .;         /* define a global symbol at bss start */
+    __bss_start__ = _sbss;
+    *(.bss)
+    *(.bss*)
+    *(COMMON)
+
+    . = ALIGN(4);
+    _ebss = .;         /* define a global symbol at bss end */
+    __bss_end__ = _ebss;
+  } >RAM_D1
+
+  /* Persistent across soft/IWDG reset; not zeroed by startup */
+  .noinit (NOLOAD) :
+  {
+    . = ALIGN(4);
+    *(.noinit)
+    *(.noinit*)
+    . = ALIGN(4);
+  } >RAM_D1
+
+  /* User_heap_stack section, used to check that there is enough RAM left */
+  ._user_heap_stack :
+  {
+    . = ALIGN(8);
+    PROVIDE ( end = . );
+    PROVIDE ( _end = . );
+    . = . + _Min_Heap_Size;
+    . = . + _Min_Stack_Size;
+    . = ALIGN(8);
+  } >RAM_D1
+
+/* Place USB buffers in RAM_D2 */
+.ram_d2 (NOLOAD) :
+{
+  . = ALIGN(4);
+  *(.ram_d2)
+  . = ALIGN(4);
+} >RAM_D2
+
+  /* Remove information from the standard libraries */
+  /DISCARD/ :
+  {
+    libc.a ( * )
+    libm.a ( * )
+    libgcc.a ( * )
+  }
+
+  .ARM.attributes 0 : { *(.ARM.attributes) }
+
+/* Place BDMA-safe buffers in SRAM4 */
+.sram4 (NOLOAD) :
+{
+  . = ALIGN(4);
+  *(.sram4)
+  . = ALIGN(4);
+} >SRAM4
+}
+
+

--- a/USB/Class/HISTO/Inc/usbd_histo.h
+++ b/USB/Class/HISTO/Inc/usbd_histo.h
@@ -29,6 +29,12 @@ uint8_t  USBD_HISTO_SendData(USBD_HandleTypeDef *pdev, uint8_t *data, uint16_t l
 void USBD_HISTO_TxCpltCallback(uint8_t *Buf, uint32_t Len, uint8_t epnum);
 void USBD_HISTO_FlushQueue(const char *who);
 
+/* Stuck-TX watchdog -- call from the main loop. Recovers the HISTO IN
+ * endpoint when an armed multi-packet transfer stops making progress
+ * (host reader died mid-transfer), which otherwise wedges the endpoint
+ * until a power cycle. No-op unless a transfer is armed and stalled. */
+void USBD_HISTO_CheckTxStuck(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/USB/Class/HISTO/Src/usbd_histo.c
+++ b/USB/Class/HISTO/Src/usbd_histo.c
@@ -109,6 +109,12 @@ static volatile uint32_t histo_deq_count = 0;
 static volatile uint32_t histo_datain_count = 0;
 static volatile uint32_t histo_tx_fail_count = 0;
 
+/* Stuck-TX watchdog state (see USBD_HISTO_CheckTxStuck). Written from the
+ * main loop and from SetTxBuffer; read alongside histo_ep_data. */
+static volatile uint32_t histo_tx_armed_ms = 0;    /* tick when the in-flight transfer last progressed */
+static volatile uint32_t histo_tx_progress = 0;    /* histo_datain_count at that moment */
+static volatile uint32_t histo_tx_stuck_count = 0; /* watchdog recoveries (diagnostic) */
+
 #ifndef USB_RAM_D2
 #define USB_RAM_D2 __attribute__((section(".ram_d2")))
 #endif
@@ -140,6 +146,18 @@ static uint8_t USBD_Histo_Init(USBD_HandleTypeDef *pdev, uint8_t cfgidx)
     histo_queue_tail = 0;
     histo_queue_count = 0;
     histo_pdev = pdev;
+
+    /* Abandon any transfer the previous session left armed. A host reader
+     * that dies mid-transfer leaves histo_ep_data set with no DataIn ever
+     * coming; the flag used to survive this reconfigure, so every later
+     * SetTxBuffer returned BUSY, the 4-entry queue filled, and the
+     * endpoint stayed dead until a power cycle. A USB reset did not help
+     * either -- it runs this same DeInit/Init path. */
+    histo_ep_data = 0;
+    tx_histo_ptr = 0;
+    tx_histo_total_len = 0;
+    histo_tx_armed_ms = 0;
+    histo_tx_progress = 0;
 
     if (pdev->dev_speed == USBD_SPEED_HIGH)
     {
@@ -192,6 +210,14 @@ static uint8_t USBD_Histo_DeInit(USBD_HandleTypeDef *pdev, uint8_t cfgidx)
   histo_queue_tail = 0;
   histo_queue_count = 0;
   histo_pdev = NULL;
+
+  /* Same reason as Init: the in-flight marker must not outlive the
+   * session that armed it. */
+  histo_ep_data = 0;
+  tx_histo_ptr = 0;
+  tx_histo_total_len = 0;
+  histo_tx_armed_ms = 0;
+  histo_tx_progress = 0;
 #ifdef USE_USBD_COMPOSITE
   if (pdev->pClassDataCmsit[pdev->classId] != NULL)
   {
@@ -405,6 +431,15 @@ uint8_t USBD_HISTO_SendData(USBD_HandleTypeDef *pdev, uint8_t *data, uint16_t le
     histo_pdev = pdev;
   }
 
+  /* Do not push into a core that cannot move data. When the host
+   * selectively suspends the device the PHY clock is gated, and
+   * transmitting into it neither completes nor errors -- it just strands
+   * a transfer that DataIn will never finish. Drop the frame instead;
+   * histogram sends are already fire-and-forget. */
+  if (pdev->dev_state != USBD_STATE_CONFIGURED) {
+    return USBD_FAIL;
+  }
+
   /* If queue is empty and not currently sending, send directly */
   if (histo_queue_is_empty() && histo_ep_data == 0) {
     uint8_t ret = USBD_HISTO_SetTxBuffer(pdev, data, len);
@@ -451,6 +486,8 @@ void USBD_HISTO_FlushQueue(const char *who)
   histo_ep_data = 0;
   tx_histo_ptr = 0;
   tx_histo_total_len = 0;
+  histo_tx_armed_ms = 0;
+  histo_tx_progress = 0;
   if (histo_pdev != NULL && histo_ep_enabled != 0) {
     USBD_LL_FlushEP(histo_pdev, HISTOInEpAdd);
   }
@@ -463,6 +500,48 @@ void USBD_HISTO_FlushQueue(const char *who)
    *   e-d= enq-deq; this should EQUAL q. If e-d != q the count was corrupted by
    *        a cross-ISR race; if e-d == q > 0 the scan honestly left frames unsent. */
   printf("HISTO flush(%s): q=%u ep=%u e-d=%ld\r\n", who, pending, inflight, gap);
+}
+
+/* Stuck-TX watchdog. A multi-packet histogram transfer is chained by the
+ * DataIn completion interrupt: each 512-byte packet arms the next. If the
+ * host stops issuing IN tokens mid-chain -- a reader process dying, a
+ * cancelled transfer halting the pipe -- DataIn never fires again, so
+ * histo_ep_data stays 1 and histo_process_queue() returns BUSY forever.
+ * Nothing else in the class can break that cycle from inside a session.
+ *
+ * Call from the main loop. When a transfer has been armed for longer than
+ * HISTO_TX_STUCK_MS with no DataIn progress, abandon it: FlushQueue drops
+ * the EP FIFO, clears the in-flight marker and empties the queue, so the
+ * next frame starts a clean transfer.
+ *
+ * Deliberately keyed on lack of *progress*, not on elapsed time alone --
+ * a slow-but-advancing host must never be interrupted (the healthy path
+ * is what test_stream_resumes_within_one_session guards). */
+#define HISTO_TX_STUCK_MS 500u
+
+void USBD_HISTO_CheckTxStuck(void)
+{
+  if (histo_ep_data == 0 || histo_pdev == NULL || histo_ep_enabled == 0) {
+    return;
+  }
+
+  uint32_t datain_now = histo_datain_count;
+  if (datain_now != histo_tx_progress) {
+    /* Transfer is advancing -- re-arm the window and leave it alone. */
+    histo_tx_progress = datain_now;
+    histo_tx_armed_ms = HAL_GetTick();
+    return;
+  }
+
+  if ((HAL_GetTick() - histo_tx_armed_ms) < HISTO_TX_STUCK_MS) {
+    return;
+  }
+
+  histo_tx_stuck_count++;
+  /* FlushQueue clears histo_ep_data/tx bookkeeping under a critical
+   * section and prints its own one-line diagnostic, so the endpoint is
+   * usable again as soon as this returns. */
+  USBD_HISTO_FlushQueue("txstuck");
 }
 
 uint8_t  USBD_HISTO_SetTxBuffer(USBD_HandleTypeDef *pdev, uint8_t  *pbuff, uint16_t length)
@@ -490,6 +569,9 @@ uint8_t  USBD_HISTO_SetTxBuffer(USBD_HandleTypeDef *pdev, uint8_t  *pbuff, uint1
 		ret = USBD_LL_Transmit(pdev, HISTOInEpAdd, pTxHistoBuff, pkt_len);
 		if (ret == USBD_OK) {
 			histo_ep_data = 1;
+			/* Arm the stuck-TX watchdog against this transfer. */
+			histo_tx_armed_ms = HAL_GetTick();
+			histo_tx_progress = histo_datain_count;
 		} else {
 			histo_tx_fail_count++;
 			histo_ep_data = 0;

--- a/cmake/gcc-arm-none-eabi.cmake
+++ b/cmake/gcc-arm-none-eabi.cmake
@@ -36,7 +36,9 @@ set(CMAKE_CXX_FLAGS_RELEASE "-Os -g0")
 set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -fno-rtti -fno-exceptions -fno-threadsafe-statics")
 
 set(CMAKE_EXE_LINKER_FLAGS "${TARGET_FLAGS}")
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -T \"${CMAKE_SOURCE_DIR}/STM32H743VIHX_FLASH.ld\"")
+# NOTE: the linker script is selected in CMakeLists.txt via the BARE_METAL option
+# (STM32H743XX_FLASH.ld = bootloader slot @0x08020400,
+#  STM32H743XX_FLASH_BARE.ld = bare-metal @0x08000000). Not hard-coded here.
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --specs=nano.specs")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-Map=${CMAKE_PROJECT_NAME}.map -Wl,--gc-sections")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--print-memory-usage")

--- a/docs/fpga-nvcm-autodetect.md
+++ b/docs/fpga-nvcm-autodetect.md
@@ -115,7 +115,7 @@ the i2cem/isp path depends on index 5 first.)
 
 ### Background
 
-Each sensor module has 8 OV2312 cameras, each with its own Lattice CrossLink
+Each sensor module has 8 OX02C1B cameras, each with its own Lattice CrossLink
 FPGA behind a TCA9548A I2C mux at address 0x70.  The FPGAs compute histograms
 from MIPI CSI-2 camera data.
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -241,6 +241,29 @@ All command and response traffic on the COMMS interface uses a fixed binary pack
 | `OW_CAMERA_POWER_OFF` | 0x51 | Remove power from camera(s) in `addr` mask; manages FSIN_EXT disable/re-enable around power transitions |
 | `OW_CAMERA_POWER_STATUS` | 0x52 | Return 1-byte bitmask of powered cameras (bit N = camera N powered) |
 | `OW_CAMERA_READ_SECURITY_UID` | 0x53 | Read 6-byte security UID from camera specified by `cmd.addr` (0–7) |
+| `OW_CAMERA_GET_TELEMETRY` | 0x54 | Return the cached 628-byte `cam_telemetry_response_t` snapshot (see Camera Telemetry below); no I2C in the handler |
+
+#### Camera Telemetry (#94)
+
+Firmware continuously sweeps every powered camera's condition registers in the
+background (`camera_telemetry_service()`, driven from `camera_i2c_service()`):
+supply rails AVDD/DOVDD/DVDD from the on-die voltage monitor, dual junction
+temperatures + cross-check alarm, voltage/charge-pump fault latches, watchdog
+fault roll-up + sensor state machine, OTP CRC status, MIPI frame counter,
+FSIN trigger-error flag, on-chip frame mean (Yavg), commanded vs applied
+exposure/gain, correction-state bytes (0x4001/0x5000/0x3503/0x3A93), and the
+eight applied BLC channel offsets.
+
+- One camera sweep (1 write + 22 burst reads, ~85 raw bytes) starts every
+  `CAM_TELEM_SWEEP_INTERVAL_MS` (125 ms), round-robin → ~1 s full-fleet
+  refresh; sweeps run in chunks of ≤6 transactions per main-loop pass.
+- Values are raw register bytes (MSB-first); the SDK converts to volts
+  (`code × 6/4096`), °C (8.8 format, >0xC000 negative), and gain factors.
+- A failed transaction aborts that sweep; the cache keeps the camera's last
+  completed snapshot (`updated_ms` reveals staleness, `i2c_err_count` counts
+  failures, `sweep_count` proves liveness).
+- Firmware prints a one-line notice when a camera's fault latches change
+  between sweeps.
 
 #### FSIN Management During Power Transitions
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -241,7 +241,7 @@ All command and response traffic on the COMMS interface uses a fixed binary pack
 | `OW_CAMERA_POWER_OFF` | 0x51 | Remove power from camera(s) in `addr` mask; manages FSIN_EXT disable/re-enable around power transitions |
 | `OW_CAMERA_POWER_STATUS` | 0x52 | Return 1-byte bitmask of powered cameras (bit N = camera N powered) |
 | `OW_CAMERA_READ_SECURITY_UID` | 0x53 | Read 6-byte security UID from camera specified by `cmd.addr` (0–7) |
-| `OW_CAMERA_GET_TELEMETRY` | 0x54 | Return the cached 628-byte `cam_telemetry_response_t` snapshot (see Camera Telemetry below); no I2C in the handler |
+| `OW_CAMERA_GET_TELEMETRY` | 0x54 | Return the cached 604-byte `cam_telemetry_response_t` snapshot (see Camera Telemetry below); no I2C in the handler |
 
 #### Camera Telemetry (#94)
 
@@ -249,12 +249,16 @@ Firmware continuously sweeps every powered camera's condition registers in the
 background (`camera_telemetry_service()`, driven from `camera_i2c_service()`):
 supply rails AVDD/DOVDD/DVDD from the on-die voltage monitor, dual junction
 temperatures + cross-check alarm, voltage/charge-pump fault latches, watchdog
-fault roll-up + sensor state machine, OTP CRC status, MIPI frame counter,
+fault roll-up + sensor state machine, OTP CRC status, live row counter,
 FSIN trigger-error flag, on-chip frame mean (Yavg), commanded vs applied
 exposure/gain, correction-state bytes (0x4001/0x5000/0x3503/0x3A93), and the
-eight applied BLC channel offsets.
+eight applied BLC channel offsets. The response header also carries the
+firmware's FSIN pulse count and uptime. (The sensor's own "32-bit frame
+counter" has no readable SCCB value register on this silicon — 0x4900-03 are
+control bytes only, bench-verified — so frames-triggered truth is the
+firmware FSIN counter.)
 
-- One camera sweep (1 write + 22 burst reads, ~85 raw bytes) starts every
+- One camera sweep (1 write + 21 burst reads, ~81 raw bytes) starts every
   `CAM_TELEM_SWEEP_INTERVAL_MS` (125 ms), round-robin → ~1 s full-fleet
   refresh; sweeps run in chunks of ≤6 transactions per main-loop pass.
 - Values are raw register bytes (MSB-first); the SDK converts to volts

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -181,6 +181,7 @@ All command and response traffic on the COMMS interface uses a fixed binary pack
 | 5 | `DEBUG_FLAG_CMD_VERBOSE` | Enable `printf` inside command handlers |
 | 6 | `DEBUG_FLAG_HISTO_CMP` | Send compressed histogram packets (`TYPE_HISTO_CMP`) |
 | 9 | `DEBUG_FLAG_CAMERA_CROP` | Crop camera output to 1720×1280 (drop rightmost 200 columns) when cameras are (re)configured — misaligned-optic test |
+| 10 | `DEBUG_FLAG_CAMERA_RAW` | Raw "scientific sensor" mode: disable all on-sensor pixel corrections (BLC, DC-BLC, dither, OTP DPC) when cameras are (re)configured. Pedestal becomes the raw per-channel offset (~255 DN @1×, ~495 DN @16×); not for production scans |
 
 ---
 

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -180,6 +180,7 @@ All command and response traffic on the COMMS interface uses a fixed binary pack
 | 4 | `DEBUG_FLAG_COMM_VERBOSE` | Enable verbose logging in `uart_comms.c` |
 | 5 | `DEBUG_FLAG_CMD_VERBOSE` | Enable `printf` inside command handlers |
 | 6 | `DEBUG_FLAG_HISTO_CMP` | Send compressed histogram packets (`TYPE_HISTO_CMP`) |
+| 9 | `DEBUG_FLAG_CAMERA_CROP` | Crop camera output to 1720×1280 (drop rightmost 200 columns) when cameras are (re)configured — misaligned-optic test |
 
 ---
 

--- a/generate_vscode_files.py
+++ b/generate_vscode_files.py
@@ -210,7 +210,94 @@ EMBED_TEMPLATES = {
             }
         },
         {
-            "label": "Flash Firmware (Debug)",
+            "label": "CMake: Configure (Debug-BareMetal)",
+            "type": "shell",
+            "command": "cmake",
+            "args": [
+                "--preset",
+                "Debug-BareMetal"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "options": {
+                "env": {
+                    "PATH": "${TOOLCHAIN_BIN_PATH}:${env:PATH}"
+                }
+            }
+        },
+        {
+            "label": "CMake: Build (Debug-BareMetal)",
+            "type": "shell",
+            "command": "cmake",
+            "args": [
+                "--build",
+                "${workspaceFolder}/${BUILD_DIR}/Debug-BareMetal",
+                "--config",
+                "Debug",
+                "--target",
+                "all",
+                "-j",
+                "10",
+                "--verbose"
+            ],
+            "group": "build",
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "dependsOn": [
+                "CMake: Configure (Debug-BareMetal)"
+            ],
+            "options": {
+                "env": {
+                    "PATH": "${TOOLCHAIN_BIN_PATH}:${env:PATH}"
+                }
+            }
+        },
+        {
+            "label": "CMake: Configure (Release-BareMetal)",
+            "type": "shell",
+            "command": "cmake",
+            "args": [
+                "--preset",
+                "Release-BareMetal"
+            ],
+            "group": "build",
+            "problemMatcher": [],
+            "options": {
+                "env": {
+                    "PATH": "${TOOLCHAIN_BIN_PATH}:${env:PATH}"
+                }
+            }
+        },
+        {
+            "label": "CMake: Build (Release-BareMetal)",
+            "type": "shell",
+            "command": "cmake",
+            "args": [
+                "--build",
+                "${workspaceFolder}/${BUILD_DIR}/Release-BareMetal",
+                "--config",
+                "Release",
+                "--target",
+                "all",
+                "-j",
+                "10"
+            ],
+            "group": "build",
+            "problemMatcher": [
+                "$gcc"
+            ],
+            "dependsOn": [
+                "CMake: Configure (Release-BareMetal)"
+            ],
+            "options": {
+                "env": {
+                    "PATH": "${TOOLCHAIN_BIN_PATH}:${env:PATH}"
+                }
+            }
+        },
+        {
+            "label": "Flash Firmware (Debug-BareMetal)",
             "type": "shell",
             "command": "${OPENOCD_PATH}",
             "args": [
@@ -219,19 +306,19 @@ EMBED_TEMPLATES = {
                 "-f",
                 "target/${STM32_TARGET}",
                 "-c",
-                "program ${BUILD_DIR}/Debug/${ELF_NAME}.hex reset exit"
+                "program ${BUILD_DIR}/Debug-BareMetal/${ELF_NAME}.hex reset exit"
             ],
             "group": "build",
             "problemMatcher": [],
             "dependsOn": [
-                "CMake: Build (Debug)"
+                "CMake: Build (Debug-BareMetal)"
             ],
             "options": {
                 "cwd": "${workspaceFolder}"
             }
         },
         {
-            "label": "Flash Firmware (Release)",
+            "label": "Flash Firmware (Release-BareMetal)",
             "type": "shell",
             "command": "${OPENOCD_PATH}",
             "args": [
@@ -240,12 +327,12 @@ EMBED_TEMPLATES = {
                 "-f",
                 "target/${STM32_TARGET}",
                 "-c",
-                "program ${BUILD_DIR}/Release/${ELF_NAME}.hex reset exit"
+                "program ${BUILD_DIR}/Release-BareMetal/${ELF_NAME}.hex reset exit"
             ],
             "group": "build",
             "problemMatcher": [],
             "dependsOn": [
-                "CMake: Build (Release)"
+                "CMake: Build (Release-BareMetal)"
             ],
             "options": {
                 "cwd": "${workspaceFolder}"
@@ -260,33 +347,11 @@ EMBED_TEMPLATES = {
             "problemMatcher": []
         },
         {
-            "label": "Deploy Sensor Left",
+            "label": "Deploy Console",
             "type": "shell",
             "command": "python",
             "args": [
-                "${workspaceFolder}/scripts/deploy.py",
-                "--device",
-                "left"
-            ],
-            "group": "build",
-            "problemMatcher": [],
-            "presentation": {
-                "reveal": "always",
-                "focus": true,
-                "panel": "dedicated"
-            },
-            "options": {
-                "cwd": "${workspaceFolder}"
-            }
-        },
-        {
-            "label": "Deploy Sensor Right",
-            "type": "shell",
-            "command": "python",
-            "args": [
-                "${workspaceFolder}/scripts/deploy.py",
-                "--device",
-                "right"
+                "${workspaceFolder}/scripts/deploy.py"
             ],
             "group": "build",
             "problemMatcher": [],

--- a/tests/_histo_wedge_reader.py
+++ b/tests/_histo_wedge_reader.py
@@ -1,0 +1,77 @@
+"""Child reader for test_histo_wedge_recovery_hil — meant to be hard-killed.
+
+Brings up two cameras, streams histograms, prints ``CHILD_STREAMING <bytes>``
+once frames are flowing, then reads until killed. It never tears anything
+down: the parent kills it with SIGKILL/taskkill, which is the only faithful
+way to produce "host reader process died mid-transfer".
+
+MotionInterface.stop() is NOT a substitute — ConnectionMonitor._teardown()
+drives every handle to DISCONNECTED so the transport releases cleanly, which
+is exactly the orderly shutdown this scenario must avoid.
+"""
+import queue
+import sys
+import time
+
+CAM_MASK = 0x03
+STREAM_TIMEOUT_S = 60.0
+
+
+def main():
+    side = sys.argv[1] if len(sys.argv) > 1 else "left"
+
+    from omotion import MotionInterface
+    from omotion.MotionProcessing import HISTOGRAM_BYTES
+
+    iface = MotionInterface()
+    iface.start(wait=False)
+    sensor = None
+    deadline = time.monotonic() + 25.0
+    while time.monotonic() < deadline and sensor is None:
+        sensor = next((s for s in iface.connected_sensors()
+                       if getattr(s, "side", None) == side), None)
+        time.sleep(0.3)
+    if sensor is None:
+        print("CHILD_FAIL no sensor", flush=True)
+        return 1
+
+    if not sensor.enable_camera_power(CAM_MASK):
+        print("CHILD_FAIL camera power", flush=True)
+        return 1
+    time.sleep(0.5)
+    if not sensor.program_fpga(camera_position=CAM_MASK, manual_process=False):
+        print("CHILD_FAIL program_fpga", flush=True)
+        return 1
+    time.sleep(0.1)
+    if not sensor.camera_configure_registers(CAM_MASK):
+        print("CHILD_FAIL configure", flush=True)
+        return 1
+
+    q = queue.Queue()
+    sensor.uart.histo.start_streaming(q, expected_size=HISTOGRAM_BYTES)
+    if not sensor.enable_camera(CAM_MASK) or not sensor.enable_aggregator_fsin():
+        print("CHILD_FAIL stream start", flush=True)
+        return 1
+
+    got = 0
+    announced = False
+    t_end = time.monotonic() + STREAM_TIMEOUT_S
+    while time.monotonic() < t_end:
+        try:
+            chunk = q.get(timeout=0.2)
+            if chunk:
+                got += len(chunk)
+        except queue.Empty:
+            pass
+        if not announced and got > 3 * HISTOGRAM_BYTES:
+            print(f"CHILD_STREAMING {got}", flush=True)
+            announced = True
+
+    # Only reached if the parent never killed us -- that is a test bug, and
+    # the parent treats it as one.
+    print("CHILD_NOT_KILLED", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_camera_gain_hil.py
+++ b/tests/test_camera_gain_hil.py
@@ -1,7 +1,7 @@
 """HIL: configure all cameras, then read back each camera's analog-gain
 register and verify it matches the per-position gain the firmware writes.
 
-The OV2312 image sensor lives at I2C 0x36; its analog-gain register is 0x3508
+The OX02C1B image sensor lives at I2C 0x36; its analog-gain register is 0x3508
 (16-bit register address). During camera_configure_registers(), the firmware
 (X02C1B_configure_sensor in Core/Src/0X02C1B.c) writes the default config table
 and then overrides 0x3508 with a per-position gain by camera id:
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 CONNECT_TIMEOUT_S = 15.0
 
 OV2312_ADDR = 0x36
-GAIN_REG = 0x3508            # OV2312 analog gain, 16-bit register address
+GAIN_REG = 0x3508            # OX02C1B analog gain, 16-bit register address
 IMU_ADDR = 0x68             # ICM20948, on the main bus (not behind the mux)
 IMU_WHOAMI_REG = 0x00
 IMU_WHOAMI_EXPECTED = 0xEA
@@ -71,7 +71,7 @@ def interface():
 
 
 def _present_cameras(sensor):
-    """0-based positions whose OV2312 responded; fall back to all 8."""
+    """0-based positions whose OX02C1B responded; fall back to all 8."""
     try:
         health = sensor.get_i2c_health(rescan=True)
         cams = health.get("cameras") if isinstance(health, dict) else None

--- a/tests/test_camera_telemetry_hil.py
+++ b/tests/test_camera_telemetry_hil.py
@@ -1,15 +1,19 @@
-"""HIL: continuous camera-sensor telemetry (#94, OW_CAMERA_GET_TELEMETRY).
+"""HIL: continuous camera-sensor telemetry (#94 + OB block #103).
 
 Brings up every present camera, lets the firmware's background sweep refresh
 the fleet (~1 s round-robin), then validates the cached snapshot end to end:
 
-- response framing: version 1, struct_size 78, valid bit per powered camera
+- response framing: version 2, struct_size 110, valid bit per powered camera
 - supply rails from the on-die voltage monitor sit inside the alarm windows
   the config table programs (AVDD [2.52, 3.08] V etc., V = code * 6 / 4096)
 - die temperatures are plausible (10-95 degC) and TPM cross-check alarm clear
 - no camera sits in safe mode (sc_state 5); no VM/watchdog fault latched
 - correction-state bytes match the production table (0x4001=0x23, 0x5000=0x34,
   AEC/AGC manual 0xA8) and commanded analog gain matches the per-slot ladder
+- the optical-black block's window/target/trigger context matches what the
+  config table programs (#103) — the dark-row averages themselves are printed,
+  not asserted, until a bench baseline exists (the watchdog bytes taught us
+  that an un-baselined "fault" byte is usually a configuration signature)
 - sweeps stay live (sweep_count advances between polls)
 - during a ~3 s stream_on + internal-FSIN burst, sweeps observe the probe
   camera actually producing frames: sc_state reads 0x9 (streaming) and the
@@ -62,6 +66,18 @@ PRODUCTION_ISP_CTRL = 0x34   # 0x5000 (raw mode #89 would read 0x30)
 AEC_AGC_MANUAL = 0xA8        # 0x3503
 EXPECTED_EXPO_ROWS = 0x0048  # 72 rows = 648 us (config table)
 SC_STATE_SAFE_MODE = 0x5
+
+# OB / black-level context the config table programs (#103). These are what
+# X02C1B_SENSOR_CONFIG writes, so a mismatch means the applied config drifted
+# — unlike the dark-row averages, they are safe to assert on the first run.
+EXPECTED_OB_CONTEXT = {
+    "blc_trig_ctrl": 0xF9,     # 0x4000
+    "blk_lvl_target": 0x080,   # 0x4004/05 — servo target pedestal 128
+    "bl_start": 0x04,          # 0x4008 — black-row window
+    "bl_end": 0x1B,            # 0x4009
+    "zl_start": 0x02,          # 0x4050 — zero-line window feeding z_avg
+    "zl_end": 0x0D,            # 0x4051
+}
 
 
 @pytest.fixture
@@ -132,7 +148,7 @@ def test_camera_telemetry_snapshot(interface):
 
         telem = sensor.get_camera_telemetry()
         assert telem is not None, f"[{side}] get_camera_telemetry returned None"
-        assert telem["version"] == 1, f"[{side}] unexpected telemetry version"
+        assert telem["version"] == 2, f"[{side}] unexpected telemetry version"
 
         print(f"\n=== Sensor [{side}] camera telemetry ===")
         print(f"{'cam':>3} | {'AVDD':>6} {'DOVDD':>6} {'DVDD':>6} | "
@@ -193,6 +209,43 @@ def test_camera_telemetry_snapshot(interface):
                 failures.append(
                     f"[{side}] cam {cam_id}: {c['i2c_err_count']} sweep I2C errors")
 
+            # OB block (#103): the window/target/trigger context is programmed
+            # by the config table, so assert it. The dark-row averages and the
+            # BLC fault byte have no bench baseline yet — report only.
+            for key, expected in EXPECTED_OB_CONTEXT.items():
+                if c[key] != expected:
+                    failures.append(
+                        f"[{side}] cam {cam_id}: {key} 0x{c[key]:02X} != "
+                        f"config-table 0x{expected:02X}")
+
+        # --- OB / black-level report (#103) -------------------------------
+        # z_avg_00/01/10/11 are the zero-line (dark row) averages per Bayer
+        # position. Mono sensor: all four sample the same physical dark rows,
+        # so spread should be ~0 and the mean is the dark pedestal. Printed
+        # for baselining; only structural context above is asserted.
+        print(f"\n--- Sensor [{side}] optical-black block ---")
+        print(f"{'cam':>3} | {'z_avg 00/01/10/11':>27} | {'mean':>7} {'spr':>4} | "
+              f"{'target':>6} | {'thres':>5} | {'blcflt':>6} | {'BLCoff_z':>19}")
+        print("-" * 96)
+        for cam_id in present:
+            c = telem["cameras"][cam_id]
+            if not c["valid"]:
+                continue
+            z = "/".join(f"{v:6d}" for v in c["z_avg"])
+            offz = "/".join(f"{v:4d}" for v in c["blc_offsets_z"])
+            print(f"{cam_id:>3} | {z:>27} | {c['z_avg_mean']:7.1f} "
+                  f"{c['z_avg_spread']:4d} | {c['blk_lvl_target']:6d} | "
+                  f"{c['blc_thres']:5d} | {c['blc_fault_latch']:02X}/"
+                  f"{c['blc_fault_state']:01X}  | {offz:>19}")
+        print(f"    zero-line window rows {telem['cameras'][present[0]]['zl_start']}"
+              f"-{telem['cameras'][present[0]]['zl_end']}, "
+              f"black-row window {telem['cameras'][present[0]]['bl_start']}"
+              f"-{telem['cameras'][present[0]]['bl_end']}, "
+              f"z_avg_sel={telem['cameras'][present[0]]['z_avg_sel']}, "
+              f"dtr_fault/dig_test_fail="
+              f"{telem['cameras'][present[0]]['dtr_fault']}/"
+              f"{telem['cameras'][present[0]]['dig_test_fail']}")
+
         # Liveness: sweeps keep advancing.
         probe_cam = present[0]
         first = telem["cameras"][probe_cam]["sweep_count"]
@@ -218,23 +271,29 @@ def test_camera_telemetry_snapshot(interface):
         while time.monotonic() < t_end:
             time.sleep(0.4)
             c = sensor.get_camera_telemetry()["cameras"][probe_cam]
-            samples.append((c["updated_ms"], c["tc_row"], c["sc_state"]))
+            samples.append((c["updated_ms"], c["tc_row"], c["sc_state"],
+                            tuple(c["z_avg"])))
         sensor.disable_aggregator_fsin()
         sensor._send(packetType=OW_CAMERA, command=OW_CAMERA_OFF)
         pc_after = sensor.get_camera_telemetry()["fsin_pulse_count"]
 
         fresh = {}
-        for upd, tc, sc in samples:
-            fresh[upd] = (tc, sc)
+        for upd, tc, sc, z in samples:
+            fresh[upd] = (tc, sc, z)
         print(f"burst sweeps for cam {probe_cam}: "
-              f"{[(u, t, hex(s)) for u, (t, s) in sorted(fresh.items())]} "
+              f"{[(u, t, hex(s)) for u, (t, s, _) in sorted(fresh.items())]} "
               f"(ext-FSIN pulse count {pc_before} -> {pc_after})")
+        # Open question this run answers: does z_avg track the dark rows while
+        # streaming, and does it move at all? Reported, not asserted.
+        z_seq = [z for _, (_, _, z) in sorted(fresh.items())]
+        print(f"  z_avg across burst sweeps: {z_seq}")
+        print(f"  z_avg changed during burst: {len(set(z_seq)) > 1}")
         if len(fresh) < 2:
             failures.append(
                 f"[{side}] only {len(fresh)} fresh sweep(s) during 3 s burst")
         else:
-            tc_vals = [t for t, _ in fresh.values()]
-            sc_vals = [s for _, s in fresh.values()]
+            tc_vals = [t for t, _, _ in fresh.values()]
+            sc_vals = [s for _, s, _ in fresh.values()]
             if 0x9 not in sc_vals:
                 failures.append(
                     f"[{side}] cam {probe_cam} never seen in streaming state "

--- a/tests/test_camera_telemetry_hil.py
+++ b/tests/test_camera_telemetry_hil.py
@@ -11,8 +11,12 @@ the fleet (~1 s round-robin), then validates the cached snapshot end to end:
 - correction-state bytes match the production table (0x4001=0x23, 0x5000=0x34,
   AEC/AGC manual 0xA8) and commanded analog gain matches the per-slot ladder
 - sweeps stay live (sweep_count advances between polls)
-- the MIPI frame counter increases after single-histogram captures and by a
-  sane amount — this also pins down the 0x4900-03 byte order on real silicon
+- during a ~3 s stream_on + internal-FSIN burst, sweeps observe the probe
+  camera actually producing frames: sc_state reads 0x9 (streaming) and the
+  live row counter (0x3892) moves between fresh sweeps. (The sensor's own
+  "frame counter" has no readable SCCB value register on this silicon, and
+  the firmware's fsin_pulse_count counts external/console FSIN edges only —
+  both bench-verified 2026-07-17.)
 
 Requires the SDK with MotionSensor.get_camera_telemetry() (openmotion-sdk#...,
 same change series as fw PR for #94); skips with a clear message on older SDKs.
@@ -177,10 +181,10 @@ def test_camera_telemetry_snapshot(interface):
             if c["aec_mode"] != AEC_AGC_MANUAL:
                 failures.append(
                     f"[{side}] cam {cam_id}: AEC mode 0x{c['aec_mode']:02X} != 0xA8")
-            if c["again_cmd"] >> 4 != EXPECTED_GAIN[cam_id]:
+            if c["again_x"] != float(EXPECTED_GAIN[cam_id]):
                 failures.append(
-                    f"[{side}] cam {cam_id}: analog gain 0x{c['again_cmd']:04X} "
-                    f"!= expected 0x{EXPECTED_GAIN[cam_id]:02X}<<4")
+                    f"[{side}] cam {cam_id}: analog gain {c['again_x']}x "
+                    f"(raw 0x{c['again_cmd']:04X}) != expected {EXPECTED_GAIN[cam_id]}x")
             if c["expo_cmd"] != EXPECTED_EXPO_ROWS:
                 failures.append(
                     f"[{side}] cam {cam_id}: commanded exposure 0x{c['expo_cmd']:04X} "
@@ -197,23 +201,47 @@ def test_camera_telemetry_snapshot(interface):
         if ((second - first) & 0xFF) == 0:
             failures.append(f"[{side}] cam {probe_cam}: sweep_count stuck at {first}")
 
-        # Frame counter: a few single captures must nudge it by a small amount.
-        # Also pins the 0x4900-03 byte order (a swapped assembly would jump by
-        # ~2^24 per frame and fail the delta bound).
-        fc_before = sensor.get_camera_telemetry()["cameras"][probe_cam]["frame_counter"]
-        for _ in range(3):
-            sensor.camera_capture_histogram(1 << probe_cam)
-            time.sleep(0.1)
-        time.sleep(FLEET_REFRESH_S)
-        fc_after = sensor.get_camera_telemetry()["cameras"][probe_cam]["frame_counter"]
-        delta = (fc_after - fc_before) & 0xFFFFFFFF
-        print(f"frame_counter cam {probe_cam}: {fc_before} -> {fc_after} (delta {delta})")
-        if delta == 0:
+        # Frames-flowing proof: stream the probe camera with internal FSIN for
+        # ~3 s and let the background sweep observe it mid-burst. Fresh sweeps
+        # must show sc_state 0x9 (streaming) and a moving live row counter.
+        # No histogram stream is enabled, so no SPI/USB reception is armed
+        # (no endpoint wedge). fsin_pulse_count is external-FSIN-only, so it
+        # is printed for information, not asserted, in this internal-FSIN run.
+        from omotion.config import OW_CAMERA, OW_CAMERA_ON, OW_CAMERA_OFF
+
+        pc_before = sensor.get_camera_telemetry()["fsin_pulse_count"]
+        sensor.switch_camera(probe_cam)
+        sensor._send(packetType=OW_CAMERA, command=OW_CAMERA_ON)
+        sensor.enable_aggregator_fsin()
+        samples = []
+        t_end = time.monotonic() + 3.2
+        while time.monotonic() < t_end:
+            time.sleep(0.4)
+            c = sensor.get_camera_telemetry()["cameras"][probe_cam]
+            samples.append((c["updated_ms"], c["tc_row"], c["sc_state"]))
+        sensor.disable_aggregator_fsin()
+        sensor._send(packetType=OW_CAMERA, command=OW_CAMERA_OFF)
+        pc_after = sensor.get_camera_telemetry()["fsin_pulse_count"]
+
+        fresh = {}
+        for upd, tc, sc in samples:
+            fresh[upd] = (tc, sc)
+        print(f"burst sweeps for cam {probe_cam}: "
+              f"{[(u, t, hex(s)) for u, (t, s) in sorted(fresh.items())]} "
+              f"(ext-FSIN pulse count {pc_before} -> {pc_after})")
+        if len(fresh) < 2:
             failures.append(
-                f"[{side}] cam {probe_cam}: frame counter did not advance after captures")
-        elif delta > 1000:
-            failures.append(
-                f"[{side}] cam {probe_cam}: frame counter delta {delta} implausible "
-                f"(byte order?)")
+                f"[{side}] only {len(fresh)} fresh sweep(s) during 3 s burst")
+        else:
+            tc_vals = [t for t, _ in fresh.values()]
+            sc_vals = [s for _, s in fresh.values()]
+            if 0x9 not in sc_vals:
+                failures.append(
+                    f"[{side}] cam {probe_cam} never seen in streaming state "
+                    f"(sc_states {[hex(s) for s in sc_vals]})")
+            if len(set(tc_vals)) < 2:
+                failures.append(
+                    f"[{side}] cam {probe_cam} live row counter frozen at "
+                    f"{tc_vals[0]} across {len(tc_vals)} mid-stream sweeps")
 
     assert not failures, "telemetry failures:\n  " + "\n  ".join(failures)

--- a/tests/test_camera_telemetry_hil.py
+++ b/tests/test_camera_telemetry_hil.py
@@ -11,9 +11,12 @@ the fleet (~1 s round-robin), then validates the cached snapshot end to end:
 - correction-state bytes match the production table (0x4001=0x23, 0x5000=0x34,
   AEC/AGC manual 0xA8) and commanded analog gain matches the per-slot ladder
 - the optical-black block's window/target/trigger context matches what the
-  config table programs (#103) — the dark-row averages themselves are printed,
-  not asserted, until a bench baseline exists (the watchdog bytes taught us
-  that an un-baselined "fault" byte is usually a configuration signature)
+  config table programs (#103), and the dark-row averages track while the
+  sensor scans rows. Baselined on the left sensor 2026-07-20: z_avg reads 0
+  at idle, ~7790 LSB (/64 = 121.7 DN) while streaming, with Bayer positions
+  10/11 ~60 LSB above 00/01. blc_thres (2047), blc_fault_latch (0xFF with
+  fault_state 0) and dtr_fault (1) are configuration signatures, not faults —
+  same lesson as the watchdog bytes — so they are printed, never asserted.
 - sweeps stay live (sweep_count advances between polls)
 - during a ~3 s stream_on + internal-FSIN burst, sweeps observe the probe
   camera actually producing frames: sc_state reads 0x9 (streaming) and the
@@ -283,11 +286,35 @@ def test_camera_telemetry_snapshot(interface):
         print(f"burst sweeps for cam {probe_cam}: "
               f"{[(u, t, hex(s)) for u, (t, s, _) in sorted(fresh.items())]} "
               f"(ext-FSIN pulse count {pc_before} -> {pc_after})")
-        # Open question this run answers: does z_avg track the dark rows while
-        # streaming, and does it move at all? Reported, not asserted.
+        # OB dark rows (#103). Bench-established 2026-07-20: z_avg reads 0 at
+        # idle and populates while the sensor scans rows, so a streaming sweep
+        # with an all-zero z_avg means the statistic stopped tracking.
         z_seq = [z for _, (_, _, z) in sorted(fresh.items())]
+        streaming_z = [z for _, (_, sc, z) in sorted(fresh.items()) if sc == 0x9]
         print(f"  z_avg across burst sweeps: {z_seq}")
-        print(f"  z_avg changed during burst: {len(set(z_seq)) > 1}")
+        print(f"  z_avg while streaming: {streaming_z}")
+        if streaming_z:
+            for z in streaming_z:
+                if not any(z):
+                    failures.append(
+                        f"[{side}] cam {probe_cam}: z_avg all-zero on a "
+                        f"streaming sweep (dark-row statistic not tracking)")
+                    break
+            else:
+                # Row-parity split: positions 10/11 run ~60 LSB above 00/01 on
+                # every camera measured. Assert only the loose envelope — this
+                # is one bench, one sensor.
+                splits = [((z[2] + z[3]) - (z[0] + z[1])) / 2.0 for z in streaming_z]
+                dn = [sum(z) / 4.0 / 64.0 for z in streaming_z]   # 6 fractional bits
+                print(f"  row-parity split (10/11 - 00/01): "
+                      f"{[round(s, 1) for s in splits]} LSB; "
+                      f"dark level {[round(d, 1) for d in dn]} DN")
+                if max(abs(s) for s in splits) > 200:
+                    failures.append(
+                        f"[{side}] cam {probe_cam}: z_avg row-parity split "
+                        f"{max(splits):.0f} LSB far above the ~60 LSB baseline")
+        else:
+            print("  (no streaming sweep captured; z_avg checks skipped)")
         if len(fresh) < 2:
             failures.append(
                 f"[{side}] only {len(fresh)} fresh sweep(s) during 3 s burst")

--- a/tests/test_camera_telemetry_hil.py
+++ b/tests/test_camera_telemetry_hil.py
@@ -1,0 +1,219 @@
+"""HIL: continuous camera-sensor telemetry (#94, OW_CAMERA_GET_TELEMETRY).
+
+Brings up every present camera, lets the firmware's background sweep refresh
+the fleet (~1 s round-robin), then validates the cached snapshot end to end:
+
+- response framing: version 1, struct_size 78, valid bit per powered camera
+- supply rails from the on-die voltage monitor sit inside the alarm windows
+  the config table programs (AVDD [2.52, 3.08] V etc., V = code * 6 / 4096)
+- die temperatures are plausible (10-95 degC) and TPM cross-check alarm clear
+- no camera sits in safe mode (sc_state 5); no VM/watchdog fault latched
+- correction-state bytes match the production table (0x4001=0x23, 0x5000=0x34,
+  AEC/AGC manual 0xA8) and commanded analog gain matches the per-slot ladder
+- sweeps stay live (sweep_count advances between polls)
+- the MIPI frame counter increases after single-histogram captures and by a
+  sane amount — this also pins down the 0x4900-03 byte order on real silicon
+
+Requires the SDK with MotionSensor.get_camera_telemetry() (openmotion-sdk#...,
+same change series as fw PR for #94); skips with a clear message on older SDKs.
+
+Run on a bench with sensor module(s) attached (WinUSB via Zadig):
+
+    OPENMOTION_HIL=1 pytest tests/test_camera_telemetry_hil.py -v -s
+    (PowerShell: $env:OPENMOTION_HIL = "1")
+
+Set OW_SENSOR_SIDE=left|right to restrict to one side, and
+OPENMOTION_POWER_CYCLE_CMD (bench Shelly script) to start from a fresh sensor.
+"""
+import logging
+import os
+import subprocess
+import time
+
+import pytest
+
+requires_bench = pytest.mark.skipif(
+    os.environ.get("OPENMOTION_HIL") != "1",
+    reason="hardware-in-the-loop test; set OPENMOTION_HIL=1 on the bench",
+)
+
+logger = logging.getLogger(__name__)
+
+CONNECT_TIMEOUT_S = 15.0
+FLEET_REFRESH_S = 3.0        # sweep interval 125 ms * 8 cams = 1 s; 3x margin
+
+# Voltage-monitor alarm windows programmed by X02C1B_SENSOR_CONFIG (0x4E03-0E),
+# in volts. Readings must land inside them or the sensor itself would latch a
+# vm fault.
+RAIL_WINDOWS_V = {
+    "avdd": (2.52, 3.08),
+    "dovdd": (1.62, 1.98),
+    "dvdd": (1.08, 1.32),
+}
+TEMP_WINDOW_C = (10.0, 95.0)
+
+EXPECTED_GAIN = [0x10, 0x04, 0x02, 0x01, 0x01, 0x02, 0x04, 0x10]
+PRODUCTION_BLC_CTRL = 0x23   # 0x4001 (raw mode #89 would read 0x00)
+PRODUCTION_ISP_CTRL = 0x34   # 0x5000 (raw mode #89 would read 0x30)
+AEC_AGC_MANUAL = 0xA8        # 0x3503
+EXPECTED_EXPO_ROWS = 0x0048  # 72 rows = 648 us (config table)
+SC_STATE_SAFE_MODE = 0x5
+
+
+@pytest.fixture
+def interface():
+    from omotion import MotionInterface
+
+    cycle_cmd = os.environ.get("OPENMOTION_POWER_CYCLE_CMD")
+    if cycle_cmd:
+        subprocess.run(cycle_cmd, shell=True, check=True, timeout=60)
+        time.sleep(8.0)  # re-enumeration settle
+
+    iface = MotionInterface()
+    iface.start(wait=False)
+    deadline = time.monotonic() + CONNECT_TIMEOUT_S
+    while time.monotonic() < deadline and not iface.connected_sensors():
+        time.sleep(0.2)
+    yield iface
+    iface.stop()
+
+
+def _present_cameras(sensor):
+    try:
+        health = sensor.get_i2c_health(rescan=True)
+        cams = health.get("cameras") if isinstance(health, dict) else None
+        if cams:
+            present = [i for i, ok in enumerate(cams) if ok]
+            if present:
+                return present
+    except Exception as exc:  # noqa: BLE001 - diagnostic fallback only
+        logger.warning("i2c-health unavailable (%s); assuming all 8 cameras", exc)
+    return list(range(8))
+
+
+def _bring_up(sensor, mask):
+    assert sensor.enable_camera_power(mask) is True, "enable_camera_power failed"
+    time.sleep(0.5)
+    assert sensor.program_fpga(camera_position=mask, manual_process=False) is True, \
+        "program_fpga failed"
+    time.sleep(0.1)
+    assert sensor.camera_configure_registers(mask) is True, \
+        "camera_configure_registers failed"
+
+
+@requires_bench
+def test_camera_telemetry_snapshot(interface):
+    side_filter = os.environ.get("OW_SENSOR_SIDE")
+    sensors = [
+        s for s in interface.connected_sensors()
+        if side_filter is None or getattr(s, "side", None) == side_filter
+    ]
+    if not sensors:
+        pytest.skip(f"no sensor module connected (side filter={side_filter!r})")
+
+    failures = []
+    for sensor in sensors:
+        side = getattr(sensor, "side", "?")
+        if not hasattr(sensor, "get_camera_telemetry"):
+            pytest.skip("SDK lacks get_camera_telemetry(); update openmotion-sdk")
+
+        present = _present_cameras(sensor)
+        mask = 0
+        for i in present:
+            mask |= (1 << i)
+        logger.info("[%s] present cameras: %s (mask 0x%02X)", side, present, mask)
+
+        _bring_up(sensor, mask)
+        time.sleep(FLEET_REFRESH_S)
+
+        telem = sensor.get_camera_telemetry()
+        assert telem is not None, f"[{side}] get_camera_telemetry returned None"
+        assert telem["version"] == 1, f"[{side}] unexpected telemetry version"
+
+        print(f"\n=== Sensor [{side}] camera telemetry ===")
+        print(f"{'cam':>3} | {'AVDD':>6} {'DOVDD':>6} {'DVDD':>6} | "
+              f"{'Tavg':>6} | {'state':>5} | {'faults':>13} | {'blc/isp':>9} | swp")
+        print("-" * 84)
+
+        for cam_id in present:
+            c = telem["cameras"][cam_id]
+            if not c["valid"]:
+                failures.append(f"[{side}] cam {cam_id}: no completed sweep (valid=0)")
+                print(f"{cam_id:>3} | {'-- no completed sweep --':^60}")
+                continue
+
+            rails = {k: c[f"{k}_v"] for k in ("avdd", "dovdd", "dvdd")}
+            t_avg = c["tpm_avg_c"]
+            faults = (f"wd={c['wd_fault_a']:02X}/{c['wd_fault_b']:02X} "
+                      f"vm={c['vm_latched']:02X}")
+            print(f"{cam_id:>3} | {rails['avdd']:6.3f} {rails['dovdd']:6.3f} "
+                  f"{rails['dvdd']:6.3f} | {t_avg:6.1f} | {c['sc_state']:>5X} | "
+                  f"{faults:>13} | {c['blc_ctrl']:02X}/{c['isp_ctrl']:02X}    | "
+                  f"{c['sweep_count']}")
+
+            for rail, (lo, hi) in RAIL_WINDOWS_V.items():
+                v = rails[rail]
+                if not (lo <= v <= hi):
+                    failures.append(
+                        f"[{side}] cam {cam_id}: {rail} {v:.3f} V outside [{lo}, {hi}]")
+            if not (TEMP_WINDOW_C[0] <= t_avg <= TEMP_WINDOW_C[1]):
+                failures.append(f"[{side}] cam {cam_id}: tpm_avg {t_avg:.1f} C implausible")
+            if abs(c["tpm0_c"] - c["tpm1_c"]) > 10.0:
+                failures.append(
+                    f"[{side}] cam {cam_id}: TPM0/TPM1 disagree "
+                    f"({c['tpm0_c']:.1f} vs {c['tpm1_c']:.1f} C)")
+            if c["sc_state"] == SC_STATE_SAFE_MODE:
+                failures.append(f"[{side}] cam {cam_id}: sensor in SAFE MODE")
+            if c["vm_latched"] & 0x3F:
+                failures.append(
+                    f"[{side}] cam {cam_id}: VM fault latched 0x{c['vm_latched']:02X}")
+            if c["tpm_status"] & 0x0F:
+                failures.append(
+                    f"[{side}] cam {cam_id}: TPM alarm 0x{c['tpm_status']:02X}")
+            if c["blc_ctrl"] != PRODUCTION_BLC_CTRL or c["isp_ctrl"] != PRODUCTION_ISP_CTRL:
+                failures.append(
+                    f"[{side}] cam {cam_id}: correction state 0x{c['blc_ctrl']:02X}/"
+                    f"0x{c['isp_ctrl']:02X} != production 0x23/0x34")
+            if c["aec_mode"] != AEC_AGC_MANUAL:
+                failures.append(
+                    f"[{side}] cam {cam_id}: AEC mode 0x{c['aec_mode']:02X} != 0xA8")
+            if c["again_cmd"] >> 4 != EXPECTED_GAIN[cam_id]:
+                failures.append(
+                    f"[{side}] cam {cam_id}: analog gain 0x{c['again_cmd']:04X} "
+                    f"!= expected 0x{EXPECTED_GAIN[cam_id]:02X}<<4")
+            if c["expo_cmd"] != EXPECTED_EXPO_ROWS:
+                failures.append(
+                    f"[{side}] cam {cam_id}: commanded exposure 0x{c['expo_cmd']:04X} "
+                    f"!= 0x{EXPECTED_EXPO_ROWS:04X}")
+            if c["i2c_err_count"] > 2:
+                failures.append(
+                    f"[{side}] cam {cam_id}: {c['i2c_err_count']} sweep I2C errors")
+
+        # Liveness: sweeps keep advancing.
+        probe_cam = present[0]
+        first = telem["cameras"][probe_cam]["sweep_count"]
+        time.sleep(1.5)
+        second = sensor.get_camera_telemetry()["cameras"][probe_cam]["sweep_count"]
+        if ((second - first) & 0xFF) == 0:
+            failures.append(f"[{side}] cam {probe_cam}: sweep_count stuck at {first}")
+
+        # Frame counter: a few single captures must nudge it by a small amount.
+        # Also pins the 0x4900-03 byte order (a swapped assembly would jump by
+        # ~2^24 per frame and fail the delta bound).
+        fc_before = sensor.get_camera_telemetry()["cameras"][probe_cam]["frame_counter"]
+        for _ in range(3):
+            sensor.camera_capture_histogram(1 << probe_cam)
+            time.sleep(0.1)
+        time.sleep(FLEET_REFRESH_S)
+        fc_after = sensor.get_camera_telemetry()["cameras"][probe_cam]["frame_counter"]
+        delta = (fc_after - fc_before) & 0xFFFFFFFF
+        print(f"frame_counter cam {probe_cam}: {fc_before} -> {fc_after} (delta {delta})")
+        if delta == 0:
+            failures.append(
+                f"[{side}] cam {probe_cam}: frame counter did not advance after captures")
+        elif delta > 1000:
+            failures.append(
+                f"[{side}] cam {probe_cam}: frame counter delta {delta} implausible "
+                f"(byte order?)")
+
+    assert not failures, "telemetry failures:\n  " + "\n  ".join(failures)

--- a/tests/test_histo_wedge_recovery_hil.py
+++ b/tests/test_histo_wedge_recovery_hil.py
@@ -1,0 +1,321 @@
+"""HIL regression for the HISTO bulk IN endpoint wedge.
+
+Pre-fix firmware armed a multi-packet histogram transfer by setting
+histo_ep_data=1 in USBD_HISTO_SetTxBuffer, and only the DataIn complete
+callback ever cleared it. histo_ep_data also survived USB
+DeInit/Init untouched. So when a host reader process died mid-stream and
+a new one connected, the new session's SET_CONFIGURATION tore down the
+in-flight transfer (DataIn never fires) while histo_ep_data stayed 1:
+every later SetTxBuffer returned BUSY, the 4-entry histo_queue filled
+("HISTO enqueue fail: queue full ... deq=0"), and the endpoint was dead
+until power cycle. A USB device reset did not clear it either — reset
+runs the same DeInit/Init path that preserved the flag.
+
+Fixed by (a) clearing histo_ep_data and the TX bookkeeping in
+DeInit/Init, and (b) a stuck-TX watchdog serviced from the main loop: if
+a transfer has been armed for >500 ms with no DataIn progress, the
+firmware flushes the HISTO IN endpoint, clears histo_ep_data, and resets
+the frame queue.
+
+Two scenarios:
+
+* test_stream_resumes_within_one_session — the reader thread stops and
+  later resumes inside one USB session. This works even on pre-fix
+  firmware (the armed transfer simply completes once IN tokens return);
+  it guards against the watchdog breaking the healthy path.
+
+* test_new_session_streams_after_reader_died_mid_stream — the reader
+  session is torn down mid-stream without any firmware-side cleanup
+  (host process death) and a brand-new SDK session connects and reads.
+  On pre-fix firmware the new session gets 0 stream bytes.
+
+Run on a bench with a sensor attached (WinUSB via Zadig):
+
+    OPENMOTION_HIL=1 pytest tests/test_histo_wedge_recovery_hil.py
+    (PowerShell: $env:OPENMOTION_HIL = "1")
+
+Select the sensor side with OW_SENSOR_SIDE=left|right (default: right).
+
+Set OPENMOTION_POWER_CYCLE_CMD to a shell command (e.g. the bench Shelly
+script) and each test starts from a fresh boot, so a wedge left by a
+previous session can't fail the sanity phase:
+
+    OPENMOTION_POWER_CYCLE_CMD="python ...\\tests\\shelly.py cycle"
+"""
+import os
+import queue
+import subprocess
+import sys
+import threading
+import time
+
+import pytest
+
+requires_bench = pytest.mark.skipif(
+    os.environ.get("OPENMOTION_HIL") != "1",
+    reason="hardware-in-the-loop test; set OPENMOTION_HIL=1 on the bench",
+)
+
+CONNECT_TIMEOUT_S = 15.0
+
+# Same bring-up as the production ScanWorkflow: two cameras on the
+# aggregator.
+CAM_MASK = 0x03
+
+# One aggregated frame: 10-byte header (SOF, type, size, timestamp) +
+# per camera (SOH + cam_id + 4096 histogram + 4 temp + EOH) + CRC16 +
+# EOF — see send_histogram_data() in Core/Src/camera_manager.c.
+FRAME_BYTES = 10 + 2 * (1 + 1 + 4096 + 4 + 1) + 3
+
+# Each read phase lasts 5 s = 200 frames nominal at 40 Hz; demand a
+# quarter so USB hiccups don't flake the test while a dead stream (0
+# bytes on wedged firmware) still fails it loudly.
+PHASE_SECONDS = 5.0
+MIN_PHASE_BYTES = 50 * FRAME_BYTES
+
+# How long the firmware streams into the void with no host reader. Must
+# comfortably exceed the firmware's stuck-TX watchdog timeout (500 ms)
+# and be long enough that the histo_queue (4 entries, 25 ms cadence)
+# overflows many times over on pre-fix firmware.
+READER_DEAD_SECONDS = 3.0
+
+
+@pytest.fixture
+def bench_side():
+    """Power-cycle the bench sensor (if configured) and return its side."""
+    cycle_cmd = os.environ.get("OPENMOTION_POWER_CYCLE_CMD")
+    if cycle_cmd:
+        # Fresh boot so a wedge left by a prior session can't fail the
+        # sanity phase (see module docstring).
+        subprocess.run(cycle_cmd, shell=True, check=True, timeout=60)
+        time.sleep(8.0)  # re-enumeration settle
+    return os.environ.get("OW_SENSOR_SIDE", "right")
+
+
+# The SDK's Win32 hotplug provider registers its window class with the
+# first instance's ctypes wndproc thunk, and later MotionInterface
+# instances in the same process reuse that class (win32.py treats
+# ERROR_CLASS_ALREADY_EXISTS as "fine"). If the first instance is
+# garbage-collected, its thunk is freed and any later message dispatch —
+# e.g. DestroyWindow during stop() — faults natively and kills pytest.
+# This file creates several MotionInterface lifetimes per process, so
+# keep them all alive. SDK bug, tracked separately.
+_INTERFACE_KEEPALIVE = []
+
+
+def _connect(side):
+    """Start a fresh SDK session and return (interface, sensor handle)."""
+    from omotion import MotionInterface
+
+    interface = MotionInterface()
+    _INTERFACE_KEEPALIVE.append(interface)
+    interface.start(wait=False)
+    handle = interface.left if side == "left" else interface.right
+    deadline = time.monotonic() + CONNECT_TIMEOUT_S
+    while time.monotonic() < deadline and not handle.is_connected():
+        time.sleep(0.2)
+    if not handle.is_connected():
+        interface.stop()
+        pytest.fail(
+            f"{side} sensor not reachable in {CONNECT_TIMEOUT_S:.0f}s — "
+            "not plugged in, no WinUSB driver, or wedged from a previous "
+            "run (power-cycle it)."
+        )
+    return interface, handle
+
+
+def _bring_up(sensor):
+    """Power -> FPGA -> configure registers (matches ScanWorkflow)."""
+    assert sensor.enable_camera_power(CAM_MASK) is True
+    time.sleep(0.5)
+    assert sensor.program_fpga(camera_position=CAM_MASK, manual_process=False) is True
+    time.sleep(0.1)
+    assert sensor.camera_configure_registers(CAM_MASK) is True
+
+
+def _shut_down(sensor):
+    """Best-effort scan teardown; failures mean assertions already fired."""
+    try:
+        sensor.disable_aggregator_fsin()
+        sensor.disable_camera(CAM_MASK)
+        sensor.uart.histo.stop_streaming()
+        # NOTE: drain_final() used to run here to clear the host endpoint
+        # buffer, but it blocks forever in dev.read() after this scenario
+        # (bench-confirmed 2026-07-20, both sensors, every run) and hung
+        # the whole test in teardown. Tracked as an SDK bug; the fixture's
+        # power cycle already gives each test a clean endpoint.
+        sensor.disable_camera_power(CAM_MASK)
+    except Exception:
+        pass
+
+
+class _CountingReader:
+    """Host-side reader that tallies stream bytes off the packet queue."""
+
+    def __init__(self, histo, histogram_bytes):
+        self._histo = histo
+        self._histogram_bytes = histogram_bytes
+        self._queue = queue.Queue(maxsize=256)
+        self._stop_evt = threading.Event()
+        self.bytes_received = 0
+        self._thread = threading.Thread(target=self._drain, daemon=True)
+
+    def _drain(self):
+        while not self._stop_evt.is_set():
+            try:
+                chunk = self._queue.get(timeout=0.2)
+            except queue.Empty:
+                continue
+            if chunk:
+                self.bytes_received += len(chunk)
+
+    def start(self):
+        self._thread.start()
+        self._histo.start_streaming(
+            self._queue, expected_size=self._histogram_bytes
+        )
+
+    def stop(self) -> int:
+        self._histo.stop_streaming()
+        self._stop_evt.set()
+        self._thread.join(timeout=2.0)
+        return self.bytes_received
+
+
+def _counted_read(histo, histogram_bytes, seconds) -> int:
+    """One reader session: start, read for `seconds`, stop; return bytes."""
+    reader = _CountingReader(histo, histogram_bytes)
+    reader.start()
+    time.sleep(seconds)
+    return reader.stop()
+
+
+@requires_bench
+def test_stream_resumes_within_one_session(bench_side):
+    """Reader pauses and resumes inside one USB session: frames must flow
+    both before and after the pause. Passes on pre-fix firmware too (the
+    armed transfer completes once IN tokens return) — this guards the
+    healthy path against the stuck-TX watchdog itself (e.g. flushing an
+    endpoint the host is actively reading)."""
+    from omotion.MotionProcessing import HISTOGRAM_BYTES
+
+    interface, sensor = _connect(bench_side)
+    try:
+        assert sensor.ping() is True, "sensor not healthy before test"
+        _bring_up(sensor)
+        histo = sensor.uart.histo
+
+        histo.flush_stale_data(HISTOGRAM_BYTES)
+        reader = _CountingReader(histo, HISTOGRAM_BYTES)
+        reader.start()
+        assert sensor.enable_camera(CAM_MASK) is True
+        assert sensor.enable_aggregator_fsin() is True
+        time.sleep(PHASE_SECONDS)
+        phase1_bytes = reader.stop()
+        assert phase1_bytes >= MIN_PHASE_BYTES, (
+            f"stream never started: got {phase1_bytes} B in "
+            f"{PHASE_SECONDS:.0f}s, expected >= {MIN_PHASE_BYTES} B"
+        )
+
+        # Reader paused, firmware still streaming into the void.
+        time.sleep(READER_DEAD_SECONDS)
+
+        histo.flush_stale_data(HISTOGRAM_BYTES)
+        resumed_bytes = _counted_read(histo, HISTOGRAM_BYTES, PHASE_SECONDS)
+        assert resumed_bytes >= MIN_PHASE_BYTES, (
+            f"stream did not resume after in-session reader pause: got "
+            f"{resumed_bytes} B in {PHASE_SECONDS:.0f}s, expected >= "
+            f"{MIN_PHASE_BYTES} B"
+        )
+        assert sensor.ping() is True, "command interface unhealthy after resume"
+    finally:
+        _shut_down(sensor)
+        interface.stop()
+
+
+@requires_bench
+def test_new_session_streams_after_reader_died_mid_stream(bench_side):
+    """Host reader process dies mid-stream; a brand-new SDK session must
+    still receive frames.
+
+    Session A runs in a SEPARATE PROCESS that is hard-killed mid-stream —
+    no FSIN disable, no camera disable, no USB release, exactly what the
+    device sees when a host process dies. Session B then connects (its
+    SET_CONFIGURATION re-inits the USB classes mid-transfer) and reads.
+    On pre-fix firmware session B gets 0 stream bytes and only a power
+    cycle recovers the endpoint.
+
+    The kill has to be a real process kill. This test previously used
+    ``MotionInterface.stop()`` for session A, but
+    ``ConnectionMonitor._teardown()`` drives every handle to DISCONNECTED
+    so the transport releases cleanly — the orderly shutdown the scenario
+    must avoid. That made the test pass against firmware that was still
+    fully wedge-prone: bench-confirmed 2026-07-20 on one build, stop()
+    gave 401 frames while a hard kill gave 0 bytes. Do not "simplify" it
+    back to stop().
+    """
+    from omotion.MotionProcessing import HISTOGRAM_BYTES
+
+    side = bench_side
+
+    # --- session A: separate process, killed mid-stream ---
+    child = subprocess.Popen(
+        [sys.executable,
+         os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                      "_histo_wedge_reader.py"),
+         side],
+        stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True,
+    )
+    streaming_line = None
+    try:
+        deadline = time.monotonic() + 60.0
+        while time.monotonic() < deadline:
+            line = child.stdout.readline()
+            if not line:
+                break
+            line = line.strip()
+            if line.startswith("CHILD_STREAMING"):
+                streaming_line = line
+                break
+            if line.startswith("CHILD_FAIL"):
+                pytest.fail(f"session A could not stream: {line}")
+    finally:
+        # Hard kill: no teardown, no USB release. The firmware keeps
+        # producing frames into a transfer nobody will ever drain.
+        if sys.platform == "win32":
+            subprocess.run(["taskkill", "/F", "/T", "/PID", str(child.pid)],
+                           capture_output=True)
+        else:
+            child.kill()
+        try:
+            child.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            pass
+
+    assert streaming_line is not None, (
+        "session A never reached streaming state — bench problem (or "
+        "endpoint wedged by a previous run), not the regression under test"
+    )
+
+    time.sleep(READER_DEAD_SECONDS)
+
+    # --- session B: fresh process-equivalent connection must stream ---
+    interface_b, sensor_b = _connect(side)
+    try:
+        assert sensor_b.ping() is True, (
+            "command interface dead after reader death — worse than the "
+            "known HISTO wedge"
+        )
+        histo = sensor_b.uart.histo
+        histo.flush_stale_data(HISTOGRAM_BYTES)
+        session_b_bytes = _counted_read(histo, HISTOGRAM_BYTES, PHASE_SECONDS)
+        assert session_b_bytes >= MIN_PHASE_BYTES, (
+            f"HISTO endpoint wedged: new session after mid-stream reader "
+            f"death got {session_b_bytes} B in {PHASE_SECONDS:.0f}s, "
+            f"expected >= {MIN_PHASE_BYTES} B (power cycle required on "
+            "pre-fix firmware)"
+        )
+        assert sensor_b.ping() is True, "command interface unhealthy after recovery"
+    finally:
+        _shut_down(sensor_b)
+        interface_b.stop()

--- a/tests/test_i2c_health_hil.py
+++ b/tests/test_i2c_health_hil.py
@@ -2,7 +2,7 @@
 
 At startup the firmware brings up each camera one at a time and verifies
 that every expected I2C device responds: the TCA9548A mux (0x70), the
-ICM-20948 IMU (0x68), and all 8 cameras (OV2312 0x36) + 8 FPGAs
+ICM-20948 IMU (0x68), and all 8 cameras (OX02C1B 0x36) + 8 FPGAs
 (CrossLink 0x40) behind the mux. The result is cached and queryable over
 OW_CMD_I2C_STATUS (SDK: MotionSensor.get_i2c_health()).
 


### PR DESCRIPTION
Release merge of `next` → `main`. Merging this cuts **sensor firmware 1.8.2**.

| | |
|---|---|
| **Ships as** | `1.8.2` |
| **Last production release on `main`** | `1.8.1` (`74b44be`) |
| **Validated as** | `1.8.2-rc.4` (`a979882`) — identical to this PR head |
| **Pre-release lineage** | `1.8.2-rc.1` → `1.8.2-dev.1` → `1.8.2-rc.2` → `1.8.2-rc.3` → `1.8.2-rc.4` |
| **Commits** | 24 (`main..next`), 30 files, 2 new modules |

The headline change is that 1.8.2 is the first sensor firmware built **two ways** — bootloader-slot and bare-metal — so flashing procedure, not just behaviour, changes with this release. Read "Flashing / host compatibility" before deploying.

---

## Bug fixes

### HISTO IN endpoint wedged permanently when a host reader died mid-transfer — `Refs #105`

A histogram frame ships as ~64 chained 512 B packets, each armed by the previous packet's DataIn interrupt, with `histo_ep_data` marking "in flight". Only the DataIn completion path ever cleared that flag, and `Init`/`DeInit` reset the queue indices but *not* the flag. When a host reader process died mid-chain, DataIn never fired again, `histo_ep_data` stayed `1` forever, `histo_process_queue()` returned BUSY for every later frame, and **the endpoint was dead until a power cycle** — reconnecting could not clear it, because a USB reset runs the same `DeInit`/`Init` path that preserved the flag.

Three changes (`17bdec1`):
- clear `histo_ep_data` + TX bookkeeping in `Init` and `DeInit`, so an abandoned transfer cannot outlive the session that armed it;
- `USBD_HISTO_CheckTxStuck()` serviced from the main loop — an armed transfer with no DataIn *progress* for 500 ms is abandoned via the existing `USBD_HISTO_FlushQueue()` (keyed on lack of progress, not elapsed time, so a slow-but-advancing host is never interrupted);
- drop sends when `dev_state != CONFIGURED`, so frames are not pushed into a clock-gated core during selective suspend.

Bench-verified on the left sensor — session A streams in a separate process and is hard-killed mid-stream, session B then reads for 5 s:

| Firmware | Session B result |
|---|---|
| `next` @ `50afbf0` (pre-fix) | **0 B — wedged** |
| this fix | **1,643,800 B (~401 frames)** |

The HIL test needed fixing too: it simulated reader death with `MotionInterface.stop()`, but `ConnectionMonitor._teardown()` releases the transport cleanly, so the condition was never created — the old test passed against fully wedge-prone firmware. It now spawns a real child reader and hard-kills it, and was confirmed to **fail** on pre-fix firmware and **pass** on this one.

### Production image shipped with no camera FPGA bitstream — `Refs #109`

The production image was bootloader + signed app only. `crosslink.c` is compiled unconditionally (it is *not* behind `BARE_METAL`), so the bootloader-slot application still programs the CrossLink from `ADDR_CAMERA_BITSTREAM` on every boot — while the bootloader clamps its DFU window to the app slot and can never write `0x081A0000`. **A factory-fresh unit flashed with `production.bin` would stream 163,489 bytes of erased flash into the FPGA and come up with no cameras.**

Fixed (`427a30f`) by placing the bitstream at `0x081A0000` alongside the bootloader and signed app, and building `production.hex` by merging the three pieces rather than converting the padded `.bin` (so the gaps stay gaps instead of ~1.4 MB of `0xFF` records). Three build-time guards now **fail the build** rather than shipping a broken image: signed app must not overrun into the bitstream region; bitstream must not overrun into the `motion_config`/serial sector; bitstream size must match the hardcoded length `crosslink.c` streams.

### Camera part number corrected in docs/comments — `Refs #97`

The image sensor is the OmniVision **OX02C1B**; OV2312 is a different part. Prose/comment references only — the `OV2312_ADDR` identifier and file names are unchanged.

---

## New capability

### Continuous camera-sensor telemetry — `Refs #94`, `Refs #103`

New `camera_telemetry` module: a main-loop background sweep reads every powered OX02C1B's condition registers — supply rails from the on-die voltage monitor (AVDD/DOVDD/DVDD, factory-calibrated, `V = code × 6/4096`), dual junction temperatures + cross-check alarm, VM/charge-pump fault latches, watchdog fault roll-up + sensor state machine, OTP CRC status, live row counter, FSIN trigger-error flag, on-chip frame mean, commanded vs applied exposure/gain, correction-state bytes, the eight applied BLC channel offsets, and (v2) the full optical-black block: the `z_avg_00..11` dark-row means plus the window/target/trigger context they are meaningless without.

- One sweep (1 write + 30 burst reads, 122 raw bytes) starts every 125 ms, round-robin over powered cameras (~1 s fleet refresh), chunked at ≤6 I2C transactions per `camera_i2c_service()` pass with the temperature poll's mux discipline. A failed transaction aborts the sweep and keeps the last-known-good snapshot.
- `OW_CAMERA_GET_TELEMETRY` (0x54) returns the cached, versioned `cam_telemetry_response_t` verbatim — no I2C in the handler. **Wire version 2**, 892 B (12 B header + 8 × 110 B). Raw register values only; the SDK converts to engineering units.
- Firmware prints a one-line notice when a camera's fault latches change.

Two wire-format corrections landed **before** anything shipped, both from bench probes that disproved the datasheet reading:
- the documented "32-bit frame counter" has no readable SCCB value register on this silicon (`0x4900-03` are control bytes, static while verifiably streaming) — dropped, replaced by the live row counter at `0x3892/93` and a firmware-side FSIN pulse count;
- `z_avg` and the BLC offsets are **not** frozen when `blc_en` is clear — the dark-row statistics engine runs regardless. Scale is 6 fractional bits (`z_avg/64 = DN`, measured 121.7 DN against the sensor's own raw-mode Yavg of 121). Bayer rows 10/11 sit ~0.8 % above 00/01 reproducibly, so `z_avg_spread` has a nonzero floor.

**HIL PASSED** on the left sensor, all 8 cameras: AVDD 2.770–2.783 V, DOVDD 1.736–1.762 V, DVDD 1.160–1.166 V (all inside the config table's VM alarm windows), die temps 27–32 °C, TPM cross-check clean, production correction state `0x23`/`0x34`, per-slot gains correct, sweeps live (~1 Hz/cam, zero I2C errors including during streaming). ⚠️ See known issue #96 before polling this during a scan.

### `OW_CMD_BOOT_INFO` (0x09) — `Refs #110`

A host could not tell a bare-metal image from a bootloader-slot image: both build from the same source at the same tag, so `OW_CMD_VERSION` is identical, and the only difference is the linker script and `SCB->VTOR`. The SDK's workaround was to enter DFU and count alt settings — power-cycling a working device just to learn its boot mode.

`OW_CMD_BOOT_INFO` replies with a packed little-endian record reporting the **runtime** vector-table base (not the compile-time flag, so the device evidences where it is actually executing): `{u8 struct_version=1; u8 rsv[3]; u32 vtor; u32 flash_base;}`. Host classifies `0x08000000` → bare-metal, `0x08020400` → bootloader slot. Old firmware returns `OW_UNKNOWN` immediately (not a timeout), so probing is cheap and no-answer means "unknown".

### NVCM boot verdict folded into `OW_FACTORY_NVCM_CHECK` — `Refs #91`

The keyless-boot pin-drive test (`fpga_detect_nvcm()`, ~105 ms, no SRAM write) now appends one byte to the existing `0x6C` blob after the NVCM rows: `1` = NVCM design booted, `0` = no boot, `0xFF` = probe refused/unpowered. Old hosts ignore the trailing byte; new hosts detect pre-#91 firmware by its absence. No SDK change needed — the existing `nvcm_check()` passthrough already returns the blob.

### Two debug-only camera modes

| Flag | Bit | Effect |
|---|---|---|
| `DEBUG_FLAG_CAMERA_CROP` (`Refs #86`) | 9 (0x200) | Crops horizontal output 1920 → 1720 by overriding `X_OUTPUT_SIZE`, left-anchored, dropping the rightmost 200 columns. Height, framerate and line timing unchanged — A/B test for whether a misaligned right-edge optic moves the speckle statistics. |
| `DEBUG_FLAG_CAMERA_RAW` (`Refs #89`) | 10 (0x400) | Raw "scientific sensor" mode: disables every on-sensor pixel correction (BLC servo, DC-BLC, dither, OTP static DPC) and re-asserts the raw contract. Output pixels become bare ADC codes — the raw per-channel pedestal (~255 DN @1×, ~495 DN @16×) replaces the servoed 128 DN target, defect pixels reappear, **and SDK pedestal assumptions do not hold**. Debug/scientific captures only. |

Both apply at camera (re)configuration time and are no-ops unless set; the base table always programs the production values, so clearing the flag and reconfiguring reverts.

---

## Flashing / host compatibility — read before deploying

`BARE_METAL` is a new CMake option and **`OFF` is the default**, i.e. an ordinary `Debug`/`Release` build is now linked for the **bootloader slot at `0x08020400`**, not `0x08000000`.

| Preset | Layout | DFU request goes to | FPGA bitstream |
|---|---|---|---|
| `Debug` / `Release` (default) | slot @ `0x08020400` | custom bootloader via `RTC->BKP7R` magic | flashed separately @ `0x081A0000` |
| `Debug-BareMetal` / `Release-BareMetal` | `0x08000000`, no bootloader | STM32 ROM bootloader (`0x1FF09800`) | merged into the image |

CI now emits four artifacts per build: `baremetal` (app only), `baremetal-fpga` (app + bitstream, single flash image), `signed` (slot image signed for the bootloader), and `production` (bootloader + signed app + bitstream). The production image bundles a pinned `open-motion-sensor-bl` release (workflow input, default latest → currently **1.1.0**) and signs with the tool + public key from *that same* bootloader version, so the signing format always matches the bootloader that will verify it. **Do not pin `bl_release` to `1.0.0`** — see known issue #108.

- **`scripts/deploy.py` still assumes bare-metal `0x08000000`** and is wrong against the new default (`Refs #88`).
- Host telemetry parsing requires the companion `openmotion-sdk` change (`get_camera_telemetry()`); firmware returns raw registers only.

---

## Known issues in this build

| Issue | Impact |
|---|---|
| `#96` | **1 Hz `OW_CAMERA_GET_TELEMETRY` polling during HISTO streaming wedges the histogram stream** (cameras keep running, FSIN keeps counting, telemetry channel stays healthy — only HISTO dies, onset 5–60 s). Do not poll telemetry during an acquisition in 1.8.2. Root-caused since: a non-atomic read-modify-write on `DIEPEMPMSK`, the single device register holding every IN endpoint's TX-FIFO-empty enable — a COMM arm from the main loop, preempted by the USB ISR (priority 0), writes back a stale mask and clears HISTO's bit. Not bandwidth, and not specific to telemetry: any COMM response concurrent with streaming can do it, which is also what killed HISTO in ~2 s under concurrent I2C passthrough on 1.8.1-rc.3. Fix is on `next` for the next release (PR #118), **not in 1.8.2**. |
| `#108` | **Fixed upstream — flash a bootloader ≥ 1.1.0.** The anti-rollback floor used to sit at `0x081C0000`, 32,417 B inside the camera bitstream, so the first successful boot under the bootloader would erase the bitstream tail. `open-motion-sensor-bl 1.1.0` moves the floor to `0x080A0000`, clear of the application band. This workflow bundles the *latest* bl release by default, so the production image built here picks up 1.1.0 (CI-confirmed: bootloader 80,004 B + signed app 394,112 B + fpga 163,489 B). **Pinning the `bl_release` input to `1.0.0` reintroduces the overlap.** Ticket stays open only pending hardware confirmation — no sensor has been converted to a bootloader unit yet. |
| `#112` | No in-app path to write the bitstream at `0x081A0000`, so bitstream updates on bootloader units still need a debugger. |
| `#93` | DFU boot magic at `0x38000000` still shares the address with `spi6_buffer` / `HISTO_SOF_MARKER`, so streamed data can spoof a bootloader request across a warm reset. Note the related fix already in `main` since 1.8.0-rc.3 (`5721ade`) is *not* this: it moves the SRAM4 ECC-seed so `CheckBootloaderFlag()` consumes the marker before it is zeroed (which is why `enter_dfu` enumerates), and deliberately leaves the marker where it is. |
| `#115`, `#116` | Camera-dropout root causes (COMM TX busy-wait stalling the main loop; DMA re-arm inside `send_data()` making any main-loop stall terminal) are **not** addressed here. |
| docs | `docs/requirements.md` still documents the telemetry response as 604 B / v1; the shipped format is 892 B / v2. Doc-only drift, follow-up. |

---

## Verification status

- **HIL passed on hardware:** camera telemetry v1 + v2 sweep (left sensor, 8 cameras), HISTO wedge recovery (fail-on-pre-fix / pass-on-fix confirmed), camera gain, I2C health.
- **Build-verified only:** `OW_CMD_BOOT_INFO` (clean in both Debug slot @`0x08020400` and Debug-BareMetal @`0x08000000`), production-image assembly guards, crop/raw debug flags.
- Debug FLASH 75.18 %, Release 60.19 % at the telemetry merge point.

Per repo process this PR does **not** auto-close its issues — 1.8.2 tickets stay *In review* through pre-release validation and close when the production release ships.

`Refs #86` `Refs #89` `Refs #91` `Refs #94` `Refs #97` `Refs #103` `Refs #105` `Refs #109` `Refs #110`
