### PR TITLE
fix: per-camera double buffering — decouple the DMA re-arm from the send path (#116)

### DIFF
--- a/Core/Inc/camera_manager.h
+++ b/Core/Inc/camera_manager.h
@@ -33,7 +33,18 @@ typedef struct {
 	bool            isPresent;
 	uint8_t 		gain;
 	uint8_t 		exposure;
+	/* #116: published frame pointer — always aliases pRxBuf[done] (the most
+	 * recent COMPLETE frame). Legacy readers (get_single_histogram, fake-data
+	 * fill) use this; the streaming send paths read pRxBuf[] through the
+	 * copy-announce protocol in camera_manager.c instead. */
 	uint8_t *pRecieveHistoBuffer;
+	/* #116: per-camera RX double buffer. DMA fills one half while the send
+	 * path copies the other, so the re-arm never waits on the send. Cam 1
+	 * (SPI6) points into SRAM4 (BDMA reaches only D3); the rest into
+	 * frame_buffer in RAM_D1. NOTE: D-cache is disabled in this firmware; if
+	 * anyone enables it, every one of these DMA buffers needs MPU/invalidate
+	 * treatment at once. */
+	uint8_t *pRxBuf[2];
     size_t   receiveBufferSize;      // Size of the buffer
 	GPIO_TypeDef *	detect_clk_port;
 	uint16_t		detect_clk_pin;
@@ -150,6 +161,19 @@ void CAM_UART_RxCpltCallback(USART_HandleTypeDef *husart);
 void CAM_SPI_RxCpltCallback(SPI_HandleTypeDef *hspi);
 
 void camera_i2c_service(void);  /* Main-loop service for hi2c1 work deferred from the frame ISRs (temp poll, failed-camera mux disables) */
+
+/* #116: camera RX decoupling. camera_rx_complete() runs in the camera DMA/SPI
+ * RX ISRs (replaces the bare event-bit set): publishes the completed buffer,
+ * swaps the DMA target, and pends PendSV for the re-arm. camera_rearm_isr()
+ * is the PendSV body (called from PendSV_Handler in stm32h7xx_it.c).
+ * camera_rx_error_recover() is the error-callback path (main.c): flags the
+ * camera for re-arm instead of abort+start in ISR context.
+ * camera_rearm_service() is the main-loop backstop: retries any failed arm
+ * with abort + backoff until it sticks — no arm failure is terminal. */
+void camera_rx_complete(uint8_t cam_id);
+void camera_rearm_isr(void);
+void camera_rx_error_recover(uint8_t cam_id);
+void camera_rearm_service(void);
 void scan_camera_sensor(uint8_t cam_id);  /* Scan single camera slot; sets isPresent */
 void scan_camera_sensors(void);
 uint8_t get_cameras_present(void);  // Get bitmask of present cameras (computed from cam_array[].isPresent)

--- a/Core/Inc/common.h
+++ b/Core/Inc/common.h
@@ -41,18 +41,38 @@
                                           * (re)configured. See X02C1B_raw_sensor in 0X02C1B.c */
 
 
+/* #116 NVIC tiering — the camera RX -> re-arm chain must outrank the send
+ * path, or a stalled send (COMM TX spin, rle_compress, logging waits) blocks
+ * the DMA re-arm and one missed re-arm kills a camera for the scan:
+ *
+ *   0  USB / I2C / UART4-logging DMA        (unchanged; all short ISRs)
+ *   1  camera RX completions                 CAMERA_RX_IRQ_PRIORITY
+ *      (DMA1_Stream2-7, DMA2_Stream0, BDMA_Channel0, SPI2/3/4/6 EOT)
+ *   2  PendSV = deferred camera re-arm       CAMERA_REARM_PENDSV_PRIORITY
+ *      (pended from RX-complete; runs after the HAL ISR unwinds, so the
+ *       peripheral state is READY, yet still preempts the send path below)
+ *   3  FSIN frame ISRs -> send_data()        FSIN_IRQ_PRIORITY (TIM4 + EXTI13)
+ *   4  USART/UART globals                    (camera error callbacks, logging)
+ *   6  (was SPI3/4 — now 1, see above)
+ *
+ * Raising RX priority alone was bench-proven insufficient (15/15 deaths on a
+ * priority-corrected build) because the re-arm CODE lived in the send path;
+ * the tiering only works together with the PendSV re-arm in camera_manager.c. */
 #define I2C_IRQ_PRIORITY 0
-#define SPI2_IRQ_PRIORITY 0
-#define SPI3_IRQ_PRIORITY 6
-#define SPI4_IRQ_PRIORITY 6
-#define SPI6_IRQ_PRIORITY 4
+#define CAMERA_RX_IRQ_PRIORITY 1
+#define CAMERA_REARM_PENDSV_PRIORITY 2
+#define SPI2_IRQ_PRIORITY CAMERA_RX_IRQ_PRIORITY
+#define SPI3_IRQ_PRIORITY CAMERA_RX_IRQ_PRIORITY
+#define SPI4_IRQ_PRIORITY CAMERA_RX_IRQ_PRIORITY
+#define SPI6_IRQ_PRIORITY CAMERA_RX_IRQ_PRIORITY
 #define USART1_IRQ_PRIORITY 4
 #define USART2_IRQ_PRIORITY 4
 #define USART3_IRQ_PRIORITY 4
 #define USART6_IRQ_PRIORITY 4
 #define UART4_IRQ_PRIORITY 4
-#define DMA_IRQ_PRIORITY 0
-#define FSIN_IRQ_PRIORITY 2
+#define DMA_IRQ_PRIORITY CAMERA_RX_IRQ_PRIORITY  /* BDMA_Channel0 = SPI6 RX (cam 2) */
+#define FSIN_IRQ_PRIORITY 3
+#define TIM4_FSIN_IRQ_PRIORITY FSIN_IRQ_PRIORITY /* internal-FSIN frame ISR (was hardcoded 0) */
 #define USB_IRQ_PRIORITY 0
 
 // #define TIM8_BRK_TIM12_IRQ_PRIORITY 0

--- a/Core/Src/camera_manager.c
+++ b/Core/Src/camera_manager.c
@@ -46,11 +46,45 @@ static int _active_cam_idx = 0;
 
 static volatile bool usb_failed = false;
 
-__ALIGN_BEGIN volatile uint8_t frame_buffer[1][CAMERA_COUNT * HISTOGRAM_DATA_SIZE] __ALIGN_END; // Double buffer
+/* #116: per-camera RX double buffer, finally living up to the old comment.
+ * DMA fills pRxBuf[armed] while the send path copies pRxBuf[done]; the re-arm
+ * happens at RX-complete (via PendSV) and never waits on the send path. */
+__ALIGN_BEGIN volatile uint8_t frame_buffer[2][CAMERA_COUNT * HISTOGRAM_DATA_SIZE] __ALIGN_END; // Double buffer
 __ALIGN_BEGIN uint8_t packet_buffer[HISTO_JSON_BUFFER_SIZE] __ALIGN_END;
 __ALIGN_BEGIN uint8_t uncmp_payload[HISTO_JSON_BUFFER_SIZE] __ALIGN_END;  // Staging buffer for compression
 
-static uint8_t _active_buffer = 0; // Index of the buffer currently being written to
+/* #116: per-camera RX buffer-exchange state. Owner rules:
+ *  - armed_idx: written by camera_rx_complete (RX ISR, prio 1) only.
+ *  - done_idx:  written by camera_rx_complete; read by send paths inside the
+ *               copy-announce critical section.
+ *  - copy_idx:  written by the send paths (announce/withdraw around memcpy);
+ *               read by camera_rx_complete to decide drop-vs-publish.
+ *  - rearm_needed: set by camera_rx_complete / camera_rx_error_recover;
+ *               claimed (cleared-then-armed) by camera_rearm_isr (PendSV) and
+ *               camera_rearm_service (main loop).
+ * Invariant: armed_idx != done_idx except transiently inside the RX ISR, and
+ * DMA is never armed into a buffer whose copy_idx announcement is active. */
+#define CAM_BUF_NONE 0xFFu
+typedef struct {
+	volatile uint8_t  armed_idx;      /* buffer DMA owns (is or will be armed into) */
+	volatile uint8_t  done_idx;       /* buffer holding the latest complete frame */
+	volatile uint8_t  copy_idx;       /* buffer the send path is copying, CAM_BUF_NONE if none */
+	volatile bool     rearm_needed;   /* PendSV / retry service must (re)arm reception */
+	volatile uint32_t overwrite_drops;/* frames dropped: consumer stalled mid-copy > 1 frame (this scan) */
+	volatile uint32_t rearm_service_saves; /* re-arms completed by the main-loop retry service (this scan) */
+	uint32_t          next_retry_ms;  /* retry-service backoff deadline (HAL_GetTick timebase) */
+} cam_rx_state_t;
+static cam_rx_state_t cam_rx[CAMERA_COUNT];
+
+/* Pend the deferred re-arm (PendSV, CAMERA_REARM_PENDSV_PRIORITY). PendSV is
+ * free on this bare-metal firmware (no RTOS). It tail-chains after the RX ISR
+ * fully unwinds — required because the H7 HAL invokes the RxCplt callback
+ * BEFORE setting the peripheral state back to READY, so arming directly in
+ * the callback would be refused as BUSY. */
+static inline void camera_pend_rearm(void)
+{
+	SCB->ICSR = SCB_ICSR_PENDSVSET_Msk;
+}
 volatile uint8_t frame_id = 0;
 extern volatile uint8_t event_bits_enabled; // holds the event bits for the cameras to be enabled
 extern volatile uint8_t event_bits;
@@ -118,7 +152,8 @@ void camera_manager_get_diag_stats(cam_diag_stats_t *out) {
 	out->cmp_max_time_us = cmp_max_time_us;
 }
 
- __ALIGN_BEGIN __attribute__((section(".sram4"))) volatile uint8_t spi6_buffer[SPI_PACKET_LENGTH] __ALIGN_END;
+/* #116: cam 1 (SPI6) double buffer — must stay in SRAM4, BDMA reaches only D3. */
+ __ALIGN_BEGIN __attribute__((section(".sram4"))) volatile uint8_t spi6_buffer[2][SPI_PACKET_LENGTH] __ALIGN_END;
 
 
 static bool camera_is_present(uint8_t cam_id) {
@@ -467,11 +502,29 @@ void init_camera_sensors() {
 
 
 	for(i=0; i<CAMERA_COUNT; i++){
-		cam_array[i].pRecieveHistoBuffer =(uint8_t *)&frame_buffer[_active_buffer][i * HISTOGRAM_DATA_SIZE];
+		/* #116: per-camera double buffer — slot i of each frame_buffer half. */
+		cam_array[i].pRxBuf[0] = (uint8_t *)&frame_buffer[0][i * HISTOGRAM_DATA_SIZE];
+		cam_array[i].pRxBuf[1] = (uint8_t *)&frame_buffer[1][i * HISTOGRAM_DATA_SIZE];
+		cam_array[i].pRecieveHistoBuffer = cam_array[i].pRxBuf[0];
+		cam_rx[i].armed_idx = 0;
+		cam_rx[i].done_idx = 0;
+		cam_rx[i].copy_idx = CAM_BUF_NONE;
+		cam_rx[i].rearm_needed = false;
+		cam_rx[i].overwrite_drops = 0;
+		cam_rx[i].rearm_service_saves = 0;
+		cam_rx[i].next_retry_ms = 0;
 		init_camera(&cam_array[i]);
 	}
 
-	cam_array[1].pRecieveHistoBuffer = (uint8_t *)spi6_buffer;
+	/* Cam 1 (SPI6) pair lives in SRAM4 — BDMA reaches only D3. */
+	cam_array[1].pRxBuf[0] = (uint8_t *)spi6_buffer[0];
+	cam_array[1].pRxBuf[1] = (uint8_t *)spi6_buffer[1];
+	cam_array[1].pRecieveHistoBuffer = cam_array[1].pRxBuf[0];
+
+	/* #116: PendSV carries the deferred camera re-arm (camera_rearm_isr).
+	 * Above the FSIN/send tier so a stalled send can't block it; below the
+	 * camera RX tier so it tail-chains after the HAL RX ISR unwinds. */
+	HAL_NVIC_SetPriority(PendSV_IRQn, CAMERA_REARM_PENDSV_PRIORITY, 0);
 
 	event_bits = 0x00;
 	event_bits_enabled = 0x00;
@@ -1400,7 +1453,11 @@ _Bool capture_single_histogram(uint8_t cam_id)
 	GPIO_SetOutput(FSIN_GPIO_Port, FSIN_Pin, GPIO_PIN_RESET);
 	delay_ms(1);
 
-	memset((uint8_t*)cam->pRecieveHistoBuffer, 0, cam->useUsart ? USART_PACKET_LENGTH : SPI_PACKET_LENGTH);
+	/* #116: clear the ARM-target half — that's where this capture will land.
+	 * (camera_rx_complete publishes it to pRecieveHistoBuffer on completion,
+	 * which is what get_single_histogram() reads.) */
+	memset(cam->pRxBuf[cam_rx[cam_id].armed_idx], 0,
+	       cam->useUsart ? USART_PACKET_LENGTH : SPI_PACKET_LENGTH);
 
 	start_data_reception(cam_id);
 
@@ -1496,23 +1553,16 @@ static void check_camera_failures(void) {
 	}
 }
 
-/* #75: consume this frame's camera data WITHOUT sending it to the host.
- * Mirrors the event-bit consume + per-camera re-arm that send_histogram_data()
- * would have done (same masking rationale — see the comment there), so the
- * cameras/SPI pipeline keeps flowing and check_camera_failures() stays happy;
- * only the USB HISTO frame is withheld. Short-circuits BEFORE compression, so
- * the #70 cmp budget guard never runs on a suppressed frame. */
+/* #75: consume this frame's camera data WITHOUT sending it to the host, so
+ * the cameras/SPI pipeline keeps flowing and check_camera_failures() stays
+ * happy; only the USB HISTO frame is withheld. Short-circuits BEFORE
+ * compression, so the #70 cmp budget guard never runs on a suppressed frame.
+ * (#116: the per-camera re-arm this used to mirror now happens at
+ * RX-complete via PendSV — consuming the event bits is all that's left.) */
 static _Bool histo_stall_suppress_frame(void) {
-	uint8_t ready_bits;
 	__disable_irq();
-	ready_bits = event_bits & event_bits_enabled;
 	event_bits = 0x00;
 	__enable_irq();
-	for (uint8_t cam_id = 0; cam_id < CAMERA_COUNT; ++cam_id) {
-		if ((ready_bits & (1u << cam_id)) != 0) {
-			start_data_reception(cam_id);
-		}
-	}
 	return true;  /* pretend success, like DEBUG_FLAG_HISTO_THROTTLE does */
 }
 
@@ -1524,8 +1574,13 @@ _Bool send_data(void) {
 		streaming_start_time = get_timestamp_ms();
 		streaming_active = true;
 		streaming_first_frame = true;
-		/* #68 instrumentation: zero per-camera overrun counts at scan start. */
-		for (uint8_t ci = 0; ci < CAMERA_COUNT; ci++) { cam_overrun_count[ci] = 0; }
+		/* #68 instrumentation: zero per-camera overrun counts at scan start.
+		 * (#116: same for the buffer-exchange drop/retry counters.) */
+		for (uint8_t ci = 0; ci < CAMERA_COUNT; ci++) {
+			cam_overrun_count[ci] = 0;
+			cam_rx[ci].overwrite_drops = 0;
+			cam_rx[ci].rearm_service_saves = 0;
+		}
 		/* #70: zero the compression-guard counters at scan START (not stop, like
 		 * cmp_total_uncompressed/cmp_frame_count etc below) — these are part of
 		 * cam_diag_stats_t (OW_CMD_DIAG_STATS), and a host naturally queries
@@ -1638,6 +1693,26 @@ _Bool check_streaming(void){
 			       (unsigned long)cam_overrun_count[2], (unsigned long)cam_overrun_count[3],
 			       (unsigned long)cam_overrun_count[4], (unsigned long)cam_overrun_count[5],
 			       (unsigned long)cam_overrun_count[6], (unsigned long)cam_overrun_count[7]);
+			/* #116 instrumentation: frames dropped because the send path was
+			 * stalled mid-copy (camera survived — that's the fix working),
+			 * and re-arms rescued by the main-loop retry service. */
+			{
+				uint32_t drop_total = 0, save_total = 0;
+				for (uint8_t ci = 0; ci < CAMERA_COUNT; ci++) {
+					drop_total += cam_rx[ci].overwrite_drops;
+					save_total += cam_rx[ci].rearm_service_saves;
+				}
+				if (drop_total > 0) {
+					printf("[DIAG] rx stall-drops c1-c8: %lu %lu %lu %lu %lu %lu %lu %lu\r\n",
+					       (unsigned long)cam_rx[0].overwrite_drops, (unsigned long)cam_rx[1].overwrite_drops,
+					       (unsigned long)cam_rx[2].overwrite_drops, (unsigned long)cam_rx[3].overwrite_drops,
+					       (unsigned long)cam_rx[4].overwrite_drops, (unsigned long)cam_rx[5].overwrite_drops,
+					       (unsigned long)cam_rx[6].overwrite_drops, (unsigned long)cam_rx[7].overwrite_drops);
+				}
+				if (save_total > 0) {
+					printf("[DIAG] rx rearm-service saves: %lu\r\n", (unsigned long)save_total);
+				}
+			}
 			/* #70 instrumentation: compression budget-guard fallback counts this scan. */
 			if (cmp_timeout_count > 0 || cmp_fail_count > 0) {
 				printf("[DIAG] cmp fallback: timeout=%lu overflow=%lu total=%lu\r\n",
@@ -1738,12 +1813,23 @@ _Bool send_histogram_data(void) {
 	// --- Data ---
 	for (uint8_t cam_id = 0; cam_id < CAMERA_COUNT; ++cam_id) {
 		if((ready_bits & (0x01 << cam_id)) != 0) {
-			uint32_t *histo_ptr = (uint32_t *)cam_array[cam_id].pRecieveHistoBuffer;
+			/* #116: copy-announce protocol. Atomically snapshot the published
+			 * buffer index and announce the copy; camera_rx_complete() will
+			 * refuse to re-arm DMA into a buffer whose announcement is active
+			 * (it drops the incoming frame instead). The re-arm itself no
+			 * longer lives here — it runs at RX-complete via PendSV, so a
+			 * stall anywhere in this send path can no longer miss it. */
+			cam_rx_state_t *st = &cam_rx[cam_id];
+			__disable_irq();
+			uint8_t src_idx = st->done_idx;
+			st->copy_idx = src_idx;
+			__enable_irq();
 		    packet_buffer[offset++] = HISTO_SOH;
 			packet_buffer[offset++] = cam_id;
-			memcpy(packet_buffer+offset,histo_ptr,HISTO_SIZE_32B*4);
+			memcpy(packet_buffer+offset, cam_array[cam_id].pRxBuf[src_idx], HISTO_SIZE_32B*4);
 			offset += HISTO_SIZE_32B*4;
-			
+			st->copy_idx = CAM_BUF_NONE;
+
 			uint32_t temp_bits;
 			memcpy(&temp_bits, (uint8_t*)&cam_temp[cam_id],4);
 
@@ -1753,9 +1839,6 @@ _Bool send_histogram_data(void) {
 			packet_buffer[offset++] = (uint8_t)((temp_bits >> 24) & 0xFF);
 
 			packet_buffer[offset++] = HISTO_EOH;
-			
-			// Re-arm reception as soon as data is copied
-			start_data_reception(cam_id);
 		}
 	}
 
@@ -1930,11 +2013,17 @@ _Bool send_histogram_data_cmp(void) {
 	/* Per-camera data blocks */
 	for (uint8_t cam_id = 0; cam_id < CAMERA_COUNT; ++cam_id) {
 		if ((ready_bits & (0x01 << cam_id)) != 0) {
-			uint32_t *histo_ptr = (uint32_t *)cam_array[cam_id].pRecieveHistoBuffer;
+			/* #116: copy-announce protocol — see send_histogram_data(). */
+			cam_rx_state_t *st = &cam_rx[cam_id];
+			__disable_irq();
+			uint8_t src_idx = st->done_idx;
+			st->copy_idx = src_idx;
+			__enable_irq();
 			uncmp_payload[p_off++] = HISTO_SOH;
 			uncmp_payload[p_off++] = cam_id;
-			memcpy(uncmp_payload + p_off, histo_ptr, HISTO_SIZE_32B * 4);
+			memcpy(uncmp_payload + p_off, cam_array[cam_id].pRxBuf[src_idx], HISTO_SIZE_32B * 4);
 			p_off += HISTO_SIZE_32B * 4;
+			st->copy_idx = CAM_BUF_NONE;
 
 			uint32_t temp_bits;
 			memcpy(&temp_bits, (uint8_t *)&cam_temp[cam_id], 4);
@@ -1944,9 +2033,6 @@ _Bool send_histogram_data_cmp(void) {
 			uncmp_payload[p_off++] = (uint8_t)((temp_bits >> 24) & 0xFF);
 
 			uncmp_payload[p_off++] = HISTO_EOH;
-
-			/* Re-arm reception as soon as data is copied */
-			start_data_reception(cam_id);
 		}
 	}
 
@@ -2136,6 +2222,9 @@ _Bool start_data_reception(uint8_t cam_id){
 	}
 
 	CameraDevice cam = cam_array[cam_id];
+	/* #116: DMA always fills the armed slot of the double buffer; the send
+	 * path reads the done slot. camera_rx_complete() swaps the two. */
+	uint8_t *rx_target = cam.pRxBuf[cam_rx[cam_id].armed_idx];
 
     // Check if the device is BUSY
     if (cam.useUsart) {
@@ -2155,36 +2244,27 @@ _Bool start_data_reception(uint8_t cam_id){
 	if (cam.useUsart) {
 		if (cam.useDma) {
 			status = HAL_USART_Receive_DMA(cam.pUart,
-					cam.pRecieveHistoBuffer, USART_PACKET_LENGTH);
+					rx_target, USART_PACKET_LENGTH);
 		} else {
 			status = HAL_USART_Receive_IT(cam.pUart,
-					cam.pRecieveHistoBuffer, USART_PACKET_LENGTH);
+					rx_target, USART_PACKET_LENGTH);
 		}
 	} else {
 		if (cam.useDma) {
 			status = HAL_SPI_Receive_DMA(cam.pSpi,
-					cam.pRecieveHistoBuffer, SPI_PACKET_LENGTH);
+					rx_target, SPI_PACKET_LENGTH);
 		} else {
 			status = HAL_SPI_Receive_IT(cam.pSpi,
-					cam.pRecieveHistoBuffer, SPI_PACKET_LENGTH);
+					rx_target, SPI_PACKET_LENGTH);
 		}
 	}
 	if (status != HAL_OK) {
+		/* #116: no abort_data_reception() here anymore — it busy-waits 10 ms,
+		 * and this function now also runs in ISR context (PendSV re-arm).
+		 * A failed arm is no longer terminal either way: the caller flags
+		 * rearm_needed and camera_rearm_service() retries with abort+backoff
+		 * from the main loop until it sticks. */
 		printf("failed to setup receive for Camera %d channel\r\n", cam_id+1);
-		// Check if the device is BUSY
-		if (cam.useUsart) {
-			if (cam.pUart->State == HAL_USART_STATE_BUSY_RX ||
-				cam.pUart->State == HAL_USART_STATE_BUSY_TX_RX) {
-					printf("USART busy\r\n");
-				}
-		} else {
-			if (cam.pSpi->State == HAL_SPI_STATE_BUSY_RX ||
-				cam.pSpi->State == HAL_SPI_STATE_BUSY_TX_RX) {
-				printf("SPI busy\r\n");
-			}
-		}
-		
-		abort_data_reception(cam_id);
 		return false;
 	}
 	if(verbose_on) { printf("done\r\n"); }
@@ -2236,6 +2316,142 @@ _Bool abort_data_reception(uint8_t cam_id){
 	if(verbose_on) { printf("done\r\n"); }
 	return true;
 }
+
+/* ---------------- #116: RX decoupling — buffer exchange + re-arm ---------------- */
+
+/* Retry-service backoff: one frame period. Fast enough that a healthy retry
+ * beats check_camera_failures()' 3-frame stall threshold, slow enough not to
+ * spam abort_data_reception()'s 10 ms settle wait. */
+#define CAMERA_REARM_RETRY_MS 25u
+
+/* Camera RX-complete, called from the DMA/SPI RX ISRs in main.c (prio
+ * CAMERA_RX_IRQ_PRIORITY). Publishes the buffer that just filled and swaps
+ * the DMA target — UNLESS the send path is still mid-copy of the other
+ * buffer (a stall longer than one frame period), in which case the frame
+ * just received is dropped and DMA re-fills the same buffer. Never re-arms
+ * into a buffer the copier owns: the alternative is a torn frame that still
+ * passes CRC (the CRC is computed over whatever bytes were copied), i.e.
+ * silent corruption. A stall costs frames, never a camera, never integrity.
+ *
+ * The actual (re)arm is deferred to PendSV: the H7 HAL calls this callback
+ * BEFORE setting the peripheral state back to READY, so arming here would be
+ * refused as BUSY. PendSV tail-chains after the HAL ISR unwinds, and its
+ * priority still preempts the FSIN/send tier — a stalled send cannot delay
+ * the re-arm (that coupling is the whole bug, see #116). */
+void camera_rx_complete(uint8_t cam_id)
+{
+	if (cam_id >= CAMERA_COUNT) {
+		return;
+	}
+	cam_rx_state_t *st = &cam_rx[cam_id];
+	uint8_t filled = st->armed_idx;
+	uint8_t other  = (uint8_t)(filled ^ 1u);
+
+	if (st->copy_idx == other) {
+		/* Consumer stalled mid-copy of the previous frame: drop the frame
+		 * that just landed, keep DMA on the same buffer, publish nothing. */
+		st->overwrite_drops++;
+	} else {
+		st->done_idx = filled;
+		cam_array[cam_id].pRecieveHistoBuffer = cam_array[cam_id].pRxBuf[filled];
+		__disable_irq();
+		event_bits |= (uint8_t)(1u << cam_id);
+		__enable_irq();
+		st->armed_idx = other;
+	}
+
+	/* Re-arm only cameras armed for streaming. Single-capture and disabled/
+	 * stall-detector-disabled cameras must NOT auto-re-arm — a dead camera's
+	 * garbage completion re-arming itself is the 2026-06-11 BUSY_RX wedge. */
+	if ((event_bits_enabled & (1u << cam_id)) != 0u) {
+		st->rearm_needed = true;
+		camera_pend_rearm();
+	}
+}
+
+/* PendSV body (see PendSV_Handler in stm32h7xx_it.c): perform every pending
+ * re-arm now that the HAL RX ISR has unwound and the peripheral is READY.
+ * On failure the flag stays set and camera_rearm_service() takes over. */
+void camera_rearm_isr(void)
+{
+	for (uint8_t cam_id = 0; cam_id < CAMERA_COUNT; cam_id++) {
+		cam_rx_state_t *st = &cam_rx[cam_id];
+		if (!st->rearm_needed) {
+			continue;
+		}
+		if ((event_bits_enabled & (1u << cam_id)) == 0u ||
+		    cam_array[cam_id].needs_recovery || !cam_array[cam_id].isPowered) {
+			st->rearm_needed = false;  /* camera left the streaming set */
+			continue;
+		}
+		st->rearm_needed = false;      /* claim before arming (see service) */
+		if (!start_data_reception(cam_id)) {
+			st->rearm_needed = true;   /* hand off to the main-loop retry service */
+			st->next_retry_ms = HAL_GetTick() + CAMERA_REARM_RETRY_MS;
+		}
+	}
+}
+
+/* Error-callback path (HAL_USART/SPI_ErrorCallback in main.c). Replaces the
+ * old in-ISR abort_data_reception()+start_data_reception() one-shot, which
+ * (a) busy-waited 10 ms inside an ISR and (b) was terminal on failure —
+ * after it, every re-arm site was gated on an event bit the camera could
+ * never set again. Now: flag + pend. PendSV usually re-arms within
+ * microseconds (the HAL has already ended the transfer, state READY); if
+ * that fails, the retry service aborts and re-arms until it sticks. */
+void camera_rx_error_recover(uint8_t cam_id)
+{
+	if (cam_id >= CAMERA_COUNT) {
+		return;
+	}
+	if ((event_bits_enabled & (1u << cam_id)) == 0u) {
+		return;  /* not streaming: enable/single-capture paths do their own arming */
+	}
+	cam_rx[cam_id].rearm_needed = true;
+	camera_pend_rearm();
+}
+
+/* Main-loop retry backstop: any arm that failed in PendSV lands here and is
+ * retried — abort (forces the peripheral out of a stuck BUSY/error state,
+ * incl. its 10 ms settle, acceptable in thread context) then arm — every
+ * CAMERA_REARM_RETRY_MS until it succeeds or the camera leaves the
+ * streaming set. Claim protocol vs PendSV: both clear-then-arm, and this
+ * side's claim is IRQ-protected, so a camera is never double-armed. */
+void camera_rearm_service(void)
+{
+	for (uint8_t cam_id = 0; cam_id < CAMERA_COUNT; cam_id++) {
+		cam_rx_state_t *st = &cam_rx[cam_id];
+		if (!st->rearm_needed) {
+			continue;
+		}
+		if ((event_bits_enabled & (1u << cam_id)) == 0u ||
+		    cam_array[cam_id].needs_recovery || !cam_array[cam_id].isPowered) {
+			st->rearm_needed = false;
+			continue;
+		}
+		if ((int32_t)(HAL_GetTick() - st->next_retry_ms) < 0) {
+			continue;  /* backoff (wrap-safe compare) */
+		}
+		__disable_irq();
+		if (!st->rearm_needed) {  /* PendSV claimed it meanwhile */
+			__enable_irq();
+			continue;
+		}
+		st->rearm_needed = false;
+		__enable_irq();
+
+		(void)abort_data_reception(cam_id);
+		if (start_data_reception(cam_id)) {
+			st->rearm_service_saves++;
+			printf("Camera %d: RX re-armed by retry service\r\n", cam_id + 1);
+		} else {
+			st->rearm_needed = true;
+			st->next_retry_ms = HAL_GetTick() + CAMERA_REARM_RETRY_MS;
+		}
+	}
+}
+
+/* ---------------- end #116 RX decoupling ---------------- */
 
 _Bool enable_camera_stream(uint8_t cam_id){
 	// printf("C%d: enable...", cam_id+1);
@@ -2290,7 +2506,16 @@ _Bool enable_camera_stream(uint8_t cam_id){
 	event_bits &= ~(1u << cam_id);
 	__enable_irq();
 
-	/* Flush this camera's receive buffer before arming DMA. The FPGA is
+	/* #116: fresh buffer-exchange state for the new scan. Safe to reset here:
+	 * this camera has no armed DMA (reset_camera_usart above forced READY)
+	 * and its enabled bit is still clear, so no RX/PendSV activity races us. */
+	cam_rx[cam_id].armed_idx = 0;
+	cam_rx[cam_id].done_idx = 0;
+	cam_rx[cam_id].copy_idx = CAM_BUF_NONE;
+	cam_rx[cam_id].rearm_needed = false;
+	cam_rx[cam_id].next_retry_ms = 0;
+
+	/* Flush this camera's receive buffers before arming DMA. The FPGA is
 	 * re-programmed at every scan start (its frame counter resets to 1), but
 	 * the MCU's frame_buffer/spi6_buffer still holds the PREVIOUS scan's last
 	 * DMA'd frame — old FPGA frame_id and timestamp. If a send fires before
@@ -2298,11 +2523,15 @@ _Bool enable_camera_stream(uint8_t cam_id){
 	 * desyncing the host's frame-id unwrap and dark schedule (issue #172:
 	 * left-sensor "stale 255/173 with negative timestamps at scan start").
 	 * Zeroing it makes any premature send an obvious empty frame, not stale
-	 * data. capture_single_histogram() clears the buffer the same way. */
-	if (cam->pRecieveHistoBuffer != NULL) {
-		memset((uint8_t *)cam->pRecieveHistoBuffer, 0,
-			cam->useUsart ? USART_PACKET_LENGTH : SPI_PACKET_LENGTH);
+	 * data. capture_single_histogram() clears the buffer the same way.
+	 * (#116: both halves of the double buffer.) */
+	for (uint8_t half = 0; half < 2u; half++) {
+		if (cam->pRxBuf[half] != NULL) {
+			memset(cam->pRxBuf[half], 0,
+				cam->useUsart ? USART_PACKET_LENGTH : SPI_PACKET_LENGTH);
+		}
 	}
+	cam->pRecieveHistoBuffer = cam->pRxBuf[0];
 
 	/* Arm DMA BEFORE stream_on so the receiver is ready when the sensor
 	 * starts clocking data.  Arming after stream_on causes an immediate SPI
@@ -2373,6 +2602,9 @@ _Bool disable_camera_stream(uint8_t cam_id){
 	}
 
 	event_bits_enabled &= ~(1 << cam_id);
+	/* #116: withdraw any pending re-arm — the eligibility gates in
+	 * camera_rearm_isr/service would drop it anyway; this is just hygiene. */
+	cam_rx[cam_id].rearm_needed = false;
 
 	cam->streaming_enabled = false;
 	HAL_GPIO_WritePin(cam->gpio1_port, cam->gpio1_pin, GPIO_PIN_RESET); // Set GPIO1 low

--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -472,6 +472,7 @@ int main(void)
   	comms_host_check_received(); // check comms
     imu_service();           /* Sample the ICM if the 200 Hz timer ticked */
     camera_i2c_service();    /* Camera-bus work deferred from the frame ISRs (temp poll, mux disables) */
+    camera_rearm_service();  /* #116: retry any camera RX arm that failed in PendSV (abort+backoff) */
     logging_pump();          /* Flush USB log data buffered from ISR context */
     check_streaming();
     USBD_HISTO_CheckTxStuck(); /* Recover the HISTO EP if an armed transfer stalls (dead host reader) */
@@ -1634,6 +1635,9 @@ static void MX_DMA_Init(void)
   }
 
   /* DMA interrupt init */
+  /* #116: DMA1_Stream2-7 + DMA2_Stream0 carry camera RX completions (SPI2/3/4
+   * RX, USART2/1/3/6 RX) — CAMERA_RX_IRQ_PRIORITY tier, see common.h.
+   * DMA1_Stream0/1 are UART4 logging RX/TX and stay at 0 (short ISRs). */
   /* DMA1_Stream0_IRQn interrupt configuration */
   HAL_NVIC_SetPriority(DMA1_Stream0_IRQn, 0, 0);
   HAL_NVIC_EnableIRQ(DMA1_Stream0_IRQn);
@@ -1641,25 +1645,25 @@ static void MX_DMA_Init(void)
   HAL_NVIC_SetPriority(DMA1_Stream1_IRQn, 0, 0);
   HAL_NVIC_EnableIRQ(DMA1_Stream1_IRQn);
   /* DMA1_Stream2_IRQn interrupt configuration */
-  HAL_NVIC_SetPriority(DMA1_Stream2_IRQn, 0, 0);
+  HAL_NVIC_SetPriority(DMA1_Stream2_IRQn, CAMERA_RX_IRQ_PRIORITY, 0);
   HAL_NVIC_EnableIRQ(DMA1_Stream2_IRQn);
   /* DMA1_Stream3_IRQn interrupt configuration */
-  HAL_NVIC_SetPriority(DMA1_Stream3_IRQn, 0, 0);
+  HAL_NVIC_SetPriority(DMA1_Stream3_IRQn, CAMERA_RX_IRQ_PRIORITY, 0);
   HAL_NVIC_EnableIRQ(DMA1_Stream3_IRQn);
   /* DMA1_Stream4_IRQn interrupt configuration */
-  HAL_NVIC_SetPriority(DMA1_Stream4_IRQn, 0, 0);
+  HAL_NVIC_SetPriority(DMA1_Stream4_IRQn, CAMERA_RX_IRQ_PRIORITY, 0);
   HAL_NVIC_EnableIRQ(DMA1_Stream4_IRQn);
   /* DMA1_Stream5_IRQn interrupt configuration */
-  HAL_NVIC_SetPriority(DMA1_Stream5_IRQn, 0, 0);
+  HAL_NVIC_SetPriority(DMA1_Stream5_IRQn, CAMERA_RX_IRQ_PRIORITY, 0);
   HAL_NVIC_EnableIRQ(DMA1_Stream5_IRQn);
   /* DMA1_Stream6_IRQn interrupt configuration */
-  HAL_NVIC_SetPriority(DMA1_Stream6_IRQn, 0, 0);
+  HAL_NVIC_SetPriority(DMA1_Stream6_IRQn, CAMERA_RX_IRQ_PRIORITY, 0);
   HAL_NVIC_EnableIRQ(DMA1_Stream6_IRQn);
   /* DMA1_Stream7_IRQn interrupt configuration */
-  HAL_NVIC_SetPriority(DMA1_Stream7_IRQn, 0, 0);
+  HAL_NVIC_SetPriority(DMA1_Stream7_IRQn, CAMERA_RX_IRQ_PRIORITY, 0);
   HAL_NVIC_EnableIRQ(DMA1_Stream7_IRQn);
   /* DMA2_Stream0_IRQn interrupt configuration */
-  HAL_NVIC_SetPriority(DMA2_Stream0_IRQn, 0, 0);
+  HAL_NVIC_SetPriority(DMA2_Stream0_IRQn, CAMERA_RX_IRQ_PRIORITY, 0);
   HAL_NVIC_EnableIRQ(DMA2_Stream0_IRQn);
 
 }
@@ -1872,11 +1876,14 @@ void HAL_USART_ErrorCallback(USART_HandleTypeDef *husart)
   /* Attempt graceful recovery for any known camera USART peripheral.
    * Same fix as HAL_SPI_ErrorCallback: non-overrun errors (framing, noise,
    * DMA) previously fell through to Error_Handler() and halted the MCU.
-   * Any error on a known camera USART is recoverable via abort+restart. */
+   * #116: recovery is now flag + PendSV re-arm instead of an in-ISR
+   * abort_data_reception() (which busy-waited 10 ms in ISR context) +
+   * one-shot start (which was terminal on failure). If the PendSV arm
+   * fails, camera_rearm_service() retries from the main loop until it
+   * sticks — a failed re-arm is no longer permanent. */
   if (cam_id >= 0)
   {
-    abort_data_reception((uint8_t)cam_id);
-    start_data_reception((uint8_t)cam_id);
+    camera_rx_error_recover((uint8_t)cam_id);
     return;
   }
 
@@ -1980,11 +1987,11 @@ void HAL_SPI_ErrorCallback(SPI_HandleTypeDef *hspi)
    *   Error_Handler() entered from interrupt context →
    *   wait_for_usb_queues_to_finish() blocks (USB ISR can't run) →
    *   __disable_irq() → MCU completely dark.
-   * Now any error on a known camera SPI triggers abort+restart instead. */
+   * #116: recovery is now flag + PendSV re-arm with a main-loop retry
+   * backstop — see the USART error callback above for the rationale. */
   if (cam_id >= 0)
   {
-    abort_data_reception((uint8_t)cam_id);
-    start_data_reception((uint8_t)cam_id);
+    camera_rx_error_recover((uint8_t)cam_id);
     return;
   }
 
@@ -1993,50 +2000,49 @@ void HAL_SPI_ErrorCallback(SPI_HandleTypeDef *hspi)
 }
 
 
-void set_event_bit_atomic(uint32_t bit) {
-  __disable_irq();
-  event_bits |= bit;
-  __enable_irq();
-}
+/* #116: RX completions run the buffer-exchange protocol in camera_manager.c
+ * (publish the filled half, swap the DMA target, pend the PendSV re-arm)
+ * instead of just setting an event bit and leaving the re-arm to the send
+ * path. Instance -> cam_id mapping matches the old BIT_n assignments. */
 
 // Interrupt handler for SPI reception
 void HAL_SPI_RxCpltCallback(SPI_HandleTypeDef *hspi)
 {
   if (hspi->Instance == SPI2)
   {
-    set_event_bit_atomic(BIT_6);
+    camera_rx_complete(6);
   }
   else if (hspi->Instance == SPI3)
   {
-    set_event_bit_atomic(BIT_5);
+    camera_rx_complete(5);
   }
   else if (hspi->Instance == SPI4)
   {
-    set_event_bit_atomic(BIT_7);
+    camera_rx_complete(7);
   }
   else if (hspi->Instance == SPI6)
   {
-    set_event_bit_atomic(BIT_1);
+    camera_rx_complete(1);
   }
 }
 
 void HAL_USART_RxCpltCallback(USART_HandleTypeDef *husart)
 {
   if (husart->Instance == USART1)
-  { // Check if the interrupt is for USART2
-    set_event_bit_atomic(BIT_4);
+  {
+    camera_rx_complete(4);
   }
   else if (husart->Instance == USART2)
-  { // Check if the interrupt is for USART2
-    set_event_bit_atomic(BIT_0);
+  {
+    camera_rx_complete(0);
   }
   else if (husart->Instance == USART3)
-  { // Check if the interrupt is for USART2
-    set_event_bit_atomic(BIT_2);
+  {
+    camera_rx_complete(2);
   }
   else if (husart->Instance == USART6)
-  { // Check if the interrupt is for USART2
-    set_event_bit_atomic(BIT_3);
+  {
+    camera_rx_complete(3);
   }
 
 }

--- a/Core/Src/stm32h7xx_hal_msp.c
+++ b/Core/Src/stm32h7xx_hal_msp.c
@@ -768,7 +768,10 @@ void HAL_TIM_PWM_MspInit(TIM_HandleTypeDef* htim_pwm)
     /* Peripheral clock enable */
     __HAL_RCC_TIM4_CLK_ENABLE();
     /* TIM4 interrupt Init */
-    HAL_NVIC_SetPriority(TIM4_IRQn, 0, 0);
+    /* #116: TIM4 is the internal-FSIN frame ISR (runs send_data). It must sit
+     * BELOW the camera-RX and PendSV re-arm tiers so a stalled send can't
+     * block the DMA re-arm — see the tier table in common.h. */
+    HAL_NVIC_SetPriority(TIM4_IRQn, TIM4_FSIN_IRQ_PRIORITY, 0);
     HAL_NVIC_EnableIRQ(TIM4_IRQn);
     /* USER CODE BEGIN TIM4_MspInit 1 */
 

--- a/Core/Src/stm32h7xx_it.c
+++ b/Core/Src/stm32h7xx_it.c
@@ -190,6 +190,19 @@ void DebugMon_Handler(void)
   /* USER CODE END DebugMonitor_IRQn 1 */
 }
 
+/**
+  * @brief This function handles Pendable request for system service.
+  * #116: repurposed as the deferred camera RX re-arm (no RTOS on this
+  * firmware, so PendSV is otherwise unused). Pended from the camera RX
+  * completion / error callbacks; runs at CAMERA_REARM_PENDSV_PRIORITY —
+  * after the HAL RX ISR unwinds (peripheral READY) but still preempting
+  * the FSIN/send tier, so a stalled send path can never delay the re-arm.
+  */
+void PendSV_Handler(void)
+{
+  camera_rearm_isr();
+}
+
 /******************************************************************************/
 /* STM32H7xx Peripheral Interrupt Handlers                                    */
 /* Add here the Interrupt Handlers for the used peripherals.                  */


### PR DESCRIPTION
## What

The per-camera DMA re-arm lived inside `send_data()`'s copy loop, so **any**
stall on the send path — COMM TX spin (#115), `rle_compress` worst case (#70),
logging waits, USB recovery — missed it, and one missed re-arm was terminal:

```
Overrun -> failed to setup receive for Camera N channel
        -> Camera N has stopped posting data -> 10 s rail-off
        -> dead until the next configure (#102)
```

This PR decouples the re-arm from the send path with per-camera double
buffering, makes any failed re-arm retryable forever, and re-tiers the NVIC so
the RX→re-arm chain outranks the send path. A stall now costs **frames, never
a camera, never data integrity**.

## How

**Double buffer + PendSV re-arm.** Each camera gets a buffer pair
(`frame_buffer[2]`; cam 1's pair in SRAM4 — BDMA reaches only D3). DMA fills
`pRxBuf[armed]` while the send path copies `pRxBuf[done]`. At RX-complete the
halves swap and the re-arm is pended on **PendSV** (free — no RTOS). PendSV is
required, not a flourish: the H7 HAL invokes the RxCplt callback **before**
restoring the peripheral state to READY, so arming inside the callback is
refused as BUSY. PendSV tail-chains after the HAL ISR unwinds, with the state
settled.

**Drop-newest ownership.** The send path announces each copy (`copy_idx`);
RX-complete never re-arms into an announced buffer. If the consumer is still
mid-copy when the next frame lands (stall > 1 frame period), the incoming
frame is **dropped** and DMA re-fills the same buffer. The alternative — re-arm
into the buffer being copied — produces a torn frame that still *passes CRC*
(the CRC is computed over whatever bytes were copied), i.e. silent corruption.
Drops are counted per camera and reported in the scan-end `[DIAG]` block.

**NVIC re-tier** (`common.h` has the full table): camera RX (DMA1_S2–7,
DMA2_S0, BDMA_C0, SPI2/3/4/6) = **1**, PendSV = **2**, FSIN (TIM4 — was
hardcoded **0** — and EXTI13) = **3**. The 15/15-deaths-on-a-priority-corrected-
build result stands: priorities alone fix nothing while the re-arm *code* lives
in the stalled path. The tier only works together with the PendSV re-arm — and
vice versa.

**Retryable re-arm (the second half of #116).** The USART/SPI error callbacks
no longer run `abort_data_reception()` + one-shot `start_data_reception()` in
ISR context (the abort busy-waited `delay_ms(10)` inside an ISR; the one-shot
was permanent on failure). They flag + pend; PendSV usually re-arms within
microseconds; any failure falls to `camera_rearm_service()` in the main loop,
which retries abort+arm with 25 ms backoff until it sticks or the camera
leaves the streaming set. Eligibility gates (`event_bits_enabled`,
`needs_recovery`, `isPowered`) preserve the 2026-06-11 dead-camera BUSY_RX
wedge protection.

**RAM** (verified in the Debug map, not estimated): +32.8 KB RAM_D1 → 81.9%
used; +4.1 KB SRAM4 → 12.5%. RAM_D2 untouched. D-cache is disabled in this
firmware; a note marks every DMA buffer for whoever enables it later.

## Validation (bench, 2026-07-28)

Build: Debug `BARE_METAL=ON` off `next` (a979882 + this change). **This branch
does NOT include #117**, so the 500 ms COMM TX spin still fires — deliberately:
it is the strongest available stall trigger, and the fix must survive it.

**Phase 1 — in-run control** (`test_printf_blocker_v2.py`, stall-sweep
worktree): LEFT = this fix, RIGHT = stock rc.4, both modules stalled at the
same instant (300 ms whole-host outage, HISTO+COMM), mask 0xC3, 40 s scans,
interleaved printf ON/OFF arms, 10 valid trials, 0 voids:

| arm (5 trials each) | LEFT (fixed) | RIGHT (stock) |
|---|---|---|
| printf ON + stall | **0/5 cameras lost** | **5/5 lost cam 0** (field cascade) |
| printf OFF + stall | 0/5 | 0/5 |

The stall landed identically on both modules — LEFT logged
`HISTO enqueue fail: queue full` in every printf-ON trial and ended every scan
with `[DIAG] overruns c1-c8: 0 0 0 0 0 0 0 0`. Per scan LEFT lost exactly
`1 frames failed` — frames, not cameras.

**Phase 2 — same-module before/after**: RIGHT (which had just died 5/5) was
flashed with this fix and the run repeated with both modules fixed:

| arm (3 trials each) | LEFT (fixed) | RIGHT (fixed) |
|---|---|---|
| printf ON + stall | 0/3 | **0/3** |
| printf OFF + stall | 0/3 | 0/3 |

**Regression**: dose-0 (no injection) run — both modules clean, 1607
frames/scan ≈ 40.2 fps, zero overruns, zero stall-drops (the drop path
correctly never triggers in normal operation).

## Not addressed here

- #117 (COMM TX non-blocking) remains complementary: it removes the biggest
  *stall source*; this PR removes the *fragility*. Either alone survives the
  bench repro; both belong in.
- Residual exposure is limited to stalls at or above the PendSV tier (USB/I2C
  ISRs, prio 0) — all short ISRs. Stalls anywhere in the send path (either
  regime: FSIN-ISR at prio 3, or `SEND_DEFER` main loop) can no longer delay
  the re-arm; they cost dropped frames at the USB queue, nothing else.

Refs #116

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
