### PR TITLE
feat: merge the camera FPGA bitstream into the production image (#109)

### DIFF
--- a/.github/workflows/build-firmware.yml
+++ b/.github/workflows/build-firmware.yml
@@ -226,34 +226,81 @@ jobs:
           echo "Signed slot image: motion-sensor-fw-signed.bin (FwVersion=${{ steps.fwver.outputs.version }})"
 
       # ---------------------------
-      # Production image = bootloader (@0x08000000) + signed app (@0x08020000),
-      # merged into a single flashable image for factory programming.
+      # Production image = bootloader (@0x08000000) + signed app (@0x08020000)
+      # + camera FPGA bitstream (@0x081A0000), merged into a single flashable
+      # image for factory programming.
+      #
+      # The bitstream has to be in here. crosslink.c is compiled unconditionally
+      # (it is not behind BARE_METAL), so the slot application still programs the
+      # CrossLink from ADDR_CAMERA_BITSTREAM on every boot -- but the bootloader
+      # clamps its DFU window to the app slot, so nothing else can ever put a
+      # bitstream at 0x081A0000. Without it, a factory-fresh unit streams erased
+      # flash into the FPGA and comes up with no cameras. See issue #109.
       # ---------------------------
-      - name: Assemble production image (bootloader + signed app)
+      - name: Assemble production image (bootloader + signed app + FPGA bitstream)
         run: |
           set -euo pipefail
+          # Downloaded into the workspace by the bare-metal CMake configure above.
+          test -s fpga/openmotion-camera-fpga.bin
           python3 - <<'PY'
-          BL  = "_artifacts/openmotion-bl.bin"
-          APP = "_artifacts/motion-sensor-fw-signed.bin"
-          OUT = "_artifacts/motion-sensor-production.bin"
-          SLOT_OFFSET = 0x08020000 - 0x08000000   # 0x20000 (bootloader occupies sector 0)
-          bl  = open(BL, "rb").read()
-          app = open(APP, "rb").read()
+          import re
+
+          BL   = "_artifacts/openmotion-bl.bin"
+          APP  = "_artifacts/motion-sensor-fw-signed.bin"
+          FPGA = "fpga/openmotion-camera-fpga.bin"
+          OUT  = "_artifacts/motion-sensor-production.bin"
+
+          BASE        = 0x08000000
+          SLOT_OFFSET = 0x08020000 - BASE   # 0x20000  bootloader occupies sector 0
+          FPGA_OFFSET = 0x081A0000 - BASE   # 0x1A0000 bank 2 sectors 5-6
+          FPGA_LIMIT  = 0x081E0000 - BASE   # motion_config + serial sector starts here
+
+          bl   = open(BL, "rb").read()
+          app  = open(APP, "rb").read()
+          fpga = open(FPGA, "rb").read()
+
           if len(bl) > SLOT_OFFSET:
               raise SystemExit(f"bootloader ({len(bl)} B) overlaps app slot at 0x{SLOT_OFFSET:x}")
-          img = bytearray(b"\xff" * SLOT_OFFSET)
+          if SLOT_OFFSET + len(app) > FPGA_OFFSET:
+              raise SystemExit(f"signed app ({len(app)} B) overlaps FPGA bitstream at 0x{FPGA_OFFSET:x}")
+          if FPGA_OFFSET + len(fpga) > FPGA_LIMIT:
+              raise SystemExit(f"FPGA bitstream ({len(fpga)} B) overruns its region at 0x{FPGA_LIMIT:x}")
+
+          # crosslink.c streams a hardcoded byte count out of ADDR_CAMERA_BITSTREAM.
+          # A bitstream of any other size is sent truncated or over-read, and the
+          # failure only shows up as a dead FPGA on hardware -- catch it here.
+          src = open("Core/Src/crosslink.c").read()
+          m = re.search(r"ADDR_CAMERA_BITSTREAM\s*,\s*\(size_t\)\s*(\d+)\s*\)", src)
+          if not m:
+              raise SystemExit("could not find the bitstream length constant in Core/Src/crosslink.c")
+          if int(m.group(1)) != len(fpga):
+              raise SystemExit(
+                  f"bitstream is {len(fpga)} B but crosslink.c streams {m.group(1)} B "
+                  f"-- update the constant in Core/Src/crosslink.c")
+
+          img = bytearray(b"\xff" * FPGA_OFFSET)
           img[:len(bl)] = bl
-          img += app
+          img[SLOT_OFFSET:SLOT_OFFSET + len(app)] = app
+          img += fpga
           with open(OUT, "wb") as f:
               f.write(img)
-          print(f"production image: {len(img)} bytes (bootloader={len(bl)} B, signed app={len(app)} B)")
+          print(f"production image: {len(img)} bytes (bootloader={len(bl)} B, "
+                f"signed app={len(app)} B, fpga={len(fpga)} B)")
           PY
-          # Intel-HEX view of the same image at load base 0x08000000
+          # Intel-HEX view, built from the three pieces rather than converted from
+          # the padded .bin: a flat conversion would emit ~1.4 MB of 0xFF records
+          # for the gaps and make flashing take far longer than it needs to.
           docker run --rm \
             -v "$GITHUB_WORKSPACE":/workspace \
             -w /workspace \
             ghcr.io/openwaterhealth/stm32-build-env:latest \
-            bash -lc "arm-none-eabi-objcopy -I binary -O ihex --change-addresses=0x08000000 _artifacts/motion-sensor-production.bin _artifacts/motion-sensor-production.hex"
+            bash -lc 'set -e
+              arm-none-eabi-objcopy -I binary -O ihex --change-addresses=0x08000000 _artifacts/openmotion-bl.bin             _artifacts/_prod_bl.hex
+              arm-none-eabi-objcopy -I binary -O ihex --change-addresses=0x08020000 _artifacts/motion-sensor-fw-signed.bin  _artifacts/_prod_app.hex
+              arm-none-eabi-objcopy -I binary -O ihex --change-addresses=0x081A0000 fpga/openmotion-camera-fpga.bin         _artifacts/_prod_fpga.hex'
+          python3 merge_hex.py _artifacts/motion-sensor-production.hex \
+            _artifacts/_prod_bl.hex _artifacts/_prod_app.hex _artifacts/_prod_fpga.hex
+          rm -f _artifacts/_prod_bl.hex _artifacts/_prod_app.hex _artifacts/_prod_fpga.hex
           test -s _artifacts/motion-sensor-production.hex
 
       # Collect the two bare-metal images with unambiguous names (the bare-metal
@@ -275,7 +322,8 @@ jobs:
       #   - baremetal      : standalone app @0x08000000, no bootloader, no FPGA
       #   - baremetal-fpga : standalone app + FPGA bitstream, single flash image
       #   - signed         : app @0x08020400 signed for the bootloader slot
-      #   - production     : bootloader + signed app, single factory image
+      #   - production     : bootloader + signed app + FPGA bitstream, single
+      #                      factory image
       - name: Upload bare-metal (app only) artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
Refs #109

Part 1 of the two-part answer on that issue: the production image now carries the camera FPGA bitstream. Part 2 (an in-app path to rewrite the bitstream on an already-converted unit) is tracked separately and is not needed yet.

## Why

`Core/Src/crosslink.c` is in `target_sources` outside every `if(BARE_METAL)` block, and `BARE_METAL_BUILD` guards only three spots in `main.c` plus the VTOR/DFU handling in `system_stm32h7xx.c` — nothing in the camera path. So the bootloader-slot application still calls `fpga_configure()` and streams a hardcoded 163,489 bytes out of `ADDR_CAMERA_BITSTREAM` on every boot.

But `production.bin` contained no bitstream, and `openmotion-bl` clamps its DFU window to the app slot (`0x08020000`–`0x0809FFFF`), so nothing can ever write `0x081A0000` on a converted unit. A factory-fresh unit flashed with the production image would clock 163,489 bytes of erased flash into the CrossLink and come up with no cameras.

## What changed

Only `.github/workflows/build-firmware.yml`, in the production-assembly step.

- The bitstream is placed at `0x081A0000`, alongside the bootloader at `0x08000000` and the signed app at `0x08020000`. It comes from `fpga/openmotion-camera-fpga.bin`, which the bare-metal CMake configure has already downloaded into the workspace by this point in the job (guarded with `test -s`).
- `production.hex` is now built by objcopying the three pieces to their load addresses and merging with `merge_hex.py`, rather than converting the padded flat `.bin`. A flat conversion would emit ~1.4 MB of `0xFF` records for the gaps and make flashing take far longer than it needs to. This mirrors what `CMakeLists.txt` already does for the bare-metal merged image.
- `production.bin` stays flat and grows from ~440 KB to ~1.87 MB, comparable to the existing 1.78 MB bare-metal merged image.

Three guards, each failing the build rather than shipping a broken image:

| Guard | Catches |
|---|---|
| signed app must not reach `0x081A0000` | app growth silently overwriting the bitstream |
| bitstream must not reach `0x081E0000` | bitstream growth eating `motion_config` + the serial record |
| bitstream size must equal the constant `crosslink.c` streams | the long-standing gotcha where a new bitstream ships and the hardcoded `163489` is not updated, which otherwise only shows up as a dead FPGA on hardware |

That third guard is slightly beyond the minimum needed to close #109 — it is three lines and it protects exactly the artifact this PR builds, but say the word and I will drop it.

## Verification

CI cannot be exercised without a tag push, so I extracted the embedded Python from the workflow (not a copy of it) and ran it in a temp workspace laid out like the CI job, against the **real** `openmotion-camera-fpga.bin` and the **real** `Core/Src/crosslink.c`:

```
happy path: 1867425 B image, fpga 163489 B, ends at 0x081C7EA1 (config sector 0x081E0000)
  production image: 1867425 bytes (bootloader=60000 B, signed app=380000 B, fpga=163489 B)
guard ok: oversized app rejected
guard ok: oversized bitstream rejected
guard ok: crosslink.c size mismatch rejected
regex ok: crosslink.c constant = 163489, real bitstream = 163489

all checks passed
```

Byte-level assertions on the assembled image: bootloader at offset 0, `0xFF` gap before the slot, signed app at `0x20000`, `0xFF` gap before the bitstream, and the bitstream's first and last 16 bytes intact at `0x1A0000`.

**Not verified on hardware.** No sensor has a bootloader installed, and none should be converted until #108 is fixed — the bootloader's anti-rollback floor currently sits at `0x081C0000`, which overlaps the last 32,417 bytes of the very bitstream this PR installs. #108 must land first or the first successful boot erases the tail of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
