### PR TITLE
fix: xi2c_write_long wipes its own source buffer, programming an all-zero FPGA design (#82)

### DIFF
--- a/Core/Src/crosslink.c
+++ b/Core/Src/crosslink.c
@@ -85,6 +85,10 @@ int xi2c_write_and_read(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *w
     return HAL_OK;
 }
 
+/* Staging area for the FIRST chunk only — the one that carries the command
+ * prefix. See xi2c_write_long. */
+static uint8_t xi2c_first_chunk[BITSTREAM_CHUNK_SIZE];
+
 static HAL_StatusTypeDef xi2c_write_long(I2C_HandleTypeDef *hi2c, uint16_t DevAddress, uint8_t *cmd, int cmd_len, uint8_t *data, size_t data_len) {
 	HAL_StatusTypeDef ret;
     size_t offset = 0;
@@ -94,9 +98,36 @@ static HAL_StatusTypeDef xi2c_write_long(I2C_HandleTypeDef *hi2c, uint16_t DevAd
     uint8_t *pData;
 	uint16_t datalen;
 
-	memset(bitstream_buffer, 0, MAX_BITSTREAM_SIZE);
-    memcpy(bitstream_buffer, cmd, cmd_len);  // copy the long write command in
-    memcpy(bitstream_buffer + cmd_len, data, data_len);
+    /* #82: this used to stage cmd+data into bitstream_buffer and transmit from
+     * there. The host-upload path (fpga_program_sram, rom_bitstream=true)
+     * passes bitstream_buffer AS `data`, so the staging memset wiped the
+     * source before the copy read it and the CrossLink received the 0x7A
+     * command followed by 163 KB of zeros — the FPGA "programmed" silently
+     * with an empty design. The embedded-flash path was unaffected only
+     * because its source is flash, not the shared scratch buffer.
+     *
+     * Only the first chunk needs assembling, because only it carries the
+     * command prefix; every later chunk is a straight slice of the caller's
+     * data. So build chunk 0 in a private buffer and stream the rest directly
+     * from `data`, never writing to the caller's buffer at all. Chunk sizes
+     * and I2C frame flags below are untouched, so the byte stream and the
+     * framing on the wire stay exactly what the working flash path already
+     * produced. Streaming straight from `data` also drops a 163 KB copy out
+     * of the flash path — the I2C transfer is interrupt-driven and reads the
+     * source with the CPU, so a memory-mapped flash address is a fine source.
+     */
+    if (cmd_len < 0 || (size_t)cmd_len > BITSTREAM_CHUNK_SIZE) {
+        printf("i2c_write_long: cmd_len %d out of range\r\n", cmd_len);
+        return HAL_ERROR;
+    }
+
+    {
+        size_t first_chunk = (total_len > BITSTREAM_CHUNK_SIZE)
+                                 ? (size_t)BITSTREAM_CHUNK_SIZE
+                                 : total_len;
+        memcpy(xi2c_first_chunk, cmd, (size_t)cmd_len);
+        memcpy(xi2c_first_chunk + cmd_len, data, first_chunk - (size_t)cmd_len);
+    }
 
     for (int i = 0; i < num_chunks; i++) {
         size_t current_chunk_size = (total_len - offset > BITSTREAM_CHUNK_SIZE)
@@ -120,7 +151,10 @@ static HAL_StatusTypeDef xi2c_write_long(I2C_HandleTypeDef *hi2c, uint16_t DevAd
             delay_ms(1);  // Add a small delay to avoid busy looping
         }
 
-        pData = (uint8_t*)&bitstream_buffer[offset];
+        /* Chunk 0 is the assembled command+data prefix; later chunks come
+         * straight from the caller's source, offset back by the command
+         * bytes that only exist in chunk 0. */
+        pData = (i == 0) ? xi2c_first_chunk : (data + (offset - (size_t)cmd_len));
         datalen = (uint16_t)current_chunk_size;
 
         // Reset completion flags


### PR DESCRIPTION
## The bug

The host-upload FPGA SRAM path programs an all-zero design.

`OW_FPGA_BITSTREAM` blocks fill `bitstream_buffer`, then `OW_FPGA_PROG_SRAM` (reserved=0) calls `fpga_program_sram(rom_bitstream=true)`, which passes `bitstream_buffer` **itself** as `xi2c_write_long`'s `data`. That function staged cmd+data into the same buffer:

```c
memset(bitstream_buffer, 0, MAX_BITSTREAM_SIZE);
memcpy(bitstream_buffer, cmd, cmd_len);
memcpy(bitstream_buffer + cmd_len, data, data_len);   /* data IS the buffer */
```

The memset destroys the source before the copy reads it, so the CrossLink receives the `0x7A` command followed by 163 KB of zeros — and reports a successful program. The embedded-flash path (`fpga_configure` → `ADDR_CAMERA_BITSTREAM`) was unaffected only because its source is flash, not the shared scratch buffer.

## The fix

Only the first chunk needs assembling, because only it carries the command prefix; every later chunk is a straight slice of the caller's data. So chunk 0 is built in a private buffer and the remaining chunks stream directly from `data` — the caller's buffer is never written to at all.

**Chunk sizes and I2C frame flags are deliberately untouched.** The byte stream and the framing on the wire stay exactly what the working flash path already produces, which keeps the blast radius off the path that currently works.

## Verification

Modelled both implementations over the real 163,489 B length plus the chunk-boundary cases, aliased and not:

```
case                               bytes  chk   OLD impl     NEW   framing
----------------------------------------------------------------------------------
flash source, 163489 B            163489   20   ok           ok    identical
ALIASED source 163489 B (#82)     163489   20   ZEROS(163488) ok   identical
exactly one chunk (8188+4)          8188    1   ok           ok    identical
one chunk minus 1                   8187    1   ok           ok    identical
one chunk plus 1                    8189    2   ok           ok    identical
exact multiple boundary            16380    2   ok           ok    identical
tiny                                   1    1   ok           ok    identical
tiny aliased                           1    1   ZEROS(0)     ok    identical
```

The new code reproduces `cmd+data` exactly in every case with an identical chunk list; the old code emits 163,488 zeros on the aliased path, reproducing the reported symptom precisely.

Builds clean in all four configs (Debug / Release × slot / bare-metal). Costs 8 KB of RAM_D1 for the first-chunk buffer (75.58% → 77.15%). Streaming from `data` also removes a 163 KB copy from the flash boot path — the transfer is interrupt-driven and reads the source with the CPU, so a memory-mapped flash address is a fine source.

**NOT yet hardware-verified.** The bench check is: upload a bitstream over `OW_FPGA_BITSTREAM`, `OW_FPGA_PROG_SRAM` with reserved=0, and confirm the FPGA comes up with a working design rather than a blank one.

## Why this matters now

This is the pre-flight for **permanent NVCM burns**. NVCM is one-time programmable, so the exact image should be proven to boot in SRAM before it is fused — and that is precisely the path this bug breaks. The workaround recorded on the issue, DFU-rewriting `0x081A0000`, is unavailable on a bootloader unit because the bootloader clamps its DFU window to the application slot, so on a converted module there is currently **no way to try a bitstream before committing it permanently**.

Note this does not make NVCM burning ready on its own — see openmotion-sdk#196 (the bundled NVCM image and the released runtime bitstream are different FPGA builds) and openmotion-sdk#158 (the success verdict keys on the wrong discriminator).

Refs #82