### PR TITLE
feat: OW_CMD_BOOT_INFO (0x09) — report runtime SCB->VTOR (#110)

### DIFF
--- a/Core/Inc/common.h
+++ b/Core/Inc/common.h
@@ -105,6 +105,7 @@ typedef enum {
 	OW_CMD_I2C_BROADCAST = 0x06,
 	OW_CMD_SERIAL = 0x07,
 	OW_CMD_I2C_REG_READ = 0x08,
+	OW_CMD_BOOT_INFO = 0x09,   /* report runtime SCB->VTOR so a host can tell bare-metal from bootloader-slot */
 	OW_CMD_USR_CFG = 0x0A,
 	OW_CMD_I2C_STATUS = 0x0B,
 	OW_CMD_DEBUG_FLAGS = 0x0C,

--- a/Core/Src/if_commands.c
+++ b/Core/Src/if_commands.c
@@ -35,6 +35,19 @@ extern volatile uint8_t event_bits_enabled;
 } while(0)
 
 static uint32_t id_words[4] = {0};  /* 3 UID words + 1 zero-pad: HWID reply is 16B, so [3] would over-read 4B past the array */
+
+/* OW_CMD_BOOT_INFO reply. Reports the RUNTIME vector-table base (SCB->VTOR),
+ * not the compile-time BARE_METAL_BUILD flag, so the device evidences where it
+ * is actually executing: 0x08000000 => bare-metal, 0x08020400 => bootloader
+ * slot. The host derives the boot mode. Packed, little-endian on the wire. */
+typedef struct __attribute__((packed)) {
+	uint8_t  struct_version;   /* 1 */
+	uint8_t  reserved[3];
+	uint32_t vtor;             /* SCB->VTOR */
+	uint32_t flash_base;       /* image link base (same as vtor sans the 0x400 header offset in slot builds) */
+} boot_info_t;
+static boot_info_t boot_info = {0};
+
 static uint8_t camera_status[8] = {0};
 static uint8_t i2c_reg_read_buf[I2C_REG_READ_MAX_LEN] = {0};
 static uint8_t camera_power_status = 0;
@@ -87,6 +100,22 @@ static void process_basic_command(UartPacket *uartResp, UartPacket cmd)
 		id_words[2] = HAL_GetUIDw2();
 		uartResp->data_len = 16;
 		uartResp->data = (uint8_t *)&id_words;
+		break;
+	case OW_CMD_BOOT_INFO:
+		VERBOSE_CMD("[CMD] OW_CMD_BOOT_INFO\r\n");
+		uartResp->command = OW_CMD_BOOT_INFO;
+		uartResp->packet_type = OW_RESP;
+		boot_info.struct_version = 1u;
+		boot_info.reserved[0] = 0u;
+		boot_info.reserved[1] = 0u;
+		boot_info.reserved[2] = 0u;
+		boot_info.vtor       = SCB->VTOR;
+		/* Link base = VTOR. In slot builds the vectors sit at slot+0x400; the
+		 * host only needs VTOR to classify (0x08000000 bare-metal vs 0x08020400
+		 * slot), so we report it directly rather than reconstructing a base. */
+		boot_info.flash_base = SCB->VTOR;
+		uartResp->data_len = sizeof(boot_info);
+		uartResp->data = (uint8_t *)&boot_info;
 		break;
 	case OW_CMD_I2C_REG_READ:
 	{


### PR DESCRIPTION
Refs #110

Lets a host tell a bare-metal image from a bootloader-slot image without entering DFU. Both build from the same source at the same tag (identical `OW_CMD_VERSION`); the only difference is the linker script and `SCB->VTOR`, which nothing exposed.

## Change

`OW_CMD_BOOT_INFO = 0x09` (free slot in `MotionGlobalCommands`). Reply is packed, little-endian:

```c
struct { uint8_t struct_version /*1*/; uint8_t reserved[3]; uint32_t vtor; uint32_t flash_base; }  // 12 B
```

It reports the **runtime** `SCB->VTOR`, not the compile-time `BARE_METAL_BUILD` flag — the device evidences where it is actually executing rather than asserting what it was built as. Host classifies:

| VTOR | mode |
|---|---|
| `0x08000000` | bare-metal |
| `0x08020400` | bootloader slot |

Those are exactly the `VECT_TAB_BASE_ADDRESS` values `system_stm32h7xx.c` sets for each build.

## Backward compatibility

Old firmware returns `OW_UNKNOWN` for `0x09` — an immediate response, not a timeout — so the host probes cheaply and treats no-answer as "unknown". (That inference isn't sound by construction: 1.8.2-rc.1/-rc.2/-rc.3 already ship slot images predating this command and would answer `OW_UNKNOWN` while running from the slot. It's safe today only because the DFU alt-setting check remains the authoritative gate before any write — this command drives UI, not flashing decisions.)

## Verification

Builds clean in both `Debug` (slot @0x08020400) and `Debug-BareMetal` (@0x08000000). Struct is 12 B. Consumed by openmotion-sdk (bootloader-aware flasher) and openmotion-test-app (lock-state icon, #71). Console equivalent is console-fw #45.

**Not yet HW-verified** — validated once flashed as 1.8.2-rc.4 and queried over the wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)