### PR TITLE
fix: HISTO/COMM endpoint-arm race (#96) + boot-mode-aware deploy.py (#88)

### DIFF
--- a/USB/Core/Src/usbd_conf.c
+++ b/USB/Core/Src/usbd_conf.c
@@ -636,7 +636,42 @@ USBD_StatusTypeDef USBD_LL_Transmit(USBD_HandleTypeDef *pdev, uint8_t ep_addr, u
   HAL_StatusTypeDef hal_status = HAL_OK;
   USBD_StatusTypeDef usb_status = USBD_OK;
 
+  /* #96: arming an IN transfer is not atomic, and the register it touches is
+   * shared by every IN endpoint.
+   *
+   * The core runs in slave mode (Init.dma_enable = DISABLE above), so packet
+   * data reaches an endpoint FIFO only because the TX-FIFO-empty interrupt is
+   * enabled for it. Those enables all live in ONE device register, and
+   * USB_EPStartXfer sets its bit with a plain read-modify-write:
+   *
+   *     stm32h7xx_ll_usb.c  USB_EPStartXfer()
+   *         USBx_DEVICE->DIEPEMPMSK |= 1UL << (ep->num & EP_ADDR_MSK);
+   *
+   * Transfers get armed from three contexts: the main loop (COMM command
+   * responses, via comms_host_check_received), the frame ISR (histogram
+   * sends) and the USB ISR (multi-packet chaining in *_DataIn). The USB ISR
+   * is NVIC priority 0 (USB_IRQ_PRIORITY), so it preempts the other two. When
+   * it lands between the load and the store, the preempted caller writes back
+   * a stale mask and silently clears the OTHER endpoint's enable bit. That
+   * endpoint's packet is never copied into the FIFO, DataIn never fires for
+   * it, and its class code waits forever on a transfer that cannot complete.
+   *
+   * Observed as: host polls camera telemetry over COMM at 1 Hz during a scan,
+   * and HISTO stops delivering within seconds-to-a-minute while COMM itself
+   * stays healthy (the clobbering writer keeps its own bit) and the cameras
+   * keep running. Same mechanism behind the older "concurrent I2C passthrough
+   * kills HISTO in ~2 s" reports.
+   *
+   * Masking interrupts across the arm makes the read-modify-write indivisible.
+   * The clear side (PCD_WriteEmptyTxFifo) needs no guard: it runs in the USB
+   * ISR at priority 0, which nothing touching this register can preempt. In
+   * slave mode this call only programs registers — the FIFO copy happens later
+   * in the ISR — so the masked window is a handful of writes, not a data copy.
+   */
+  uint32_t primask = __get_PRIMASK();
+  __disable_irq();
   hal_status = HAL_PCD_EP_Transmit(pdev->pData, ep_addr, pbuf, size);
+  __set_PRIMASK(primask);
 
   usb_status =  USBD_Get_USB_Status(hal_status);
 

--- a/scripts/_deploy_helpers.py
+++ b/scripts/_deploy_helpers.py
@@ -29,6 +29,57 @@ def read_project_name(cmake_path: Path) -> str:
     return m.group(1)
 
 
+_BARE_METAL_CACHE_RE = re.compile(
+    r"^BARE_METAL:BOOL=(\w+)\s*$", re.MULTILINE
+)
+
+# CMake preset suffix marking the bare-metal variants (see CMakePresets.json).
+_BARE_METAL_SUFFIX = "-BareMetal"
+
+
+def build_type_for(config: str) -> str:
+    """Return the CMAKE_BUILD_TYPE for a preset name.
+
+    ``Debug-BareMetal`` is a *preset* name, not a build type — the build type
+    is still ``Debug``. Mirrors what .github/workflows/build-firmware.yml
+    passes to ``cmake --build --config``.
+    """
+    if config.endswith(_BARE_METAL_SUFFIX):
+        return config[: -len(_BARE_METAL_SUFFIX)]
+    return config
+
+
+def read_boot_mode(build_dir: Path) -> str:
+    """Return "baremetal" or "slot" for an already-configured build dir.
+
+    The CMakeCache is the only honest source: BARE_METAL can be set by the
+    preset *or* by a bare ``-DBARE_METAL=ON``, and the preset name alone
+    doesn't prove which linker script was used.
+
+    Raises RuntimeError if the directory was never configured, or if the
+    cache predates the BARE_METAL option — in that case the layout is
+    genuinely unknown, and guessing is how a slot image ends up flashed to
+    0x08000000.
+    """
+    cache = build_dir / "CMakeCache.txt"
+    if not cache.is_file():
+        raise RuntimeError(
+            f"No CMakeCache.txt in {build_dir} — that build directory has "
+            f"never been configured. Run: cmake --preset {build_dir.name}"
+        )
+
+    m = _BARE_METAL_CACHE_RE.search(cache.read_text(encoding="utf-8",
+                                                    errors="replace"))
+    if not m:
+        raise RuntimeError(
+            f"{cache} has no BARE_METAL entry, so it predates the boot-mode "
+            "split and its flash layout cannot be determined. Reconfigure "
+            f"from scratch: cmake --preset {build_dir.name}"
+        )
+
+    return "baremetal" if m.group(1).upper() in ("ON", "TRUE", "1", "YES") else "slot"
+
+
 def bin_path_for(repo_root: Path, config: str, project: str,
                  fw_only: bool = False) -> Path:
     """Return the absolute path to the produced .bin for a given config.

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -5,9 +5,17 @@ Flashes via STM32_Programmer_CLI (STM32CubeProgrammer) when installed —
 ~10x faster than dfu-util against the ROM bootloader — and falls back to
 dfu-util otherwise.
 
+Bare-metal images only. The ROM DFU bootloader this drives writes 0x08000000,
+which is where a bare-metal image lives; a bootloader-slot build (the repo's
+default `Debug`/`Release` presets) is linked at 0x08020400 and must be signed
+by CI, so it is refused rather than flashed to the wrong address (#88). The
+default preset is therefore Debug-BareMetal, configured automatically if its
+build directory doesn't exist yet.
+
 Usage:
     python scripts/deploy.py --device left|right
-                             [--config Debug|Release] [--no-build]
+                             [--config Debug-BareMetal|Release-BareMetal]
+                             [--no-build]
                              [--fw-only] [--use-dfu-util]
                              [--programmer-cli PATH] [--dfu-util PATH]
                              [--power-cycle-cmd CMD]
@@ -26,6 +34,8 @@ sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 from _deploy_helpers import (  # noqa: E402
     bin_path_for,
+    build_type_for,
+    read_boot_mode,
     read_project_name,
     resolve_dfu_util,
     resolve_programmer_cli,
@@ -37,7 +47,15 @@ from _deploy_helpers import (  # noqa: E402
 # Boot includes FPGA SRAM erase (~5 s), so give the comeback some headroom.
 COMEBACK_TIMEOUT_S = 15.0
 DFU_ENUM_TIMEOUT_S = 10.0
+
+# This script drives the STM32 ROM DFU bootloader, which is only reachable on
+# a bare-metal image — so 0x08000000 is the only address it ever writes. A
+# bootloader-slot image lives at 0x08020400 behind the custom bootloader and
+# must be SIGNED to boot, which needs CI-held keys; there is deliberately no
+# local path to flash one here (#88).
 FLASH_BASE = 0x08000000
+
+CONFIG_CHOICES = ("Debug-BareMetal", "Release-BareMetal", "Debug", "Release")
 
 
 def parse_args() -> argparse.Namespace:
@@ -46,7 +64,10 @@ def parse_args() -> argparse.Namespace:
     )
     p.add_argument("--device", choices=("left", "right"), required=True,
                    help="Which sensor side to flash (required to avoid wrong-side mistakes)")
-    p.add_argument("--config", choices=("Debug", "Release"), default="Debug")
+    p.add_argument("--config", choices=CONFIG_CHOICES, default="Debug-BareMetal",
+                   help="CMake preset to build and flash (default: "
+                        "Debug-BareMetal — the bare-metal layout is the only "
+                        "one this script can flash; see --help notes on #88)")
     p.add_argument("--no-build", action="store_true")
     p.add_argument("--fw-only", action="store_true",
                    help="Flash the firmware-only image (no FPGA bitstream) — "
@@ -98,12 +119,41 @@ def _confirm(device: str, bin_file: Path) -> bool:
 def _build(config: str) -> None:
     build_dir = REPO_ROOT / "build" / config
     if not build_dir.exists():
-        raise RuntimeError(
-            f"Build dir {build_dir} does not exist. Run cmake configure first."
-        )
-    rc = _run(["cmake", "--build", str(build_dir), "--config", config])
+        # Configure it rather than making the caller do it by hand — the
+        # preset carries the boot mode, so there is nothing to get wrong.
+        rc = _run(["cmake", "--preset", config], cwd=str(REPO_ROOT))
+        if rc != 0:
+            raise RuntimeError(f"cmake --preset {config} failed with exit code {rc}")
+    rc = _run(["cmake", "--build", str(build_dir),
+               "--config", build_type_for(config)])
     if rc != 0:
         raise RuntimeError(f"cmake --build failed with exit code {rc}")
+
+
+def _require_bare_metal(config: str) -> None:
+    """Refuse to flash a bootloader-slot image (#88).
+
+    A slot image is linked at 0x08020400 with VTOR relocated there. Writing it
+    to 0x08000000 puts the vector table at the wrong address — the unit does
+    not boot, and on a bootloader unit it also destroys the bootloader.
+    """
+    build_dir = REPO_ROOT / "build" / config
+    mode = read_boot_mode(build_dir)
+    if mode == "baremetal":
+        return
+
+    bare = config if config.endswith("-BareMetal") else f"{config}-BareMetal"
+    raise RuntimeError(
+        f"build/{config} is a BOOTLOADER-SLOT build (BARE_METAL=OFF): the app "
+        f"is linked at 0x08020400 and must be signed by CI to boot.\n"
+        f"   This script only flashes bare-metal images to 0x{FLASH_BASE:08x} "
+        f"via the ROM DFU bootloader, so it will not flash this one.\n"
+        f"   For a bench deploy, use the bare-metal preset:\n"
+        f"       python scripts/deploy.py --device <side> --config {bare}\n"
+        f"   To put a real bootloader unit into service, flash the signed "
+        f"`production` artifact from the build-firmware workflow with "
+        f"STM32CubeProgrammer instead."
+    )
 
 
 def _sensor_handle(interface, device: str):
@@ -198,6 +248,15 @@ def main() -> int:
         except RuntimeError as e:
             print(f"❌ {e}")
             return 1
+
+    # Boot-mode gate before any existence check: a slot build DOES produce a
+    # {project}.bin, so without this the script would happily flash it to the
+    # wrong address (#88).
+    try:
+        _require_bare_metal(args.config)
+    except RuntimeError as e:
+        print(f"❌ {e}")
+        return 1
 
     if not bin_file.exists():
         print(f"❌ Binary not found: {bin_file}")

--- a/tests/test_deploy_helpers.py
+++ b/tests/test_deploy_helpers.py
@@ -9,6 +9,8 @@ import pytest
 from _deploy_helpers import (
     read_project_name,
     bin_path_for,
+    build_type_for,
+    read_boot_mode,
     resolve_dfu_util,
     wait_for_dfu_device,
 )
@@ -35,6 +37,57 @@ def test_bin_path_for_returns_repo_relative(tmp_path: Path):
     repo = tmp_path
     result = bin_path_for(repo, "Debug", "motion-console-fw")
     assert result == repo / "build" / "Debug" / "motion-console-fw.bin"
+
+
+def _write_cache(build_dir: Path, body: str) -> Path:
+    build_dir.mkdir(parents=True, exist_ok=True)
+    cache = build_dir / "CMakeCache.txt"
+    cache.write_text(textwrap.dedent(body), encoding="utf-8")
+    return cache
+
+
+def test_read_boot_mode_detects_baremetal(tmp_path: Path):
+    _write_cache(tmp_path / "Debug-BareMetal", """
+        CMAKE_BUILD_TYPE:STRING=Debug
+        BARE_METAL:BOOL=ON
+    """)
+    assert read_boot_mode(tmp_path / "Debug-BareMetal") == "baremetal"
+
+
+def test_read_boot_mode_detects_slot(tmp_path: Path):
+    _write_cache(tmp_path / "Debug", """
+        CMAKE_BUILD_TYPE:STRING=Debug
+        BARE_METAL:BOOL=OFF
+    """)
+    assert read_boot_mode(tmp_path / "Debug") == "slot"
+
+
+def test_read_boot_mode_raises_when_cache_missing(tmp_path: Path):
+    with pytest.raises(RuntimeError, match="CMakeCache.txt"):
+        read_boot_mode(tmp_path / "never-configured")
+
+
+def test_read_boot_mode_raises_on_stale_cache_without_the_option(tmp_path: Path):
+    """A cache predating the BARE_METAL option says nothing about layout.
+
+    Guessing here is how you flash a slot image to 0x08000000, so refuse and
+    make the caller reconfigure.
+    """
+    _write_cache(tmp_path / "Debug", """
+        CMAKE_BUILD_TYPE:STRING=Debug
+    """)
+    with pytest.raises(RuntimeError, match="BARE_METAL"):
+        read_boot_mode(tmp_path / "Debug")
+
+
+@pytest.mark.parametrize("config,expected", [
+    ("Debug", "Debug"),
+    ("Release", "Release"),
+    ("Debug-BareMetal", "Debug"),
+    ("Release-BareMetal", "Release"),
+])
+def test_build_type_for_strips_the_preset_suffix(config: str, expected: str):
+    assert build_type_for(config) == expected
 
 
 def test_resolve_dfu_util_uses_override_when_given(tmp_path: Path):

--- a/tests/test_histo_telemetry_contention_hil.py
+++ b/tests/test_histo_telemetry_contention_hil.py
@@ -1,0 +1,285 @@
+"""HIL regression: COMM traffic during a scan must not kill the HISTO stream.
+
+Issue #96. Polling OW_CAMERA_GET_TELEMETRY (0x54) at 1 Hz *while HISTO is
+streaming* stopped histogram delivery within seconds-to-a-minute — cameras
+kept running, FSIN kept counting, the telemetry channel itself stayed
+perfectly healthy, and only HISTO died. Without host polling the same
+firmware streamed clean, so the firmware's own 125 ms background telemetry
+sweep was never the trigger; the sustained COMM response TX was.
+
+Root cause: the OTG core runs in slave mode (usbd_conf.c,
+Init.dma_enable = DISABLE), so packet data only reaches an endpoint FIFO
+because that endpoint's TX-FIFO-empty interrupt is enabled — and every IN
+endpoint's enable bit lives in ONE device register, DIEPEMPMSK, which
+USB_EPStartXfer updates with a plain read-modify-write
+(stm32h7xx_ll_usb.c). Transfers are armed from the main loop (COMM command
+responses), the frame ISR (histogram sends) and the USB ISR (multi-packet
+chaining). The USB ISR is NVIC priority 0 and preempts the other two, so
+when it landed inside that read-modify-write the preempted caller wrote back
+a stale mask and cleared the HISTO endpoint's bit. HISTO's packet was then
+never copied into the FIFO, DataIn never fired, and histo_ep_data stayed 1.
+COMM survived because the clobbering writer keeps its own bit.
+
+Fixed by masking interrupts across the arm in USBD_LL_Transmit so the
+read-modify-write cannot be split.
+
+Note this is a *race*, so absence of failure in a short window proves
+little — prefer a long run. Onset in the original report varied from 4.6 s
+to 59.2 s. Override the window with OW_CONTENTION_SECONDS.
+
+What failure looks like on unfixed firmware:
+
+  * pre-#105 firmware (no stuck-TX watchdog): delivery stops dead and never
+    resumes — total bytes collapse.
+  * #105-or-later firmware: the watchdog flushes the endpoint after 500 ms
+    with no DataIn progress, so each clobber shows up as a ~0.5 s hole in an
+    otherwise 25 ms cadence. That is what MAX_GAP_S catches.
+
+Run on a bench with a sensor attached (WinUSB via Zadig):
+
+    OPENMOTION_HIL=1 pytest tests/test_histo_telemetry_contention_hil.py -v -s
+    (PowerShell: $env:OPENMOTION_HIL = "1")
+
+Select the sensor side with OW_SENSOR_SIDE=left|right (default: right), and
+set OPENMOTION_POWER_CYCLE_CMD to start from a fresh boot.
+"""
+import os
+import queue
+import statistics
+import subprocess
+import threading
+import time
+
+import pytest
+
+requires_bench = pytest.mark.skipif(
+    os.environ.get("OPENMOTION_HIL") != "1",
+    reason="hardware-in-the-loop test; set OPENMOTION_HIL=1 on the bench",
+)
+
+CONNECT_TIMEOUT_S = 15.0
+
+# Two cameras, same bring-up as test_histo_wedge_recovery_hil. The camera
+# count is not load-bearing for this race — it is a COMM/HISTO arming
+# collision, and 2 cameras at 40 Hz already means a multi-packet transfer
+# every 25 ms. More cameras only widen the window.
+CAM_MASK = 0x03
+
+# The reported trigger: 1 Hz host polling of get_camera_telemetry().
+POLL_INTERVAL_S = 1.0
+
+# Default observation window. The original report saw onset between 4.6 s
+# and 59.2 s, so short runs under-detect.
+DEFAULT_SECONDS = 60.0
+
+# Nominal cadence is 40 fps = 25 ms. Anything approaching the firmware's
+# 500 ms stuck-TX watchdog means delivery actually stalled rather than
+# jittered; 0.5 s is 20 missed frames.
+MAX_GAP_S = 0.5
+
+# Even with recovery, a run that loses most of its frames is a failure.
+MIN_DELIVERY_RATIO = 0.60
+NOMINAL_FPS = 40.0
+
+_INTERFACE_KEEPALIVE = []
+
+
+@pytest.fixture
+def bench_side():
+    cycle_cmd = os.environ.get("OPENMOTION_POWER_CYCLE_CMD")
+    if cycle_cmd:
+        subprocess.run(cycle_cmd, shell=True, check=True, timeout=60)
+        time.sleep(8.0)
+    return os.environ.get("OW_SENSOR_SIDE", "right")
+
+
+def _connect(side):
+    from omotion import MotionInterface
+
+    interface = MotionInterface()
+    _INTERFACE_KEEPALIVE.append(interface)
+    interface.start(wait=False)
+    handle = interface.left if side == "left" else interface.right
+    deadline = time.monotonic() + CONNECT_TIMEOUT_S
+    while time.monotonic() < deadline and not handle.is_connected():
+        time.sleep(0.2)
+    if not handle.is_connected():
+        interface.stop()
+        pytest.fail(
+            f"{side} sensor not reachable in {CONNECT_TIMEOUT_S:.0f}s — not "
+            "plugged in, no WinUSB driver, or wedged from a previous run "
+            "(power-cycle it)."
+        )
+    return interface, handle
+
+
+def _bring_up(sensor):
+    assert sensor.enable_camera_power(CAM_MASK) is True
+    time.sleep(0.5)
+    assert sensor.program_fpga(camera_position=CAM_MASK,
+                               manual_process=False) is True
+    time.sleep(0.1)
+    assert sensor.camera_configure_registers(CAM_MASK) is True
+
+
+def _shut_down(sensor):
+    try:
+        sensor.disable_aggregator_fsin()
+        sensor.disable_camera(CAM_MASK)
+        sensor.uart.histo.stop_streaming()
+        sensor.disable_camera_power(CAM_MASK)
+    except Exception:
+        pass
+
+
+class _TimestampingReader:
+    """Reader that records WHEN each chunk arrived, not just how many bytes.
+
+    Total-byte checks alone cannot distinguish "streamed clean" from
+    "streamed, stalled 500 ms, recovered, repeat" — and post-#105 firmware
+    does exactly the latter under this bug.
+    """
+
+    def __init__(self, histo, histogram_bytes):
+        self._histo = histo
+        self._histogram_bytes = histogram_bytes
+        self._queue = queue.Queue(maxsize=256)
+        self._stop_evt = threading.Event()
+        self.arrivals = []  # monotonic timestamps
+        self.bytes_received = 0
+        self._thread = threading.Thread(target=self._drain, daemon=True)
+
+    def _drain(self):
+        while not self._stop_evt.is_set():
+            try:
+                chunk = self._queue.get(timeout=0.2)
+            except queue.Empty:
+                continue
+            if chunk:
+                self.arrivals.append(time.monotonic())
+                self.bytes_received += len(chunk)
+
+    def start(self):
+        self._thread.start()
+        self._histo.start_streaming(self._queue,
+                                    expected_size=self._histogram_bytes)
+
+    def stop(self):
+        self._histo.stop_streaming()
+        self._stop_evt.set()
+        self._thread.join(timeout=2.0)
+
+
+class _TelemetryPoller:
+    """Polls get_camera_telemetry() at 1 Hz — the reported trigger."""
+
+    def __init__(self, sensor, interval_s):
+        self._sensor = sensor
+        self._interval = interval_s
+        self._stop_evt = threading.Event()
+        self.polls_ok = 0
+        self.polls_failed = 0
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def _run(self):
+        while not self._stop_evt.is_set():
+            try:
+                if self._sensor.get_camera_telemetry() is not None:
+                    self.polls_ok += 1
+                else:
+                    self.polls_failed += 1
+            except Exception:
+                self.polls_failed += 1
+            self._stop_evt.wait(self._interval)
+
+    def start(self):
+        self._thread.start()
+
+    def stop(self):
+        self._stop_evt.set()
+        self._thread.join(timeout=5.0)
+
+
+def _gap_report(arrivals, started_at, ended_at):
+    """Return (max_gap, gaps_over_threshold, count) over the whole window.
+
+    The window edges count: a stream that dies at t=4.6 s and never returns
+    has few *inter-arrival* gaps but an enormous trailing one.
+    """
+    marks = [started_at] + list(arrivals) + [ended_at]
+    gaps = [b - a for a, b in zip(marks, marks[1:])]
+    over = [g for g in gaps if g >= MAX_GAP_S]
+    return (max(gaps) if gaps else 0.0), over, len(arrivals)
+
+
+@requires_bench
+def test_histo_survives_telemetry_polling_during_scan(bench_side):
+    """1 Hz telemetry polling must not interrupt histogram delivery (#96)."""
+    from omotion.MotionProcessing import HISTOGRAM_BYTES
+
+    seconds = float(os.environ.get("OW_CONTENTION_SECONDS", DEFAULT_SECONDS))
+
+    interface, sensor = _connect(bench_side)
+    try:
+        if not hasattr(sensor, "get_camera_telemetry"):
+            pytest.skip("SDK lacks get_camera_telemetry(); update openmotion-sdk")
+
+        _bring_up(sensor)
+        histo = sensor.uart.histo
+        histo.flush_stale_data(HISTOGRAM_BYTES)
+
+        reader = _TimestampingReader(histo, HISTOGRAM_BYTES)
+        poller = _TelemetryPoller(sensor, POLL_INTERVAL_S)
+
+        reader.start()
+        assert sensor.enable_camera(CAM_MASK) is True
+        assert sensor.enable_aggregator_fsin() is True
+
+        started_at = time.monotonic()
+        poller.start()
+        time.sleep(seconds)
+        poller.stop()
+        ended_at = time.monotonic()
+        reader.stop()
+
+        max_gap, over, frames = _gap_report(reader.arrivals, started_at,
+                                            ended_at)
+        elapsed = ended_at - started_at
+        expected = elapsed * NOMINAL_FPS
+        ratio = (frames / expected) if expected else 0.0
+        median_gap = statistics.median(
+            [b - a for a, b in zip(reader.arrivals, reader.arrivals[1:])]
+        ) if len(reader.arrivals) > 2 else float("nan")
+
+        print(f"\n=== #96 contention, {bench_side} sensor, {elapsed:.1f}s ===")
+        print(f"  telemetry polls   : {poller.polls_ok} ok, "
+              f"{poller.polls_failed} failed")
+        print(f"  histogram frames  : {frames} "
+              f"({ratio * 100:.1f}% of {expected:.0f} nominal)")
+        print(f"  bytes received    : {reader.bytes_received}")
+        print(f"  median gap        : {median_gap * 1000:.1f} ms")
+        print(f"  max gap           : {max_gap * 1000:.1f} ms "
+              f"(limit {MAX_GAP_S * 1000:.0f} ms)")
+        print(f"  gaps >= limit     : {len(over)}"
+              + (f"  {[f'{g:.2f}s' for g in over[:8]]}" if over else ""))
+
+        # The poller is the trigger, so a poller that never ran proves
+        # nothing — fail loudly rather than passing a test that did nothing.
+        assert poller.polls_ok > 0, (
+            "telemetry polling never succeeded; the contention this test "
+            "exists to reproduce was never applied"
+        )
+        assert not over, (
+            f"HISTO delivery stalled {len(over)} time(s) while telemetry was "
+            f"polled at {POLL_INTERVAL_S:.0f} Hz — longest hole "
+            f"{max_gap * 1000:.0f} ms (#96). A ~500 ms hole is the firmware's "
+            f"stuck-TX watchdog recovering a HISTO transfer whose DIEPEMPMSK "
+            f"bit was clobbered by a concurrent COMM arm."
+        )
+        assert ratio >= MIN_DELIVERY_RATIO, (
+            f"only {frames} frames in {elapsed:.1f}s "
+            f"({ratio * 100:.1f}% of nominal) — stream did not keep up (#96)"
+        )
+    finally:
+        _shut_down(sensor)
+        interface.stop()


### PR DESCRIPTION
Two bugs that both came out of the 1.8.2 work and were never on the board. Added to Project #11 and fixed here.

| | |
|---|---|
| **#96** | 1 Hz `OW_CAMERA_GET_TELEMETRY` polling during HISTO streaming wedges the histogram stream |
| **#88** | `deploy.py` assumes bare-metal `0x08000000`, broken against the new bootloader-slot default |

---

## #96 — concurrent COMM arms clobber the HISTO FIFO enable

### Root cause

The OTG core runs in **slave mode** (`usbd_conf.c`, `Init.dma_enable = DISABLE`), so packet data only reaches an endpoint FIFO because that endpoint's TX-FIFO-empty interrupt is enabled. Every IN endpoint's enable bit lives in **one device register**, and `USB_EPStartXfer` sets its bit with a plain read-modify-write:

```c
/* Drivers/.../stm32h7xx_ll_usb.c  USB_EPStartXfer() */
USBx_DEVICE->DIEPEMPMSK |= 1UL << (ep->num & EP_ADDR_MSK);
```

Transfers get armed from three contexts:

| Context | Path | Priority |
|---|---|---|
| Main loop | `comms_host_check_received` → `process_if_command` → `USBD_COMMS_SetTxBuffer` | thread |
| Frame ISR | `USBD_HISTO_SendData` → `USBD_HISTO_SetTxBuffer` | 2 |
| USB ISR | `USBD_Histo_DataIn` (multi-packet chaining) | **0** |

The USB ISR preempts the other two. When it lands between the load and the store, the preempted caller **writes back a stale mask and silently clears the other endpoint's enable bit**. That endpoint's packet is never copied into the FIFO, `DataIn` never fires for it, `histo_ep_data` stays `1`, and every later frame gets BUSY.

That accounts for every reported symptom, including the ones that made this look mysterious:

- **only HISTO dies, COMM stays healthy** — the clobbering writer keeps its own bit;
- **the firmware's own 125 ms background telemetry sweep is not the trigger** — it is I2C only and arms no USB transfer;
- **variable onset, 4.6 s to 59.2 s** — it needs the ISR to land inside a specific two-instruction window;
- **cameras keep running and FSIN keeps counting** — nothing camera-side is involved.

It also explains the older report that *8-camera streaming + concurrent host I2C passthrough killed HISTO in ~2 s*: same collision, different COMM traffic. Telemetry polling didn't introduce the bug, it just made a **supported** workflow hit it constantly.

### Fix

Mask interrupts across the arm in `USBD_LL_Transmit` (our wrapper, not vendor HAL) so the read-modify-write can't be split. The clear side (`PCD_WriteEmptyTxFifo`) needs no guard: it runs in the USB ISR at priority 0, which nothing touching this register can preempt. In slave mode the call only programs registers — the FIFO copy happens later in the ISR — so the masked window is a handful of writes, not a data copy.

### Relationship to #105

The stuck-TX watchdog from #105 already turned this from a permanent wedge into a ~500 ms recovery, which is why `next` no longer dies outright. **That is mitigation, not a fix** — the stream still loses ~20 frames every time it happens. #96 was reported on `1.8.2-dev.1-3-g7f8fe08`, before that watchdog existed, which is why the original report shows delivery stopping dead at t=4.6 s and never returning.

### Test

`tests/test_histo_telemetry_contention_hil.py` reproduces the reported scenario directly: stream HISTO while polling `get_camera_telemetry()` at 1 Hz. It records **arrival timestamps**, not just byte totals — totals cannot distinguish "streamed clean" from "stalled 500 ms, recovered, repeat", which is exactly what post-#105 firmware does under this bug. Fails on any gap ≥ 500 ms (the watchdog's signature) or on bulk frame loss, and fails loudly if the poller never ran, so it can't pass by doing nothing.

Window defaults to 60 s (`OW_CONTENTION_SECONDS` to override) because this is a race and a short run under-detects.

---

## #88 — deploy.py flashed the wrong address for the default build

The boot-mode split made `BARE_METAL=OFF` the default, so `cmake --preset Debug && cmake --build build/Debug` now produces an app-only image linked for the **bootloader slot at `0x08020400`**. `deploy.py` still hardcoded `FLASH_BASE = 0x08000000` and resolved `{project}-raw.bin`, which the slot build no longer emits. The default build was therefore either unflashable or — worse — flashable **to the wrong address**, putting the vector table where nothing boots and, on a bootloader unit, destroying the bootloader.

There is no correct local slot flow to support: this script drives the ROM DFU bootloader (bare-metal only), and a slot image additionally needs CI-held signing keys to boot. So:

- `--config` now takes the **preset** name, accepts the bare-metal presets, and defaults to `Debug-BareMetal` — the layout this script can actually flash, so the default build works with no manual `-DBARE_METAL=ON`. `cmake --build` gets the build *type* (`Debug`), matching what `build-firmware.yml` passes.
- A missing build directory is **configured** via `cmake --preset <config>` instead of erroring, since the preset carries the boot mode.
- `read_boot_mode()` reads `BARE_METAL` out of the **CMakeCache** — the only honest source, since the flag can come from the preset or a bare `-D` — and a slot build is refused with the exact bare-metal command to run instead, plus a pointer to the signed `production` CI artifact for real bootloader units.

The gate runs **before** the binary-exists check, because a slot build *does* produce a `{project}.bin` and would otherwise sail straight into the bad flash.

A cache with no `BARE_METAL` entry predates the option and can't be classified, so it raises rather than guessing — guessing is precisely how a slot image reaches `0x08000000`.

### Verified against real configured build dirs

```
Debug              boot_mode=slot        -> REFUSED, exit 1, before any hardware contact
Debug-BareMetal    boot_mode=baremetal   -> accepted

Debug-BareMetal  fw_only=True   motion-sensor-fw-raw.bin   exists=True
Debug-BareMetal  fw_only=False  motion-sensor-fw.bin       exists=True
Debug            fw_only=True   motion-sensor-fw-raw.bin   exists=False   <- the reported breakage
Debug            fw_only=False  motion-sensor-fw.bin       exists=True    <- what used to get mis-flashed
```

Unit tests cover both classifications, the missing cache, the stale cache, and preset-suffix stripping (`tests/test_deploy_helpers.py`, 18 passed).

---

## Verification status

- **Builds clean in all four configs** — Debug (FLASH 75.42 %), Debug-BareMetal (37.70 %), Release, Release-BareMetal. No new compiler warnings.
- **#88 verified end-to-end** against real configured build directories, refusal path exercised (no hardware contact by construction).
- **#96 is NOT hardware-verified.** The root cause is established from the code and matches every symptom, and the fix is mechanical, but the bench run is still owed — the HIL test in this PR is what to run. Worth also confirming the pre-fix failure signature reproduces (gaps ≈ 500 ms on current `next`), so the test is known to discriminate.

Refs #96
Refs #88
